### PR TITLE
rust-toolchain: bump rust to 1.62.1 (like vector)

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.61.0"
+channel = "1.62.1"
 profile = "default"


### PR DESCRIPTION
### What does this PR do?

This commit bumps the Rust version Lading uses to version 1.62.1
for parity with the [Vector project](https://github.com/vectordotdev/vector).

Signed-off-by: Geoffrey M. Oxberry <geoffrey.oxberry@datadoghq.com>

### Motivation

This PR was motivated by Vector's upgrade to Rust 1.62.1, as well as the changes in https://github.com/DataDog/single-machine-performance/pull/18.

### Related issues

See the discussion in https://github.com/DataDog/single-machine-performance/pull/18#discussion_r924893069.

### Additional Notes

n/a
