### PR TITLE
Use rust-cache Action to speed up CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,7 @@ jobs:
       - name: Install protobuf (Brew)
         run: brew install protobuf
         if: matrix.os == 'macos-latest'
+      - uses: Swatinem/rust-cache@v2
       - uses: actions-rs/cargo@v1
         with:
           command: check
@@ -55,6 +56,7 @@ jobs:
       - name: Install protobuf (Brew)
         run: brew install protobuf
         if: matrix.os == 'macos-latest'
+      - uses: Swatinem/rust-cache@v2
       - uses: actions-rs/cargo@v1
         with:
           command: test
@@ -96,6 +98,7 @@ jobs:
       - name: Install protobuf (Brew)
         run: brew install protobuf
         if: matrix.os == 'macos-latest'
+      - uses: Swatinem/rust-cache@v2
       - uses: actions-rs/cargo@v1
         with:
           command: clippy
@@ -120,6 +123,7 @@ jobs:
       - name: Install protobuf (Brew)
         run: brew install protobuf
         if: matrix.os == 'macos-latest'
+      - uses: Swatinem/rust-cache@v2
       - uses: actions-rs/cargo@v1
         with:
           command: test


### PR DESCRIPTION
### What does this PR do?

Add caching to our CI jobs. This will cache dependency download & build artifacts.

This should save about a minute of wall time & eight to ten minutes of runner time.

### Motivation

Our CI times are inching upwards. This is the easy first step before doing any compile time analysis.

### Related issues

N/A

### Additional Notes

- Here's a before & after to verify caching is working and get a rough idea of the impact:
  - Before: https://github.com/DataDog/lading/actions/runs/3092062204/jobs/5002899386
  - After: https://github.com/DataDog/lading/actions/runs/3092062204/jobs/5003046258