### PR TITLE
Fix one last rust 1.64 warning

### DIFF
--- a/src/bin/lading.rs
+++ b/src/bin/lading.rs
@@ -272,19 +272,16 @@ async fn inner_main(
     //
     // BLACKHOLE
     //
-    match config.blackhole {
-        Some(cfgs) => {
-            for cfg in cfgs {
-                let blackhole_server = blackhole::Server::new(cfg, shutdown.clone());
-                let _bsrv = tokio::spawn(async {
-                    match blackhole_server.run().await {
-                        Ok(()) => debug!("blackhole shut down successfully"),
-                        Err(err) => warn!("blackhole failed with {:?}", err),
-                    }
-                });
-            }
+    if let Some(cfgs) = config.blackhole {
+        for cfg in cfgs {
+            let blackhole_server = blackhole::Server::new(cfg, shutdown.clone());
+            let _bsrv = tokio::spawn(async {
+                match blackhole_server.run().await {
+                    Ok(()) => debug!("blackhole shut down successfully"),
+                    Err(err) => warn!("blackhole failed with {:?}", err),
+                }
+            });
         }
-        None => {}
     }
 
     //


### PR DESCRIPTION
### What does this PR do?

Fixes the last warning from updating to rust 1.64

### Motivation

Didn't want to delay #333 with another CI iteration

### Related issues

Fixed the 1.64 clippy dings in https://github.com/DataDog/lading/pull/333

### Additional Notes

https://blog.rust-lang.org/2022/09/22/Rust-1.64.0.html