### PR TITLE
Three fixes to the release workflow

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -40,7 +40,7 @@ jobs:
             type=ref,prefix=pr-,event=pr
             type=semver,pattern={{version}},event=tag
             type=semver,pattern={{major}}.{{minor}},event=tag
-            type=semver,pattern={{major}},event=tag
+            type=semver,pattern={{major}},event=tag,enable=${{ !startsWith(github.ref, 'refs/tags/v0.') }}
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
 
       - name: Build and push Docker image (${{ matrix.platform }})

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -40,7 +40,7 @@ jobs:
             type=ref,prefix=pr-,event=pr
             type=semver,pattern={{version}},event=tag
             type=semver,pattern={{major}}.{{minor}},event=tag
-            type=semver,pattern={{major}},event=tag,enable=${{ !startsWith(github.ref, 'refs/tags/v0.') }}
+            type=semver,pattern={{major}},event=tag
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
 
       - name: Build and push Docker image (${{ matrix.platform }})

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -37,7 +37,6 @@ jobs:
         with:
           tags: |
             type=sha,format=long
-            type=ref,event=tag
             type=ref,prefix=pr-,event=pr
             type=semver,pattern={{version}},event=tag
             type=semver,pattern={{major}}.{{minor}},event=tag

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,6 +37,13 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
+      - name: Install protobuf (Apt)
+        run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
+        if: matrix.os == 'ubuntu-latest'
+      - name: Install protobuf (Brew)
+        run: brew install protobuf
+        if: matrix.os == 'macos-latest'
+
       - name: Build and upload lading binaries
         uses: taiki-e/upload-rust-binary-action@v1
         with:


### PR DESCRIPTION
### What does this PR do?

- I forgot to install the protobuf compiler
- The docker image is being tagged with the git tag verbatim, in addition to semver tags. This is unnecessary and confusing.
- <s>Stop tagging images with major version 0</s> Reverted. I can't delete the image that was released as '0', and I'm not too offended by having a '0' major tag. I can unwind this, but I'm not sure it's worth finding a github org admin to help fix.

### Motivation

Fixing up the release workflow

### Related issues

#320 #326 

### Additional Notes

<s>Unless anyone objects, I plan to delete the 0.10.0 tag, image, and release, retag, and allow the workflow to run again. I'm not against cutting a 0.10.1, but I'm not too concerned about re-tagging a dev version without code changes.</s> I'll cut a 0.10.1 release since I can't delete the 0.10.0 image.