### PR TITLE
Fixes for gRPC generator

### DIFF
--- a/src/generator/grpc.rs
+++ b/src/generator/grpc.rs
@@ -220,7 +220,13 @@ impl Grpc {
         let mut parts = self.target_uri.clone().into_parts();
         parts.path_and_query = Some(PathAndQuery::from_static(""));
         let uri = Uri::from_parts(parts).unwrap();
+
+        let endpoint = tonic::transport::Endpoint::new(uri)?;
+        let endpoint = endpoint.connect_timeout(Duration::from_secs(1));
+        let conn = endpoint.connect().await?;
         let conn = tonic::client::Grpc::new(conn);
+
+        debug!("gRPC generator connected");
 
         Ok(conn)
     }

--- a/src/generator/grpc.rs
+++ b/src/generator/grpc.rs
@@ -3,6 +3,7 @@
 use std::{
     convert::TryFrom,
     num::{NonZeroU32, NonZeroUsize},
+    time::Duration,
 };
 
 use bytes::{Buf, BufMut, Bytes};
@@ -20,7 +21,7 @@ use tonic::{
     codec::{DecodeBuf, Decoder, EncodeBuf, Encoder},
     Request, Response, Status,
 };
-use tracing::info;
+use tracing::{debug, info};
 
 use crate::{
     block::{self, chunk_bytes, construct_block_cache, Block},
@@ -261,7 +262,14 @@ impl Grpc {
     ///
     /// Function will panic if underlying byte capacity is not available.
     pub async fn spin(mut self) -> Result<(), Error> {
-        let mut client = self.connect().await?;
+        let mut client = loop {
+            match self.connect().await {
+                Ok(c) => break c,
+                Err(e) => debug!("Failed to connect gRPC generator (will retry): {}", e),
+            }
+
+            tokio::time::sleep(Duration::from_millis(100)).await;
+        };
 
         let mut blocks = self.block_cache.iter().cycle();
         let rpc_path = self.rpc_path;

--- a/src/generator/grpc.rs
+++ b/src/generator/grpc.rs
@@ -217,9 +217,9 @@ impl Grpc {
 
     /// Establish a connection with the configured RPC server
     async fn connect(&self) -> Result<tonic::client::Grpc<tonic::transport::Channel>, Error> {
-        let conn = tonic::transport::Endpoint::new(self.target_uri.clone())?
-            .connect()
-            .await?;
+        let mut parts = self.target_uri.clone().into_parts();
+        parts.path_and_query = Some(PathAndQuery::from_static(""));
+        let uri = Uri::from_parts(parts).unwrap();
         let conn = tonic::client::Grpc::new(conn);
 
         Ok(conn)

--- a/src/observer.rs
+++ b/src/observer.rs
@@ -165,6 +165,7 @@ impl Server {
     /// # Panics
     ///
     /// None are known.
+    #[allow(clippy::unused_async)]
     #[cfg(not(target_os = "linux"))]
     pub async fn run(self, _pid_snd: Receiver<u32>) -> Result<(), Error> {
         tracing::warn!("observer unavailable on non-Linux system");

--- a/src/target.rs
+++ b/src/target.rs
@@ -204,15 +204,12 @@ impl Server {
 
         tokio::select! {
             target_exit = target_wait => {
-                match target_exit {
-                    Some(code) => {
-                        error!("target exited unexpectedly with code {}", code);
-                        Err(Error::TargetExited(Some(code)))
-                    },
-                    None => {
-                        error!("target exited unexpectedly; exit code unavailable");
-                        Err(Error::TargetExited(None))
-                    },
+                if let Some(code) = target_exit{
+                    error!("target exited unexpectedly with code {}", code);
+                    Err(Error::TargetExited(Some(code)))
+                } else {
+                    error!("target exited unexpectedly; exit code unavailable");
+                    Err(Error::TargetExited(None))
                 }
             },
             _ = shutdown.recv() => {


### PR DESCRIPTION
### What does this PR do?

Fix issues that came up in https://github.com/DataDog/single-machine-performance/pull/154. The primary issue here is the lack of connection retries: the generator was attempting to connect before Vector's gRPC server was available.

### Motivation

Run an OTel experiment

### Related issues

https://github.com/DataDog/single-machine-performance/pull/154

### Additional Notes

N/A
