### PR TITLE
Switch generator & blackhole config to lists

### DIFF
--- a/integration/sheepdog/src/lib.rs
+++ b/integration/sheepdog/src/lib.rs
@@ -203,17 +203,17 @@ mod tests {
             },
             r#"
 generator:
-  http:
-    seed: [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53,
-      59, 61, 67, 71, 73, 79, 83, 89, 97, 101, 103, 107, 109, 113, 127, 131]
-    headers: {}
-    target_uri: "http://localhost:{{port_number}}/"
-    bytes_per_second: "100 Mb"
-    parallel_connections: 5
-    method:
-      post:
-        maximum_prebuild_cache_size_bytes: "8 Mb"
-        variant: "apache_common"
+  - http:
+        seed: [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53,
+          59, 61, 67, 71, 73, 79, 83, 89, 97, 101, 103, 107, 109, 113, 127, 131]
+        headers: {}
+        target_uri: "http://localhost:{{port_number}}/"
+        bytes_per_second: "100 Mb"
+        parallel_connections: 5
+        method:
+          post:
+            maximum_prebuild_cache_size_bytes: "8 Mb"
+            variant: "apache_common"
         "#,
         )?;
 
@@ -233,17 +233,17 @@ generator:
             },
             r#"
 generator:
-  http:
-    seed: [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53,
-      59, 61, 67, 71, 73, 79, 83, 89, 97, 101, 103, 107, 109, 113, 127, 131]
-    headers: {}
-    target_uri: "http://localhost:{{port_number}}/"
-    bytes_per_second: "100 Mb"
-    parallel_connections: 5
-    method:
-      post:
-        maximum_prebuild_cache_size_bytes: "8 Mb"
-        variant: "ascii"
+  - http:
+        seed: [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53,
+          59, 61, 67, 71, 73, 79, 83, 89, 97, 101, 103, 107, 109, 113, 127, 131]
+        headers: {}
+        target_uri: "http://localhost:{{port_number}}/"
+        bytes_per_second: "100 Mb"
+        parallel_connections: 5
+        method:
+          post:
+            maximum_prebuild_cache_size_bytes: "8 Mb"
+            variant: "ascii"
         "#,
         )?;
 
@@ -263,19 +263,19 @@ generator:
             },
             r#"
 generator:
-  http:
-    seed: [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53,
-      59, 61, 67, 71, 73, 79, 83, 89, 97, 101, 103, 107, 109, 113, 127, 131]
-    headers: {}
-    target_uri: "http://localhost:{{port_number}}/v1/logs"
-    bytes_per_second: "100 Mb"
-    parallel_connections: 5
-    method:
-      post:
-        maximum_prebuild_cache_size_bytes: "8 Mb"
-        variant: "opentelemetry_logs"
-        headers:
-            Content-Type: "application/x-protobuf"
+  - http:
+        seed: [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53,
+          59, 61, 67, 71, 73, 79, 83, 89, 97, 101, 103, 107, 109, 113, 127, 131]
+        headers: {}
+        target_uri: "http://localhost:{{port_number}}/v1/logs"
+        bytes_per_second: "100 Mb"
+        parallel_connections: 5
+        method:
+          post:
+            maximum_prebuild_cache_size_bytes: "8 Mb"
+            variant: "opentelemetry_logs"
+            headers:
+                Content-Type: "application/x-protobuf"
         "#,
         )?;
 
@@ -295,19 +295,19 @@ generator:
             },
             r#"
 generator:
