### PR TITLE
Align default body variant w/ comment

### DIFF
--- a/src/blackhole/http.rs
+++ b/src/blackhole/http.rs
@@ -50,7 +50,7 @@ impl FromStr for BodyVariant {
 }
 
 fn default_body_variant() -> BodyVariant {
-    BodyVariant::AwsKinesis
+    BodyVariant::Nothing
 }
 
 #[derive(Debug, Deserialize, Clone, Copy, PartialEq, Eq)]


### PR DESCRIPTION
### What does this PR do?

The doc-comment on `body_variant` says that it defaults to `Nothing`. That wasn't true before, now it is.

### Motivation

Align comments & choose unsurprising defaults.

### Related issues

N/A

### Additional Notes

I didn't really want to change behavior here, but I think this is the right decision long term.