### PR TITLE
Tag PR containers

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -38,6 +38,7 @@ jobs:
           tags: |
             type=sha,format=long
             type=ref,event=tag
+            type=ref,prefix=pr-,event=pr
             type=semver,pattern={{version}},event=tag
             type=semver,pattern={{major}}.{{minor}},event=tag
             type=semver,pattern={{major}},event=tag


### PR DESCRIPTION
### What does this PR do?

This change tags PR containers with a `pr-xyz` tag. This makes it a bit easier to test changes from PRs.

### Motivation

Got tired of searching Actions logs for container SHAs.

### Related issues

N/A

### Additional Notes

Built on https://github.com/DataDog/lading/pull/320. The only new commit here is the last one in the series.
