### PR TITLE
Add GitHub release workflow w/ binaries & containers. Add changelog.

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -1,4 +1,4 @@
-name: Release
+name: Container
 
 on:
   push:
@@ -38,6 +38,9 @@ jobs:
           tags: |
             type=sha,format=long
             type=ref,event=tag
+            type=semver,pattern={{version}},event=tag
+            type=semver,pattern={{major}}.{{minor}},event=tag
+            type=semver,pattern={{major}},event=tag
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
 
       - name: Build and push Docker image (${{ matrix.platform }})

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,45 @@
+name: Release
+
+permissions:
+  contents: write
+
+on:
+  push:
+    tags:
+      - v[0-9]+.*
+
+jobs:
+  create-release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Create GitHub release
+        uses: taiki-e/create-gh-release-action@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+  upload-binaries:
+    strategy:
+      matrix:
+        include:
+          - target: aarch64-unknown-linux-gnu
+            os: ubuntu-latest
+          - target: aarch64-apple-darwin
+            os: macos-latest
+          - target: x86_64-unknown-linux-gnu
+            os: ubuntu-latest
+          - target: x86_64-apple-darwin
+            os: macos-latest
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Build and upload lading binaries
+        uses: taiki-e/upload-rust-binary-action@v1
+        with:
+          bin: lading
+          target: ${{ matrix.target }}
+          checksum: sha256
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,7 @@ jobs:
       - name: Create GitHub release
         uses: taiki-e/create-gh-release-action@v1
         with:
+          changelog: CHANGELOG.md
           token: ${{ secrets.GITHUB_TOKEN }}
 
   upload-binaries:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+


### PR DESCRIPTION
### What does this PR do?

Add a release process to the project.

Releases will be triggered by creating a git tag. The `release.yml` workflow will then automatically create a github release with a changelog snippet and then build and upload `lading` binaries. The `container.yml` workflow will build and tag a set of images according to semver.

For now, the changelog should be written manually before release. We may decide to automate that in the future, maybe with additional automation like [release-please](https://github.com/googleapis/release-please).

### Motivation

This allows us to offer predictability and documentation around breaking changes.

### Related issues

Closes #266 

### Additional Notes

Best reviewed commit-by-commit