### PR TITLE
Ignore RUSTSEC-2021-0139

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -21,6 +21,7 @@ vulnerability = "deny"
 unmaintained = "deny"
 notice = "deny"
 unsound = "deny"
+ignore = [ "RUSTSEC-2021-0139" ]
 
 [bans]
 multiple-versions = "allow"


### PR DESCRIPTION
We're currently being dinged by the above RUSTSEC, REF https://github.com/tokio-rs/tracing/issues/2282. It looks like tracing will update itself soon but meanwhile `ansi_term` being unmaintained is not a terrible problem for lading.

Signed-off-by: Brian L. Troutwine <brian.troutwine@datadoghq.com>