### PR TITLE
Count bytes received by TCP blackhole

### DIFF
--- a/src/blackhole/tcp.rs
+++ b/src/blackhole/tcp.rs
@@ -45,8 +45,11 @@ impl Tcp {
     async fn handle_connection(socket: TcpStream) {
         let mut stream = ReaderStream::new(socket);
 
-        while stream.next().await.is_some() {
+        while let Some(msg) = stream.next().await {
             counter!("message_received", 1);
+            if let Ok(msg) = msg {
+                counter!("bytes_received", msg.len() as u64)
+            }
         }
     }
 

--- a/src/blackhole/tcp.rs
+++ b/src/blackhole/tcp.rs
@@ -48,7 +48,7 @@ impl Tcp {
         while let Some(msg) = stream.next().await {
             counter!("message_received", 1);
             if let Ok(msg) = msg {
-                counter!("bytes_received", msg.len() as u64)
+                counter!("bytes_received", msg.len() as u64);
             }
         }
     }


### PR DESCRIPTION
### What does this PR do?

Track bytes received by the TCP blackhole.

### Motivation

This provides more visibility into incoming TCP streams.

### Related issues

N/A

### Additional Notes

N/A