### PR TITLE
Support OTEL payloads

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,12 @@ jobs:
           profile: minimal
           toolchain: stable
           override: true
+      - name: Install protobuf (Apt)
+        run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
+        if: matrix.os == 'ubuntu-latest'
+      - name: Install protobuf (Brew)
+        run: brew install protobuf
+        if: matrix.os == 'macos-latest'
       - uses: actions-rs/cargo@v1
         with:
           command: check
@@ -43,6 +49,12 @@ jobs:
           profile: minimal
           toolchain: stable
           override: true
+      - name: Install protobuf (Apt)
+        run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
+        if: matrix.os == 'ubuntu-latest'
+      - name: Install protobuf (Brew)
+        run: brew install protobuf
+        if: matrix.os == 'macos-latest'
       - uses: actions-rs/cargo@v1
         with:
           command: test

--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -15,6 +15,12 @@ jobs:
     steps:
       - uses: actions/checkout@v1
       - run: rustup component add clippy
+      - name: Install protobuf (Apt)
+        run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
+        if: matrix.os == 'ubuntu-latest'
+      - name: Install protobuf (Brew)
+        run: brew install protobuf
+        if: matrix.os == 'macos-latest'
       - uses: actions-rs/clippy-check@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -334,6 +334,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-channel"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2dd04ddaf88237dc3b8d8f9a3c1004b506b54b3313403944054d23c0870c521"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-epoch"
 version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -885,9 +895,11 @@ dependencies = [
  "metrics-util",
  "nix",
  "once_cell",
+ "opentelemetry-proto",
  "procfs",
  "proptest",
  "proptest-derive",
+ "prost",
  "rand",
  "rdkafka",
  "rmp-serde",
@@ -1176,6 +1188,66 @@ name = "once_cell"
 version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2f7254b99e31cad77da24b08ebf628882739a608578bb1bcdfc1f9c21260d7c0"
+
+[[package]]
+name = "opentelemetry"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69d6c3d7288a106c0a363e4b0e8d308058d56902adefb16f4936f417ffef086e"
+dependencies = [
+ "opentelemetry_api",
+ "opentelemetry_sdk",
+]
+
+[[package]]
+name = "opentelemetry-proto"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d61a2f56df5574508dd86aaca016c917489e589ece4141df1b5e349af8d66c28"
+dependencies = [
+ "futures",
+ "futures-util",
+ "opentelemetry",
+ "prost",
+ "tonic",
+ "tonic-build",
+]
+
+[[package]]
+name = "opentelemetry_api"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c24f96e21e7acc813c7a8394ee94978929db2bcc46cf6b5014fc612bf7760c22"
+dependencies = [
+ "fnv",
+ "futures-channel",
+ "futures-util",
+ "indexmap",
+ "js-sys",
+ "once_cell",
+ "pin-project-lite",
+ "thiserror",
+]
+
+[[package]]
+name = "opentelemetry_sdk"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ca41c4933371b61c2a2f214bf16931499af4ec90543604ec828f7a625c09113"
+dependencies = [
+ "async-trait",
+ "crossbeam-channel",
+ "dashmap",
+ "fnv",
+ "futures-channel",
+ "futures-executor",
+ "futures-util",
+ "once_cell",
+ "opentelemetry_api",
+ "percent-encoding",
+ "rand",
+ "thiserror",
+]
 
 [[package]]
 name = "ordered-float"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,6 @@ members = [
     "integration/ducks",
 ]
 
-
 [package]
 name = "lading"
 version = "0.9.1"
@@ -34,6 +33,8 @@ metrics-exporter-prometheus = { version = "0.11.0", default-features = false, fe
 metrics-util = { version = "0.14" }
 nix = { version = "0.25" }
 once_cell = "1.14"
+opentelemetry-proto = { version = "0.1", features = ["traces", "metrics", "logs", "gen-tonic"] }
+prost = "0.11"
 rand = { version = "0.8", default-features = false, features = ["small_rng", "std", "std_rng"] }
 rdkafka = "0.28"
 rmp-serde = { version = "1.1", default-features = false }

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,9 @@
 FROM docker.io/rust:1.63.0-bullseye@sha256:d7e3f69edcdcd03b145d8d9361765b816656755e49c1c1fe28224a4505f91b0a as builder
 
+RUN apt-get update && apt-get install -y \
+    protobuf-compiler \
+    && rm -rf /var/lib/apt/lists/*
+
 WORKDIR /app
 COPY . /app
 RUN cargo build --release --locked

--- a/README.md
+++ b/README.md
@@ -6,6 +6,12 @@ generation across a variety of protocols. The ambition is to be a worry-free
 component of a larger performance testing strategy for complex programs. The
 [Vector][vector] project uses lading in their 'soak' tests.
 
+## Development Setup
+
+`lading` requires the protobuf compiler to build. See
+[installation instructions](https://grpc.io/docs/protoc-installation/) from the
+protobuf docs.
+
 ## Operating Model
 
 `lading` operates on three conceptual components:

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,0 +1,2 @@
+# https://rust-lang.github.io/rust-clippy/master/index.html#doc_markdown
+doc-valid-idents = ["OpenTelemetry", ".."]

--- a/deny.toml
+++ b/deny.toml
@@ -10,7 +10,7 @@ allow = [
   "Apache-2.0",
   "Apache-2.0 WITH LLVM-exception",
   "Zlib",
-  "Unicode-DFS-2016"
+  "Unicode-DFS-2016",
 ]
 
 copyleft = "deny"
@@ -21,7 +21,12 @@ vulnerability = "deny"
 unmaintained = "deny"
 notice = "deny"
 unsound = "deny"
-ignore = [ "RUSTSEC-2021-0139" ]
+ignore = [
+  # ansi_term is unmaintained
+  "RUSTSEC-2021-0139",
+  # axum-core denial of service
+  "RUSTSEC-2022-0055",
+]
 
 [bans]
 multiple-versions = "allow"

--- a/integration/sheepdog/src/lib.rs
+++ b/integration/sheepdog/src/lib.rs
@@ -254,6 +254,96 @@ generator:
     }
 
     #[tokio::test]
+    async fn http_otel_logs() -> Result<(), anyhow::Error> {
+        let test = IntegrationTest::new(
+            DucksConfig {
+                listen: shared::ListenConfig::Http,
+                emit: shared::EmitConfig::None,
+                assertions: shared::AssertionConfig::None,
+            },
+            r#"
+generator:
+  http:
+    seed: [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53,
+      59, 61, 67, 71, 73, 79, 83, 89, 97, 101, 103, 107, 109, 113, 127, 131]
+    headers: {}
+    target_uri: "http://localhost:{{port_number}}/"
+    bytes_per_second: "100 Mb"
+    parallel_connections: 5
+    method:
+      post:
+        maximum_prebuild_cache_size_bytes: "8 Mb"
+        variant: "opentelemetry_logs"
+        "#,
+        )?;
+
+        let reqs = test.run().await?;
+
+        assert!(reqs.http.request_count > 10);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn http_otel_traces() -> Result<(), anyhow::Error> {
+        let test = IntegrationTest::new(
+            DucksConfig {
+                listen: shared::ListenConfig::Http,
+                emit: shared::EmitConfig::None,
+                assertions: shared::AssertionConfig::None,
+            },
+            r#"
+generator:
+  http:
+    seed: [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53,
+      59, 61, 67, 71, 73, 79, 83, 89, 97, 101, 103, 107, 109, 113, 127, 131]
+    headers: {}
+    target_uri: "http://localhost:{{port_number}}/"
+    bytes_per_second: "100 Mb"
+    parallel_connections: 5
+    method:
+      post:
+        maximum_prebuild_cache_size_bytes: "8 Mb"
+        variant: "opentelemetry_traces"
+        "#,
+        )?;
+
+        let reqs = test.run().await?;
+
+        assert!(reqs.http.request_count > 10);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn http_otel_metrics() -> Result<(), anyhow::Error> {
+        let test = IntegrationTest::new(
+            DucksConfig {
+                listen: shared::ListenConfig::Http,
+                emit: shared::EmitConfig::None,
+                assertions: shared::AssertionConfig::None,
+            },
+            r#"
+generator:
+  http:
+    seed: [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53,
+      59, 61, 67, 71, 73, 79, 83, 89, 97, 101, 103, 107, 109, 113, 127, 131]
+    headers: {}
+    target_uri: "http://localhost:{{port_number}}/"
+    bytes_per_second: "100 Mb"
+    parallel_connections: 5
+    method:
+      post:
+        maximum_prebuild_cache_size_bytes: "8 Mb"
+        variant: "opentelemetry_metrics"
+        "#,
+        )?;
+
+        let reqs = test.run().await?;
+
+        assert!(reqs.http.request_count > 10);
+        Ok(())
+    }
+
+    #[tokio::test]
     async fn tcp_fluent() -> Result<(), anyhow::Error> {
         let test = IntegrationTest::new(
             DucksConfig {

--- a/src/block.rs
+++ b/src/block.rs
@@ -146,6 +146,24 @@ where
             block_chunks,
             labels,
         ),
+        payload::Config::OpentelemetryTraces => construct_block_cache_inner(
+            rng,
+            &payload::OpentelemetryTraces::default(),
+            block_chunks,
+            labels,
+        ),
+        payload::Config::OpentelemetryLogs => construct_block_cache_inner(
+            rng,
+            &payload::OpentelemetryLogs::default(),
+            block_chunks,
+            labels,
+        ),
+        payload::Config::OpentelemetryMetrics => construct_block_cache_inner(
+            rng,
+            &payload::OpentelemetryMetrics::default(),
+            block_chunks,
+            labels,
+        ),
     }
 }
 

--- a/src/payload/opentelemetry_log.rs
+++ b/src/payload/opentelemetry_log.rs
@@ -1,0 +1,181 @@
+//! Generates OpenTelemetry OTLP log payloads
+//!
+//! [Specification](https://opentelemetry.io/docs/reference/specification/protocol/otlp/),
+//! [data model](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/logs/data-model.md)
+//!
+//! This format is valid for OTLP/gRPC and binary OTLP/HTTP messages. The
+//! experimental JSON OTLP/HTTP format can also be supported but is not
+//! currently implemented.
+
+use crate::payload::{Error, Serialize};
+use arbitrary::{Arbitrary, Unstructured};
+use opentelemetry_proto::tonic::{
+    common::v1::{any_value, AnyValue},
+    logs::v1,
+};
+use prost::Message;
+use rand::Rng;
+use std::io::Write;
+
+/// Wrapper to generate arbitrary OpenTelemetry [`ExportLogsServiceRequests`](opentelemetry_proto::tonic::collector::logs::v1::ExportLogsServiceRequest)
+struct ExportLogsServiceRequest(Vec<LogRecord>);
+
+impl ExportLogsServiceRequest {
+    fn into_prost_type(
+        self,
+    ) -> opentelemetry_proto::tonic::collector::logs::v1::ExportLogsServiceRequest {
+        opentelemetry_proto::tonic::collector::logs::v1::ExportLogsServiceRequest {
+            resource_logs: vec![v1::ResourceLogs {
+                resource: None,
+                instrumentation_library_logs: vec![v1::InstrumentationLibraryLogs {
+                    instrumentation_library: None,
+                    log_records: self.0.into_iter().map(|log| log.0).collect(),
+                    schema_url: String::new(),
+                }],
+                schema_url: String::new(),
+            }],
+        }
+    }
+}
+
+struct LogRecord(v1::LogRecord);
+
+impl<'a> Arbitrary<'a> for ExportLogsServiceRequest {
+    fn arbitrary(u: &mut Unstructured<'a>) -> arbitrary::Result<Self> {
+        let logs: Vec<LogRecord> = u.arbitrary()?;
+        Ok(Self(logs))
+    }
+}
+
+impl<'a> Arbitrary<'a> for LogRecord {
+    fn arbitrary(u: &mut Unstructured<'a>) -> arbitrary::Result<Self> {
+        let time_unix_nano = u.arbitrary()?;
+        let observed_time_unix_nano = u.arbitrary()?;
+
+        let severity_number = u.int_in_range(1..=24)?;
+        let severity_text = String::new();
+
+        let body = Some(AnyValue {
+            value: Some(any_value::Value::StringValue(u.arbitrary()?)),
+        });
+
+        let attributes = Vec::new();
+
+        let dropped_attributes_count = 0;
+        let flags = 0;
+        let trace_id = Vec::new();
+        let span_id = Vec::new();
+
+        #[allow(deprecated)]
+        Ok(LogRecord(v1::LogRecord {
+            time_unix_nano,
+            observed_time_unix_nano,
+            severity_number,
+            severity_text,
+            name: String::new(),
+            body,
+            attributes,
+            dropped_attributes_count,
+            flags,
+            trace_id,
+            span_id,
+        }))
+    }
+}
+
+#[derive(Debug, Default, Clone, Copy)]
+#[cfg_attr(test, derive(proptest_derive::Arbitrary))]
+pub(crate) struct OpentelemetryLogs;
+
+impl Serialize for OpentelemetryLogs {
+    fn to_bytes<W, R>(&self, mut rng: R, max_bytes: usize, writer: &mut W) -> Result<(), Error>
+    where
+        R: Rng + Sized,
+        W: Write,
+    {
+        let mut entropy: Vec<u8> = vec![0; max_bytes];
+        rng.fill_bytes(&mut entropy);
+        let mut unstructured = Unstructured::new(&entropy);
+
+        // An Export*ServiceRequest message has ~5 bytes of fixed values and
+        // includes a varint-encoded message length. Use the worst case for this
+        // length value.
+        let bytes_remaining = max_bytes.checked_sub(5 + max_bytes / 0x7F);
+        let mut bytes_remaining = if let Some(val) = bytes_remaining {
+            val
+        } else {
+            return Ok(());
+        };
+
+        let mut acc = ExportLogsServiceRequest(Vec::new());
+        while let Ok(member) = unstructured.arbitrary::<LogRecord>() {
+            // Note: this 2 is a guessed value for an unknown size factor.
+            let len = member.0.encoded_len() + 2;
+            match bytes_remaining.checked_sub(len) {
+                Some(remainder) => {
+                    acc.0.push(member);
+                    bytes_remaining = remainder;
+                }
+                None => break,
+            }
+        }
+        let buf = acc.into_prost_type().encode_to_vec();
+        writer.write_all(&buf)?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::OpentelemetryLogs;
+    use crate::payload::Serialize;
+    use proptest::prelude::*;
+    use prost::Message;
+    use rand::{rngs::SmallRng, SeedableRng};
+
+    // We want to be sure that the serialized size of the payload does not
+    // exceed `max_bytes`.
+    proptest! {
+        #[test]
+        fn payload_not_exceed_max_bytes(seed: u64, max_bytes: u16) {
+            let max_bytes = max_bytes as usize;
+            let rng = SmallRng::seed_from_u64(seed);
+            let logs = OpentelemetryLogs::default();
+
+            let mut bytes = Vec::with_capacity(max_bytes);
+            logs.to_bytes(rng, max_bytes, &mut bytes).unwrap();
+            assert!(bytes.len() <= max_bytes, "max len: {}, actual: {}", max_bytes, bytes.len());
+        }
+    }
+
+    // We want to be sure that the payloads are not being left empty.
+    proptest! {
+        #[test]
+        fn payload_is_at_least_half_of_max_bytes(seed: u64, max_bytes in 16u16..u16::MAX) {
+            let max_bytes = max_bytes as usize;
+            let rng = SmallRng::seed_from_u64(seed);
+            let logs = OpentelemetryLogs::default();
+
+            let mut bytes = Vec::with_capacity(max_bytes);
+            logs.to_bytes(rng, max_bytes, &mut bytes).unwrap();
+
+            assert!(bytes.len() > 0);
+        }
+    }
+
+    // We want to know that every payload produced by this type actually
+    // deserializes as a collection of OTEL LogRecords.
+    proptest! {
+        #[test]
+        fn payload_deserializes(seed: u64, max_bytes: u16)  {
+            let max_bytes = max_bytes as usize;
+            let rng = SmallRng::seed_from_u64(seed);
+            let logs = OpentelemetryLogs::default();
+
+            let mut bytes: Vec<u8> = Vec::with_capacity(max_bytes);
+            logs.to_bytes(rng, max_bytes, &mut bytes).unwrap();
+
+            opentelemetry_proto::tonic::collector::logs::v1::ExportLogsServiceRequest::decode(bytes.as_slice()).unwrap();
+        }
+    }
+}

--- a/src/payload/opentelemetry_metric.rs
+++ b/src/payload/opentelemetry_metric.rs
@@ -40,9 +40,6 @@ struct Metric(v1::Metric);
 struct NumberDataPoint(v1::NumberDataPoint);
 struct Gauge(v1::Gauge);
 struct Sum(v1::Sum);
-struct Histogram(v1::Histogram);
-struct ExponentialHistogram(v1::ExponentialHistogram);
-struct Summary(v1::Summary);
 
 impl<'a> Arbitrary<'a> for ExportMetricsServiceRequest {
     fn arbitrary(u: &mut Unstructured<'a>) -> arbitrary::Result<Self> {
@@ -132,32 +129,6 @@ impl<'a> Arbitrary<'a> for Sum {
     }
 }
 
-// impl<'a> Arbitrary<'a> for Histogram {
-//     fn arbitrary(u: &mut Unstructured<'a>) -> arbitrary::Result<Self> {
-//         let len = u.arbitrary_len::<NumberDataPoint>()?;
-//         let mut data_points = Vec::new();
-//         for _ in 0..len {
-//             data_points.push(u.arbitrary::<NumberDataPoint>()?.0);
-//         }
-//         Ok(Self(v1::Histogram {
-//             data_points,
-//             aggregation_temporality: *u.choose(&[1, 2])?,
-//         }))
-//     }
-// }
-
-// impl<'a> Arbitrary<'a> for ExponentialHistogram {
-//     fn arbitrary(u: &mut Unstructured<'a>) -> arbitrary::Result<Self> {
-//         todo!()
-//     }
-// }
-
-// impl<'a> Arbitrary<'a> for Summary {
-//     fn arbitrary(u: &mut Unstructured<'a>) -> arbitrary::Result<Self> {
-//         todo!()
-//     }
-// }
-
 impl<'a> Arbitrary<'a> for Metric {
     fn arbitrary(u: &mut Unstructured<'a>) -> arbitrary::Result<Self> {
         let name = u.arbitrary()?;
@@ -167,9 +138,7 @@ impl<'a> Arbitrary<'a> for Metric {
         let data = match u.int_in_range(0u8..=1)? {
             0 => v1::metric::Data::Gauge(u.arbitrary::<Gauge>()?.0),
             1 => v1::metric::Data::Sum(u.arbitrary::<Sum>()?.0),
-            // 2 => v1::metric::Data::Histogram(u.arbitrary::<Histogram>()?.0),
-            // 3 => v1::metric::Data::ExponentialHistogram(u.arbitrary::<ExponentialHistogram>()?.0),
-            // 4 => v1::metric::Data::Summary(u.arbitrary::<Summary>()?.0),
+            // Currently unsupported: Histogram, ExponentialHistogram, Summary
             _ => unreachable!(),
         };
 
@@ -194,9 +163,6 @@ impl<'a> Arbitrary<'a> for Metric {
                     size_hint::or_all(&[
                         <Gauge as Arbitrary>::size_hint(depth),
                         <Sum as Arbitrary>::size_hint(depth),
-                        // <Histogram as Arbitrary>::size_hint(depth),
-                        // <ExponentialHistogram as Arbitrary>::size_hint(depth),
-                        // <Summary as Arbitrary>::size_hint(depth),
                     ]),
                 ])
                 .0,

--- a/src/payload/opentelemetry_metric.rs
+++ b/src/payload/opentelemetry_metric.rs
@@ -1,0 +1,304 @@
+//! Generates OpenTelemetry OTLP metric payloads
+//!
+//! [Specification](https://opentelemetry.io/docs/reference/specification/protocol/otlp/),
+//! [data model](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/data-model.md)
+//!
+//! This format is valid for OTLP/gRPC and binary OTLP/HTTP messages. The
+//! experimental JSON OTLP/HTTP format can also be supported but is not
+//! currently implemented.
+
+use std::io::Write;
+
+use crate::payload::{Error, Serialize};
+use arbitrary::{size_hint, Arbitrary, Unstructured};
+use opentelemetry_proto::tonic::metrics::v1::{self};
+use prost::Message;
+use rand::Rng;
+
+/// Wrapper to generate arbitrary OpenTelemetry [`ExportMetricsServiceRequests`](opentelemetry_proto::tonic::collector::metrics::v1::ExportMetricsServiceRequest)
+struct ExportMetricsServiceRequest(Vec<Metric>);
+
+impl ExportMetricsServiceRequest {
+    fn into_prost_type(
+        self,
+    ) -> opentelemetry_proto::tonic::collector::metrics::v1::ExportMetricsServiceRequest {
+        opentelemetry_proto::tonic::collector::metrics::v1::ExportMetricsServiceRequest {
+            resource_metrics: vec![v1::ResourceMetrics {
+                resource: None,
+                instrumentation_library_metrics: vec![v1::InstrumentationLibraryMetrics {
+                    instrumentation_library: None,
+                    metrics: self.0.into_iter().map(|metric| metric.0).collect(),
+                    schema_url: String::new(),
+                }],
+                schema_url: String::new(),
+            }],
+        }
+    }
+}
+
+struct Metric(v1::Metric);
+struct NumberDataPoint(v1::NumberDataPoint);
+struct Gauge(v1::Gauge);
+struct Sum(v1::Sum);
+struct Histogram(v1::Histogram);
+struct ExponentialHistogram(v1::ExponentialHistogram);
+struct Summary(v1::Summary);
+
+impl<'a> Arbitrary<'a> for ExportMetricsServiceRequest {
+    fn arbitrary(u: &mut Unstructured<'a>) -> arbitrary::Result<Self> {
+        let metrics: Vec<Metric> = u.arbitrary()?;
+        Ok(Self(metrics))
+    }
+}
+
+impl<'a> Arbitrary<'a> for NumberDataPoint {
+    fn arbitrary(u: &mut Unstructured<'a>) -> arbitrary::Result<Self> {
+        let time_unix_nano = u.arbitrary()?;
+        let start_time_unix_nano = u.arbitrary()?;
+
+        let value = match u.int_in_range(0u8..=1)? {
+            0 => v1::number_data_point::Value::AsDouble(u.arbitrary()?),
+            1 => v1::number_data_point::Value::AsInt(u.arbitrary()?),
+            _ => unreachable!(),
+        };
+
+        Ok(Self(v1::NumberDataPoint {
+            attributes: Vec::new(),
+            start_time_unix_nano,
+            time_unix_nano,
+            exemplars: Vec::new(),
+            flags: 0,
+            value: Some(value),
+        }))
+    }
+
+    fn size_hint(depth: usize) -> (usize, Option<usize>) {
+        size_hint::recursion_guard(depth, |depth| {
+            size_hint::and_all(&[
+                <u64 as Arbitrary>::size_hint(depth),
+                <u64 as Arbitrary>::size_hint(depth),
+                <u8 as Arbitrary>::size_hint(depth),
+                size_hint::or(
+                    <f64 as Arbitrary>::size_hint(depth),
+                    <i64 as Arbitrary>::size_hint(depth),
+                ),
+            ])
+        })
+    }
+}
+
+impl<'a> Arbitrary<'a> for Gauge {
+    fn arbitrary(u: &mut Unstructured<'a>) -> arbitrary::Result<Self> {
+        let len = u.arbitrary_len::<NumberDataPoint>()?;
+        let mut data_points = Vec::new();
+        for _ in 0..len {
+            data_points.push(u.arbitrary::<NumberDataPoint>()?.0);
+        }
+        Ok(Self(v1::Gauge { data_points }))
+    }
+
+    fn size_hint(depth: usize) -> (usize, Option<usize>) {
+        (<NumberDataPoint as Arbitrary>::size_hint(depth).0, None)
+    }
+}
+
+impl<'a> Arbitrary<'a> for Sum {
+    fn arbitrary(u: &mut Unstructured<'a>) -> arbitrary::Result<Self> {
+        let len = u.arbitrary_len::<NumberDataPoint>()?;
+        let mut data_points = Vec::new();
+        for _ in 0..len {
+            data_points.push(u.arbitrary::<NumberDataPoint>()?.0);
+        }
+        Ok(Self(v1::Sum {
+            data_points,
+            // 0: Unspecified AggregationTemporality, MUST not be used
+            // 1: Delta
+            // 2: Cumulative
+            aggregation_temporality: *u.choose(&[1, 2])?,
+            is_monotonic: *u.choose(&[true, false])?,
+        }))
+    }
+
+    fn size_hint(depth: usize) -> (usize, Option<usize>) {
+        (
+            size_hint::and_all(&[
+                <NumberDataPoint as Arbitrary>::size_hint(depth),
+                <usize as Arbitrary>::size_hint(depth),
+                <usize as Arbitrary>::size_hint(depth),
+            ])
+            .0,
+            None,
+        )
+    }
+}
+
+// impl<'a> Arbitrary<'a> for Histogram {
+//     fn arbitrary(u: &mut Unstructured<'a>) -> arbitrary::Result<Self> {
+//         let len = u.arbitrary_len::<NumberDataPoint>()?;
+//         let mut data_points = Vec::new();
+//         for _ in 0..len {
+//             data_points.push(u.arbitrary::<NumberDataPoint>()?.0);
+//         }
+//         Ok(Self(v1::Histogram {
+//             data_points,
+//             aggregation_temporality: *u.choose(&[1, 2])?,
+//         }))
+//     }
+// }
+
+// impl<'a> Arbitrary<'a> for ExponentialHistogram {
+//     fn arbitrary(u: &mut Unstructured<'a>) -> arbitrary::Result<Self> {
+//         todo!()
+//     }
+// }
+
+// impl<'a> Arbitrary<'a> for Summary {
+//     fn arbitrary(u: &mut Unstructured<'a>) -> arbitrary::Result<Self> {
+//         todo!()
+//     }
+// }
+
+impl<'a> Arbitrary<'a> for Metric {
+    fn arbitrary(u: &mut Unstructured<'a>) -> arbitrary::Result<Self> {
+        let name = u.arbitrary()?;
+        let description = u.arbitrary()?;
+        let unit = u.arbitrary()?;
+
+        let data = match u.int_in_range(0u8..=1)? {
+            0 => v1::metric::Data::Gauge(u.arbitrary::<Gauge>()?.0),
+            1 => v1::metric::Data::Sum(u.arbitrary::<Sum>()?.0),
+            // 2 => v1::metric::Data::Histogram(u.arbitrary::<Histogram>()?.0),
+            // 3 => v1::metric::Data::ExponentialHistogram(u.arbitrary::<ExponentialHistogram>()?.0),
+            // 4 => v1::metric::Data::Summary(u.arbitrary::<Summary>()?.0),
+            _ => unreachable!(),
+        };
+
+        let data = Some(data);
+
+        Ok(Metric(v1::Metric {
+            name,
+            description,
+            unit,
+            data,
+        }))
+    }
+
+    fn size_hint(depth: usize) -> (usize, Option<usize>) {
+        size_hint::recursion_guard(depth, |depth| {
+            (
+                size_hint::and_all(&[
+                    <String as Arbitrary>::size_hint(depth),
+                    <String as Arbitrary>::size_hint(depth),
+                    <String as Arbitrary>::size_hint(depth),
+                    <u8 as Arbitrary>::size_hint(depth),
+                    size_hint::or_all(&[
+                        <Gauge as Arbitrary>::size_hint(depth),
+                        <Sum as Arbitrary>::size_hint(depth),
+                        // <Histogram as Arbitrary>::size_hint(depth),
+                        // <ExponentialHistogram as Arbitrary>::size_hint(depth),
+                        // <Summary as Arbitrary>::size_hint(depth),
+                    ]),
+                ])
+                .0,
+                None,
+            )
+        })
+    }
+}
+
+#[derive(Debug, Default, Clone, Copy)]
+#[cfg_attr(test, derive(proptest_derive::Arbitrary))]
+pub(crate) struct OpentelemetryMetrics;
+
+impl Serialize for OpentelemetryMetrics {
+    fn to_bytes<W, R>(&self, mut rng: R, max_bytes: usize, writer: &mut W) -> Result<(), Error>
+    where
+        R: Rng + Sized,
+        W: Write,
+    {
+        let mut entropy: Vec<u8> = vec![0; max_bytes];
+        rng.fill_bytes(&mut entropy);
+        let mut unstructured = Unstructured::new(&entropy);
+
+        // An Export*ServiceRequest message has ~5 bytes of fixed values and
+        // includes a varint-encoded message length. Use the worst case for this
+        // length value.
+        let bytes_remaining = max_bytes.checked_sub(4 + 1 + max_bytes / 0x7F);
+        let mut bytes_remaining = if let Some(val) = bytes_remaining {
+            val
+        } else {
+            return Ok(());
+        };
+
+        let mut acc = ExportMetricsServiceRequest(Vec::new());
+        while let Ok(member) = unstructured.arbitrary::<Metric>() {
+            // Note: this 2 is a guessed value for an unknown size factor.
+            let len = member.0.encoded_len() + 2;
+            match bytes_remaining.checked_sub(len) {
+                Some(remainder) => {
+                    acc.0.push(member);
+                    bytes_remaining = remainder;
+                }
+                None => break,
+            }
+        }
+        let buf = acc.into_prost_type().encode_to_vec();
+        writer.write_all(&buf)?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::OpentelemetryMetrics;
+    use crate::payload::Serialize;
+    use proptest::prelude::*;
+    use prost::Message;
+    use rand::{rngs::SmallRng, SeedableRng};
+
+    // We want to be sure that the serialized size of the payload does not
+    // exceed `max_bytes`.
+    proptest! {
+        #[test]
+        fn payload_not_exceed_max_bytes(seed: u64, max_bytes: u16) {
+            let max_bytes = max_bytes as usize;
+            let rng = SmallRng::seed_from_u64(seed);
+            let logs = OpentelemetryMetrics::default();
+
+            let mut bytes = Vec::with_capacity(max_bytes);
+            logs.to_bytes(rng, max_bytes, &mut bytes).unwrap();
+            assert!(bytes.len() <= max_bytes, "max len: {}, actual: {}", max_bytes, bytes.len());
+        }
+    }
+
+    // We want to be sure that the payloads are not being left empty.
+    proptest! {
+        #[test]
+        fn payload_is_at_least_half_of_max_bytes(seed: u64, max_bytes in 16u16..u16::MAX) {
+            let max_bytes = max_bytes as usize;
+            let rng = SmallRng::seed_from_u64(seed);
+            let logs = OpentelemetryMetrics::default();
+
+            let mut bytes = Vec::with_capacity(max_bytes);
+            logs.to_bytes(rng, max_bytes, &mut bytes).unwrap();
+
+            assert!(bytes.len() > 0);
+        }
+    }
+
+    // We want to know that every payload produced by this type actually
+    // deserializes as a collection of OTEL metrics.
+    proptest! {
+        #[test]
+        fn payload_deserializes(seed: u64, max_bytes: u16)  {
+            let max_bytes = max_bytes as usize;
+            let rng = SmallRng::seed_from_u64(seed);
+            let logs = OpentelemetryMetrics::default();
+
+            let mut bytes: Vec<u8> = Vec::with_capacity(max_bytes);
+            logs.to_bytes(rng, max_bytes, &mut bytes).unwrap();
+
+            opentelemetry_proto::tonic::collector::metrics::v1::ExportMetricsServiceRequest::decode(bytes.as_slice()).unwrap();
+        }
+    }
+}

--- a/src/payload/opentelemetry_trace.rs
+++ b/src/payload/opentelemetry_trace.rs
@@ -1,0 +1,193 @@
+//! Generates OpenTelemetry OTLP trace payloads
+//!
+//! [Specification](https://opentelemetry.io/docs/reference/specification/protocol/otlp/)
+//!
+//! This format is valid for OTLP/gRPC and binary OTLP/HTTP messages. The
+//! experimental JSON OTLP/HTTP format can also be supported but is not
+//! currently implemented.
+
+use crate::payload::{Error, Serialize};
+use arbitrary::{Arbitrary, Unstructured};
+use opentelemetry_proto::tonic::trace::v1;
+use prost::Message;
+use rand::Rng;
+use std::io::Write;
+
+/// Wrapper to generate arbitrary OpenTelemetry [`ExportTraceServiceRequest`](opentelemetry_proto::tonic::collector::trace::v1::ExportTraceServiceRequest)
+struct ExportTraceServiceRequest(Vec<Span>);
+
+impl ExportTraceServiceRequest {
+    fn into_prost_type(
+        self,
+    ) -> opentelemetry_proto::tonic::collector::trace::v1::ExportTraceServiceRequest {
+        opentelemetry_proto::tonic::collector::trace::v1::ExportTraceServiceRequest {
+            resource_spans: [v1::ResourceSpans {
+                resource: None,
+                instrumentation_library_spans: [v1::InstrumentationLibrarySpans {
+                    instrumentation_library: None,
+                    spans: self.0.into_iter().map(|span| span.0).collect(),
+                    schema_url: String::new(),
+                }]
+                .to_vec(),
+                schema_url: String::new(),
+            }]
+            .to_vec(),
+        }
+    }
+}
+
+impl<'a> Arbitrary<'a> for ExportTraceServiceRequest {
+    fn arbitrary(u: &mut Unstructured<'a>) -> arbitrary::Result<Self> {
+        let spans: Vec<Span> = u.arbitrary()?;
+        Ok(Self(spans))
+    }
+}
+
+struct Span(v1::Span);
+
+impl<'a> Arbitrary<'a> for Span {
+    fn arbitrary(u: &mut Unstructured<'a>) -> arbitrary::Result<Self> {
+        let trace_id: [u8; 16] = u.arbitrary()?;
+        let trace_id = trace_id.to_vec();
+
+        // span_id must be nonzero
+        let span_id: [u8; 8] = u.arbitrary()?;
+        let span_id = span_id.to_vec();
+
+        // https://www.w3.org/TR/trace-context/#tracestate-header
+        let trace_state = String::new();
+
+        // zeros: root span
+        let parent_span_id: [u8; 8] = [0; 8];
+        let parent_span_id = parent_span_id.to_vec();
+
+        let name: String = u.arbitrary()?;
+
+        let kind: i32 = u.int_in_range(0..=5)?;
+
+        // Some collectors may immediately drop old/future spans. Consider
+        // constraining these to recent timestamps.
+        let start_time_unix_nano: u64 = u.arbitrary()?;
+        // end time is expected to be greater than or equal to start time
+        let end_time_unix_nano: u64 = u.int_in_range(start_time_unix_nano..=u64::MAX)?;
+
+        let attributes = Vec::new();
+        let events = Vec::new();
+        let links = Vec::new();
+
+        Ok(Span(v1::Span {
+            trace_id,
+            span_id,
+            trace_state,
+            parent_span_id,
+            name,
+            kind,
+            start_time_unix_nano,
+            end_time_unix_nano,
+            attributes,
+            dropped_attributes_count: 0,
+            events,
+            dropped_events_count: 0,
+            links,
+            dropped_links_count: 0,
+            status: None,
+        }))
+    }
+}
+
+#[derive(Debug, Default, Clone, Copy)]
+#[cfg_attr(test, derive(proptest_derive::Arbitrary))]
+pub(crate) struct OpentelemetryTraces;
+
+impl Serialize for OpentelemetryTraces {
+    fn to_bytes<W, R>(&self, mut rng: R, max_bytes: usize, writer: &mut W) -> Result<(), Error>
+    where
+        R: Rng + Sized,
+        W: Write,
+    {
+        let mut entropy: Vec<u8> = vec![0; max_bytes];
+        rng.fill_bytes(&mut entropy);
+        let mut unstructured = Unstructured::new(&entropy);
+
+        // An Export*ServiceRequest message has ~5 bytes of fixed values and
+        // includes a varint-encoded message length. Use the worst case for this
+        // length value.
+        let bytes_remaining = max_bytes.checked_sub(5 + max_bytes / 0x7F);
+        let mut bytes_remaining = if let Some(val) = bytes_remaining {
+            val
+        } else {
+            return Ok(());
+        };
+
+        let mut acc = ExportTraceServiceRequest(Vec::new());
+        while let Ok(member) = unstructured.arbitrary::<Span>() {
+            // Note: this 2 is a guessed value for an unknown size factor.
+            let len = member.0.encoded_len() + 2;
+            match bytes_remaining.checked_sub(len) {
+                Some(remainder) => {
+                    acc.0.push(member);
+                    bytes_remaining = remainder;
+                }
+                None => break,
+            }
+        }
+        let buf = acc.into_prost_type().encode_to_vec();
+        writer.write_all(&buf)?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::OpentelemetryTraces;
+    use crate::payload::Serialize;
+    use proptest::prelude::*;
+    use prost::Message;
+    use rand::{rngs::SmallRng, SeedableRng};
+
+    // We want to be sure that the serialized size of the payload does not
+    // exceed `max_bytes`.
+    proptest! {
+        #[test]
+        fn payload_not_exceed_max_bytes(seed: u64, max_bytes: u16) {
+            let max_bytes = max_bytes as usize;
+            let rng = SmallRng::seed_from_u64(seed);
+            let traces = OpentelemetryTraces::default();
+
+            let mut bytes = Vec::with_capacity(max_bytes);
+            traces.to_bytes(rng, max_bytes, &mut bytes).unwrap();
+            assert!(bytes.len() <= max_bytes, "max len: {}, actual: {}", max_bytes, bytes.len());
+        }
+    }
+
+    // We want to be sure that the payloads are not being left empty.
+    proptest! {
+        #[test]
+        fn payload_is_at_least_half_of_max_bytes(seed: u64, max_bytes in 16u16..u16::MAX) {
+            let max_bytes = max_bytes as usize;
+            let rng = SmallRng::seed_from_u64(seed);
+            let logs = OpentelemetryTraces::default();
+
+            let mut bytes = Vec::with_capacity(max_bytes);
+            logs.to_bytes(rng, max_bytes, &mut bytes).unwrap();
+
+            assert!(bytes.len() > 0);
+        }
+    }
+
+    // We want to know that every payload produced by this type actually
+    // deserializes as a collection of OTEL Spans.
+    proptest! {
+        #[test]
+        fn payload_deserializes(seed: u64, max_bytes: u16)  {
+            let max_bytes = max_bytes as usize;
+            let rng = SmallRng::seed_from_u64(seed);
+            let traces = OpentelemetryTraces::default();
+
+            let mut bytes: Vec<u8> = Vec::with_capacity(max_bytes);
+            traces.to_bytes(rng, max_bytes, &mut bytes).unwrap();
+
+            opentelemetry_proto::tonic::collector::trace::v1::ExportTraceServiceRequest::decode(bytes.as_slice()).unwrap();
+        }
+    }
+}


### PR DESCRIPTION
### What does this PR do?

Add baseline support for generating OTEL payloads. This can be used to generate binary OTLP/HTTP messages. OTLP/gRPC support will be built on top of this.

### Motivation

This is the first piece of OpenTelemetry support.

### Related issues

SMP-7

### Additional Notes

This takes on all of `tonic` as a dependency. That's not great - it's a heavy dependency and this PR only needs the codegen parts. I'm not too concerned about it because we're going to need tonic for `OTLP/gRPC` support. Related upstream issue: https://github.com/open-telemetry/opentelemetry-rust/issues/873.