### PR TITLE
Make http blackhole content type configurable

### DIFF
--- a/src/bin/lading.rs
+++ b/src/bin/lading.rs
@@ -274,7 +274,7 @@ async fn inner_main(
     //
     if let Some(cfgs) = config.blackhole {
         for cfg in cfgs {
-            let blackhole_server = blackhole::Server::new(cfg, shutdown.clone());
+            let blackhole_server = blackhole::Server::new(cfg, shutdown.clone()).unwrap();
             let _bsrv = tokio::spawn(async {
                 match blackhole_server.run().await {
                     Ok(()) => debug!("blackhole shut down successfully"),

--- a/src/blackhole/http.rs
+++ b/src/blackhole/http.rs
@@ -193,7 +193,13 @@ impl Http {
         // A very weird dance to satisfy the borrow checker for moving into & out of an FnMut.
         let content_type = self.content_type_header.clone();
         let content_type = Box::new(content_type);
-        // Turn the mutable ref from `leak` into an immutable ref so it's Copy
+        // Turn the mutable ref from `leak` into an immutable ref so it's Copy.
+        //
+        // This memory is intentionally leaked for the life of the process. This
+        // is acceptable because it only runs once at startup (for each
+        // configured `Http` generator). These generators are expected to stay
+        // active until the program shuts down. The memory is left for the OS
+        // to clean up.
         let content_type = &*Box::leak::<'static>(content_type);
 
         let service = make_service_fn(|_: &AddrStream| async move {

--- a/src/blackhole/http.rs
+++ b/src/blackhole/http.rs
@@ -2,6 +2,7 @@
 
 use std::{net::SocketAddr, str::FromStr, time::Duration};
 
+use http::{header::InvalidHeaderValue, HeaderValue};
 use hyper::{
     body, header,
     server::conn::{AddrIncoming, AddrStream},
@@ -22,11 +23,15 @@ fn default_concurrent_requests_max() -> usize {
     100
 }
 
-#[derive(Debug)]
 /// Errors produced by [`Http`].
+#[derive(thiserror::Error, Debug)]
 pub enum Error {
     /// Wrapper for [`hyper::Error`].
+    #[error("HTTP server error: {0}")]
     Hyper(hyper::Error),
+    /// The configured content type value was not valid.
+    #[error("The configured content type value was not valid: {0}")]
+    InvalidContentType(InvalidHeaderValue),
 }
 
 #[derive(Debug, Copy, Clone, Deserialize, PartialEq, Eq)]
@@ -53,7 +58,11 @@ fn default_body_variant() -> BodyVariant {
     BodyVariant::AwsKinesis
 }
 
-#[derive(Debug, Deserialize, Clone, Copy, PartialEq, Eq)]
+fn default_content_type() -> String {
+    "application/json".to_string()
+}
+
+#[derive(Debug, Deserialize, Clone, PartialEq, Eq)]
 /// Configuration for [`Http`]
 pub struct Config {
     /// number of concurrent HTTP connections to allow
@@ -64,6 +73,9 @@ pub struct Config {
     /// the body variant to respond with, default nothing
     #[serde(default = "default_body_variant")]
     pub body_variant: BodyVariant,
+    /// the content-type header to respond with, defaults to application/json
+    #[serde(default = "default_content_type")]
+    pub content_type: String,
 }
 
 #[derive(Serialize)]
@@ -86,6 +98,7 @@ struct KinesisPutRecordBatchResponse {
 async fn srv(
     body_variant: BodyVariant,
     req: Request<Body>,
+    content_type: &Option<HeaderValue>,
 ) -> Result<Response<Body>, hyper::Error> {
     metrics::counter!("requests_received", 1);
 
@@ -100,10 +113,10 @@ async fn srv(
 
             let mut okay = Response::default();
             *okay.status_mut() = StatusCode::OK;
-            okay.headers_mut().insert(
-                header::CONTENT_TYPE,
-                header::HeaderValue::from_static("application/json"),
-            );
+
+            if let Some(val) = content_type {
+                okay.headers_mut().insert(header::CONTENT_TYPE, val.clone());
+            }
 
             let body_bytes = RESPONSE
                 .get_or_init(|| match body_variant {
@@ -135,18 +148,32 @@ pub struct Http {
     body_variant: BodyVariant,
     concurrency_limit: usize,
     shutdown: Shutdown,
+    content_type_header: Option<HeaderValue>,
 }
 
 impl Http {
     /// Create a new [`Http`] server instance
-    #[must_use]
-    pub fn new(config: &Config, shutdown: Shutdown) -> Self {
-        Self {
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the configuration is invalid.
+    pub fn new(config: &Config, shutdown: Shutdown) -> Result<Self, Error> {
+        let content_type_header = if config.content_type.is_empty() {
+            None
+        } else {
+            Some(
+                header::HeaderValue::from_str(&config.content_type)
+                    .map_err(Error::InvalidContentType)?,
+            )
+        };
+
+        Ok(Self {
             httpd_addr: config.binding_addr,
             body_variant: config.body_variant,
             concurrency_limit: config.concurrent_requests_max,
             shutdown,
-        }
+            content_type_header,
+        })
     }
 
     /// Run [`Http`] to completion
@@ -156,16 +183,23 @@ impl Http {
     ///
     /// # Errors
     ///
-    /// Function will return an error if receiving a packet fails.
+    /// Function will return an error if the configuration is invalid or if
+    /// receiving a packet fails.
     ///
     /// # Panics
     ///
     /// None known.
     pub async fn run(mut self) -> Result<(), Error> {
+        // A very weird dance to satisfy the borrow checker for moving into & out of an FnMut.
+        let content_type = self.content_type_header.clone();
+        let content_type = Box::new(content_type);
+        // Turn the mutable ref from `leak` into an immutable ref so it's Copy
+        let content_type = &*Box::leak::<'static>(content_type);
+
         let service = make_service_fn(|_: &AddrStream| async move {
             Ok::<_, hyper::Error>(service_fn(move |request| {
                 debug!("REQUEST: {:?}", request);
-                srv(self.body_variant, request)
+                srv(self.body_variant, request, content_type)
             }))
         });
         let svc = ServiceBuilder::new()


### PR DESCRIPTION
### What does this PR do?

Make the HTTP blackhole's response content type configurable.

### Motivation

This allows http responses to masquerade as anything. The next step will be to add configurable payloads, but we'll cross that bridge when we come to it.

### Related issues

https://github.com/DataDog/lading/issues/101

### Additional Notes

This required some unpleasantness to pass through to the service handler. I'd typically solve lifetimes for a series of moves with nested clones, but that's insufficient in this case. I worked around it by leaking a box and holding the `Copy` reference in the `FnMut` closure that was causing problems. I would gladly accept suggestions or improvements on this!