### PR TITLE
Correct clippy ding

### DIFF
--- a/src/bin/lading.rs
+++ b/src/bin/lading.rs
@@ -192,7 +192,7 @@ async fn inner_main(
             for (k, v) in global_labels {
                 builder = builder.add_global_label(k, v);
             }
-            let _: () = builder.install().unwrap();
+            builder.install().unwrap()
         }
         Telemetry::Log {
             path,


### PR DESCRIPTION
After upgrading our Rust toolchain we got dinged by clippy in a new spot. Simple
little patch, mechanical really.

Signed-off-by: Brian L. Troutwine <brian.troutwine@datadoghq.com>