-  http:
-    seed: [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53,
-      59, 61, 67, 71, 73, 79, 83, 89, 97, 101, 103, 107, 109, 113, 127, 131]
-    headers: {}
-    target_uri: "http://localhost:{{port_number}}/v1/traces"
-    bytes_per_second: "100 Mb"
-    parallel_connections: 5
-    method:
-      post:
-        maximum_prebuild_cache_size_bytes: "8 Mb"
-        variant: "opentelemetry_traces"
-        headers:
-            Content-Type: "application/x-protobuf"
+  - http:
+        seed: [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53,
+          59, 61, 67, 71, 73, 79, 83, 89, 97, 101, 103, 107, 109, 113, 127, 131]
+        headers: {}
+        target_uri: "http://localhost:{{port_number}}/v1/traces"
+        bytes_per_second: "100 Mb"
+        parallel_connections: 5
+        method:
+          post:
+            maximum_prebuild_cache_size_bytes: "8 Mb"
+            variant: "opentelemetry_traces"
+            headers:
+                Content-Type: "application/x-protobuf"
         "#,
         )?;
 
@@ -327,19 +327,19 @@ generator:
             },
             r#"
 generator:
-  http:
-    seed: [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53,
-      59, 61, 67, 71, 73, 79, 83, 89, 97, 101, 103, 107, 109, 113, 127, 131]
-    headers: {}
-    target_uri: "http://localhost:{{port_number}}/v1/metrics"
-    bytes_per_second: "100 Mb"
-    parallel_connections: 5
-    method:
-      post:
-        maximum_prebuild_cache_size_bytes: "8 Mb"
-        variant: "opentelemetry_metrics"
-        headers:
-            Content-Type: "application/x-protobuf"
+  - http:
+        seed: [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53,
+          59, 61, 67, 71, 73, 79, 83, 89, 97, 101, 103, 107, 109, 113, 127, 131]
+        headers: {}
+        target_uri: "http://localhost:{{port_number}}/v1/metrics"
+        bytes_per_second: "100 Mb"
+        parallel_connections: 5
+        method:
+          post:
+            maximum_prebuild_cache_size_bytes: "8 Mb"
+            variant: "opentelemetry_metrics"
+            headers:
+                Content-Type: "application/x-protobuf"
         "#,
         )?;
 
@@ -359,14 +359,14 @@ generator:
             },
             r#"
 generator:
-  tcp:
-    seed: [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53,
-      59, 61, 67, 71, 73, 79, 83, 89, 97, 101, 103, 107, 109, 113, 127, 131]
-    addr: "127.0.0.1:{{port_number}}"
-    bytes_per_second: "100 Mb"
-    block_sizes: ["1Mb", "0.5Mb", "0.25Mb", "0.125Mb", "128Kb"]
-    variant: fluent
-    maximum_prebuild_cache_size_bytes: "8 Mb"
+  - tcp:
+        seed: [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53,
+          59, 61, 67, 71, 73, 79, 83, 89, 97, 101, 103, 107, 109, 113, 127, 131]
+        addr: "127.0.0.1:{{port_number}}"
+        bytes_per_second: "100 Mb"
+        block_sizes: ["1Mb", "0.5Mb", "0.25Mb", "0.125Mb", "128Kb"]
+        variant: fluent
+        maximum_prebuild_cache_size_bytes: "8 Mb"
         "#,
         )?;
 

