### PR TITLE
Dockerfile: update to use Rust 1.62.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/rust:1.58-bullseye@sha256:e4979d36d5d30838126ea5ef05eb59c4c25ede7f064985e676feb21402d0661b as builder
+FROM docker.io/rust:1.62.1-bullseye@sha256:9bdedf91cf0ae0a76cc6b17b333898926dcace17dee3a50974242684b386cc23 as builder
 
 WORKDIR /app
 COPY . /app


### PR DESCRIPTION
### What does this PR do?

This commit updates the Dockerfile in the Lading project to use
an image that includes Rust 1.62.1 instead of Rust 1.58.0. 

### Motivation

Lading's toolchain also uses Rust 1.62.1, which motivates updating the Dockerfile. Changes were taken from Dockerfiles in https://github.com/DataDog/single-machine-performance.

### Related issues

n/a

### Additional Notes

n/a
