### PR TITLE
Bias UDP send loop towards the shutdown signal

### DIFF
--- a/src/generator/udp.rs
+++ b/src/generator/udp.rs
@@ -149,6 +149,7 @@ impl Udp {
                     "UDP packet too large (over 65507 B)"
                 );
                 if let Some(sock) = &connection {
+                    tokio::task::yield_now().await;
                     self.rate_limiter.until_n_ready(total_bytes).await.unwrap();
 
                     match sock.send_to(&blk.bytes, self.addr).await {

--- a/src/generator/udp.rs
+++ b/src/generator/udp.rs
@@ -150,6 +150,11 @@ impl Udp {
             );
 
             tokio::select! {
+                biased;
+                _ = self.shutdown.recv() => {
+                    info!("shutdown signal received");
+                    return Ok(());
+                },
                 sock = UdpSocket::bind("127.0.0.1:0"), if connection.is_none() => {
                     debug!("UDP port bound");
 
@@ -187,10 +192,6 @@ impl Udp {
                         }
                     }
                 }
-                _ = self.shutdown.recv() => {
-                    info!("shutdown signal received");
-                    return Ok(());
-                },
             }
         }
     }

--- a/src/generator/udp.rs
+++ b/src/generator/udp.rs
@@ -138,28 +138,36 @@ impl Udp {
         debug!("UDP generator running");
         let labels = self.metric_labels;
 
-        let mut connection = None;
-        let mut blocks = self.block_cache.iter().cycle();
+        let send_task = tokio::spawn(async move {
+            let mut blocks = self.block_cache.iter().cycle();
+            let mut connection = Option::<UdpSocket>::None;
+            loop {
+                let blk = blocks.next().unwrap();
+                let total_bytes = blk.total_bytes;
+                assert!(
+                    total_bytes.get() <= 65507,
+                    "UDP packet too large (over 65507 B)"
+                );
+                if let Some(sock) = &connection {
+                    self.rate_limiter.until_n_ready(total_bytes).await.unwrap();
 
-        loop {
-            let blk = blocks.next().unwrap();
-            let total_bytes = blk.total_bytes;
-            assert!(
-                total_bytes.get() <= 65507,
-                "UDP packet too large (over 65507 B)"
-            );
+                    match sock.send_to(&blk.bytes, self.addr).await {
+                        Ok(bytes) => {
+                            counter!("bytes_written", bytes as u64, &labels);
+                        }
+                        Err(err) => {
+                            debug!("write failed: {}", err);
 
-            tokio::select! {
-                biased;
-                _ = self.shutdown.recv() => {
-                    info!("shutdown signal received");
-                    return Ok(());
-                },
-                sock = UdpSocket::bind("127.0.0.1:0"), if connection.is_none() => {
-                    debug!("UDP port bound");
-
-                    match sock {
+                            let mut error_labels = labels.clone();
+                            error_labels.push(("error".to_string(), err.to_string()));
+                            counter!("request_failure", 1, &error_labels);
+                            connection = None;
+                        }
+                    }
+                } else {
+                    match UdpSocket::bind("127.0.0.1:0").await {
                         Ok(sock) => {
+                            debug!("UDP port bound");
                             connection = Some(sock);
                         }
                         Err(err) => {
@@ -171,28 +179,12 @@ impl Udp {
                         }
                     }
                 }
-                _ = self.rate_limiter.until_n_ready(total_bytes), if connection.is_some() => {
-                    let client = connection.unwrap();
-                    match client.send_to(&blk.bytes, self.addr).await {
-                        Ok(_) => {
-                            counter!(
-                                "bytes_written",
-                                blk.bytes.len() as u64,
-                                &labels
-                            );
-                            connection = Some(client);
-                        }
-                        Err(err) => {
-                            debug!("write failed: {}", err);
-
-                            let mut error_labels = labels.clone();
-                            error_labels.push(("error".to_string(), err.to_string()));
-                            counter!("request_failure", 1, &error_labels);
-                            connection = None;
-                        }
-                    }
-                }
             }
-        }
+        });
+
+        self.shutdown.recv().await;
+        info!("shutdown signal received");
+        send_task.abort();
+        Ok(())
     }
 }


### PR DESCRIPTION
### What does this PR do?

We've observed an issue where the UDP generator will run forever, ignoring the shutdown signal. This PR biases the UDP generation task towards polling the shutdown signal to avoid this.

### Motivation

Stop `lading` processes from spinning on UDP forever.

### Related issues

N/A

### Additional Notes

We may consider refactoring shutdown to abort async tasks rather than signal and expect cooperation.