--- a/src/bin/lading.rs
+++ b/src/bin/lading.rs
@@ -245,7 +245,7 @@ async fn inner_main(
     // GENERATOR
     //
     assert!(
-        config.generator.len() >= 1,
+        !config.generator.is_empty(),
         "lading requires at least one generator in order to run"
     );
     for cfg in config.generator {

--- a/src/bin/lading.rs
+++ b/src/bin/lading.rs
@@ -11,7 +11,7 @@ use clap::{ArgGroup, Parser};
 use lading::{
     blackhole,
     captures::CaptureManager,
-    config::{self, Config, Telemetry},
+    config::{Config, Telemetry},
     generator, inspector, observer,
     signals::Shutdown,
     target::{self, Behavior, Output},
@@ -244,19 +244,14 @@ async fn inner_main(
     //
     // GENERATOR
     //
-    match config.generator {
-        config::Generator::One(cfg) => {
-            let tgt_rcv = tgt_snd.subscribe();
-            let generator_server = generator::Server::new(*cfg, shutdown.clone()).unwrap();
-            let _gsrv = tokio::spawn(generator_server.run(tgt_rcv));
-        }
-        config::Generator::Many(cfgs) => {
-            for cfg in cfgs {
-                let tgt_rcv = tgt_snd.subscribe();
-                let generator_server = generator::Server::new(cfg, shutdown.clone()).unwrap();
-                let _gsrv = tokio::spawn(generator_server.run(tgt_rcv));
-            }
-        }
+    assert!(
+        config.generator.len() >= 1,
+        "lading requires at least one generator in order to run"
+    );
+    for cfg in config.generator {
+        let tgt_rcv = tgt_snd.subscribe();
+        let generator_server = generator::Server::new(cfg, shutdown.clone()).unwrap();
+        let _gsrv = tokio::spawn(generator_server.run(tgt_rcv));
     }
 
     //
@@ -275,16 +270,7 @@ async fn inner_main(
     // BLACKHOLE
     //
     match config.blackhole {
-        Some(config::Blackhole::One(cfg)) => {
-            let blackhole_server = blackhole::Server::new(*cfg, shutdown.clone());
-            let _bsrv = tokio::spawn(async {
-                match blackhole_server.run().await {
-                    Ok(()) => debug!("blackhole shut down successfully"),
-                    Err(err) => warn!("blackhole failed with {:?}", err),
-                }
-            });
-        }
-        Some(config::Blackhole::Many(cfgs)) => {
+        Some(cfgs) => {
             for cfg in cfgs {
                 let blackhole_server = blackhole::Server::new(cfg, shutdown.clone());
                 let _bsrv = tokio::spawn(async {

--- a/src/blackhole.rs
+++ b/src/blackhole.rs
@@ -30,7 +30,7 @@ pub enum Error {
     Sqs(sqs::Error),
 }
 
-#[derive(Debug, Deserialize, Clone, Copy)]
+#[derive(Debug, Deserialize, Clone, Copy, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 /// Configuration for [`Server`]
 pub enum Config {

--- a/src/blackhole/http.rs
+++ b/src/blackhole/http.rs
@@ -29,7 +29,7 @@ pub enum Error {
     Hyper(hyper::Error),
 }
 
-#[derive(Debug, Copy, Clone, Deserialize)]
+#[derive(Debug, Copy, Clone, Deserialize, PartialEq, Eq)]
 /// Body variant supported by this blackhole.
 pub enum BodyVariant {
     /// All response bodies will be empty.
@@ -53,7 +53,7 @@ fn default_body_variant() -> BodyVariant {
     BodyVariant::AwsKinesis
 }
 
-#[derive(Debug, Deserialize, Clone, Copy)]
+#[derive(Debug, Deserialize, Clone, Copy, PartialEq, Eq)]
 /// Configuration for [`Http`]
 pub struct Config {
     /// number of concurrent HTTP connections to allow

--- a/src/blackhole/splunk_hec.rs
+++ b/src/blackhole/splunk_hec.rs
@@ -32,7 +32,7 @@ pub enum Error {
     Hyper(hyper::Error),
 }
 
-#[derive(Debug, Deserialize, Clone, Copy)]
+#[derive(Debug, Deserialize, Clone, Copy, PartialEq, Eq)]
 /// Configuration for [`SplunkHec`].
 pub struct Config {
     /// number of concurrent HTTP connections to allow

--- a/src/blackhole/sqs.rs
+++ b/src/blackhole/sqs.rs
@@ -27,7 +27,7 @@ fn default_concurrent_requests_max() -> usize {
     100
 }
 
-#[derive(Debug, Deserialize, Clone, Copy)]
+#[derive(Debug, Deserialize, Clone, Copy, PartialEq, Eq)]
 /// Configuration for [`Sqs`]
 pub struct Config {
     /// number of concurrent HTTP connections to allow

--- a/src/blackhole/tcp.rs
+++ b/src/blackhole/tcp.rs
@@ -18,11 +18,11 @@ pub enum Error {
     Io(io::Error),
 }
 
-#[derive(Debug, Deserialize, Clone, Copy)]
+#[derive(Debug, Deserialize, Clone, Copy, PartialEq, Eq)]
 /// Configuration for [`Tcp`]
 pub struct Config {
     /// address -- IP plus port -- to bind to
-    binding_addr: SocketAddr,
+    pub binding_addr: SocketAddr,
 }
 
 #[derive(Debug)]

--- a/src/blackhole/udp.rs
+++ b/src/blackhole/udp.rs
@@ -16,7 +16,7 @@ pub enum Error {
     Io(io::Error),
 }
 
-#[derive(Debug, Deserialize, Clone, Copy)]
+#[derive(Debug, Deserialize, Clone, Copy, PartialEq, Eq)]
 /// Configuration for [`Udp`].
 pub struct Config {
     /// address -- IP plus port -- to bind to

--- a/src/common.rs
+++ b/src/common.rs
@@ -2,7 +2,7 @@ use std::{fmt, fs, path::PathBuf, process::Stdio, str};
 
 use serde::Deserialize;
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, PartialEq, Eq)]
 /// Defines how sub-process stderr and stdout are handled.
 pub struct Output {
     #[serde(default)]
@@ -13,7 +13,7 @@ pub struct Output {
     pub stdout: Behavior,
 }
 
-#[derive(Debug, Deserialize, Clone)]
+#[derive(Debug, Deserialize, Clone, PartialEq, Eq)]
 #[serde(untagged)]
 /// Defines the [`Output`] behavior for stderr and stdout.
 pub enum Behavior {

--- a/src/generator.rs
+++ b/src/generator.rs
@@ -39,7 +39,7 @@ pub enum Error {
     Grpc(grpc::Error),
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 /// Configuration for [`Server`]
 pub enum Config {

--- a/src/generator/file_gen.rs
+++ b/src/generator/file_gen.rs
@@ -70,7 +70,7 @@ fn default_rotation() -> bool {
     true
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, PartialEq, Eq)]
 /// Configuration of [`FileGen`]
 pub struct Config {
     /// The seed for random operations against this target

--- a/src/generator/grpc.rs
+++ b/src/generator/grpc.rs
@@ -79,7 +79,7 @@ impl std::fmt::Display for Error {
 impl std::error::Error for Error {}
 
 /// Config for [`Grpc`]
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, PartialEq, Eq)]
 pub struct Config {
     /// The gRPC URI. Looks like http://host/service.path/endpoint
     pub target_uri: String,

--- a/src/generator/http.rs
+++ b/src/generator/http.rs
@@ -32,7 +32,7 @@ use crate::{
 static CONNECTION_SEMAPHORE: OnceCell<Semaphore> = OnceCell::new();
 
 /// The HTTP method to be used in requests
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum Method {
     /// Make HTTP Post requests
@@ -44,7 +44,7 @@ pub enum Method {
     },
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, PartialEq, Eq)]
 /// Configuration of this generator.
 pub struct Config {
     /// The seed for random operations against this target

--- a/src/generator/kafka.rs
+++ b/src/generator/kafka.rs
@@ -32,7 +32,7 @@ use crate::{
 };
 
 /// Configuration for generator throughput.
-#[derive(Clone, Copy, Debug, Deserialize)]
+#[derive(Clone, Copy, Debug, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum Throughput {
     /// The producer should run as fast as possible.
@@ -51,7 +51,7 @@ pub enum Throughput {
     },
 }
 
-#[derive(Clone, Debug, Deserialize)]
+#[derive(Clone, Debug, Deserialize, PartialEq, Eq)]
 /// Configuration for [`Kafka`]
 pub struct Config {
     /// The seed for random operations against this target

--- a/src/generator/splunk_hec.rs
+++ b/src/generator/splunk_hec.rs
@@ -45,7 +45,7 @@ const SPLUNK_HEC_TEXT_PATH: &str = "/services/collector/raw";
 const SPLUNK_HEC_CHANNEL_HEADER: &str = "x-splunk-request-channel";
 
 /// Optional Splunk HEC indexer acknowledgements configuration
-#[derive(Deserialize, Debug, Clone, Copy)]
+#[derive(Deserialize, Debug, Clone, Copy, PartialEq, Eq)]
 pub struct AckSettings {
     /// The time in seconds between queries to /services/collector/ack
     pub ack_query_interval_seconds: u64,
@@ -55,7 +55,7 @@ pub struct AckSettings {
 }
 
 /// Configuration for [`SplunkHec`]
-#[derive(Deserialize, Debug)]
+#[derive(Deserialize, Debug, PartialEq, Eq)]
 pub struct Config {
     /// The seed for random operations against this target
     pub seed: [u8; 32],

--- a/src/generator/tcp.rs
+++ b/src/generator/tcp.rs
@@ -23,7 +23,7 @@ use crate::{
     signals::Shutdown,
 };
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, PartialEq, Eq)]
 /// Configuration of this generator.
 pub struct Config {
     /// The seed for random operations against this target

--- a/src/inspector.rs
+++ b/src/inspector.rs
@@ -38,7 +38,7 @@ pub enum Error {
     Io(io::Error),
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 /// Configuration for [`Server`]
 pub struct Config {

--- a/src/observer.rs
+++ b/src/observer.rs
@@ -32,7 +32,7 @@ pub enum Error {
     ProcError(procfs::ProcError),
 }
 
-#[derive(Debug, Deserialize, Clone, Copy, Default)]
+#[derive(Debug, Deserialize, Clone, Copy, Default, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 /// Configuration for [`Server`]
 pub struct Config {}

--- a/src/payload.rs
+++ b/src/payload.rs
@@ -84,7 +84,7 @@ pub(crate) trait Serialize {
 }
 
 /// Configuration for `Payload`
-#[derive(Debug, Deserialize, Clone)]
+#[derive(Debug, Deserialize, Clone, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum Config {
     /// Generates Fluent messages

--- a/src/payload/splunk_hec.rs
+++ b/src/payload/splunk_hec.rs
@@ -141,7 +141,7 @@ impl<'a> Arbitrary<'a> for Member {
     }
 }
 
-#[derive(Deserialize, Debug, Clone, Copy)]
+#[derive(Deserialize, Debug, Clone, Copy, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 #[cfg_attr(test, derive(proptest_derive::Arbitrary))]
 pub enum Encoding {

--- a/src/target.rs
+++ b/src/target.rs
@@ -49,14 +49,14 @@ pub enum Error {
 
 /// Configuration for PID target mode
 #[allow(missing_copy_implementations)]
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Eq)]
 pub struct PidConfig {
     /// PID to watch
     pub pid: NonZeroU32,
 }
 
 /// Configuration for binary launch mode
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Eq)]
 pub struct BinaryConfig {
     /// The path to the target executable.
     pub command: PathBuf,
@@ -70,7 +70,7 @@ pub struct BinaryConfig {
 }
 
 /// Configuration for [`Server`]
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Eq)]
 pub enum Config {
     /// An existing process that is managed externally
     Pid(PidConfig),


### PR DESCRIPTION
### What does this PR do?

Switch generator & blackhole config sections to (always) be lists.

**This is a breaking change.**

### Motivation

This change allows us to remove the `serde(untagged)` attribute on the relevant config sections. This enables serde to offer a significantly improved debug experience.

Before:
```
Error("blackhole: data did not match any variant of untagged enum Config", line: 14, column: 3)
```

After:
```
Error("blackhole[0]: unknown variant `tcpa`, expected one of `tcp`, `http`, `splunk_hec`, `udp`,
`sqs`", line: 14, column: 5)
```

### Related issues

Closes https://github.com/DataDog/lading/issues/306

### Additional Notes

See: https://docs.rs/serde_yaml/0.9.13/serde_yaml/with/singleton_map_recursive/index.html