### PR TITLE
Improve OpenTelemetry integration tests

### DIFF
--- a/integration/sheepdog/src/lib.rs
+++ b/integration/sheepdog/src/lib.rs
@@ -267,13 +267,15 @@ generator:
     seed: [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53,
       59, 61, 67, 71, 73, 79, 83, 89, 97, 101, 103, 107, 109, 113, 127, 131]
     headers: {}
-    target_uri: "http://localhost:{{port_number}}/"
+    target_uri: "http://localhost:{{port_number}}/v1/logs"
     bytes_per_second: "100 Mb"
     parallel_connections: 5
     method:
       post:
         maximum_prebuild_cache_size_bytes: "8 Mb"
         variant: "opentelemetry_logs"
+        headers:
+            Content-Type: "application/x-protobuf"
         "#,
         )?;
 
@@ -297,13 +299,15 @@ generator:
     seed: [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53,
       59, 61, 67, 71, 73, 79, 83, 89, 97, 101, 103, 107, 109, 113, 127, 131]
     headers: {}
-    target_uri: "http://localhost:{{port_number}}/"
+    target_uri: "http://localhost:{{port_number}}/v1/traces"
     bytes_per_second: "100 Mb"
     parallel_connections: 5
     method:
       post:
         maximum_prebuild_cache_size_bytes: "8 Mb"
         variant: "opentelemetry_traces"
+        headers:
+            Content-Type: "application/x-protobuf"
         "#,
         )?;
 
@@ -327,13 +331,15 @@ generator:
     seed: [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53,
       59, 61, 67, 71, 73, 79, 83, 89, 97, 101, 103, 107, 109, 113, 127, 131]
     headers: {}
-    target_uri: "http://localhost:{{port_number}}/"
+    target_uri: "http://localhost:{{port_number}}/v1/metrics"
     bytes_per_second: "100 Mb"
     parallel_connections: 5
     method:
       post:
         maximum_prebuild_cache_size_bytes: "8 Mb"
         variant: "opentelemetry_metrics"
+        headers:
+            Content-Type: "application/x-protobuf"
         "#,
         )?;
 


### PR DESCRIPTION
### What does this PR do?

Use the default OTLP/HTTP URIs and the correct Content-Type header.

### Motivation

Improve the correctness of our integration tests.

### Related issues

SMP-7

### Additional Notes

Relevant docs section: https://opentelemetry.io/docs/reference/specification/protocol/otlp/#otlphttp-request
