### PR TITLE
lading.rs: fix clippy warning re: let & unit value

### DIFF
--- a/src/bin/lading.rs
+++ b/src/bin/lading.rs
@@ -192,7 +192,7 @@ async fn inner_main(
             for (k, v) in global_labels {
                 builder = builder.add_global_label(k, v);
             }
-            let _: () = builder.install().unwrap();
+            builder.install().unwrap();
         }
         Telemetry::Log {
             path,


### PR DESCRIPTION
### What does this PR do?

This PR fixes a Clippy warning about a let binding with unit
value in lading.rs that arose due to upgrading the Rust toolchain
to use Rust 1.62.1.

Signed-off-by: Geoffrey M. Oxberry <geoffrey.oxberry@datadoghq.com>

### Motivation

This PR was motivated by Clippy warnings in CI from [PR#242](https://github.com/DataDog/lading/pull/242).

### Related issues

n/a (other than the PR already mentioned)

### Additional Notes

n/a
