### PR TITLE
HTTP blackhole: Support arbitrary response headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- HTTP blackhole can be configured with arbitrary response body, headers and
+status code
 
 ## [0.10.3] - 2022-11-02
 ### Fixed


### PR DESCRIPTION
### What does this PR do?

Adds support for arbitrary response headers to the HTTP blackhole.

### Motivation

Filling in a functionality gap that we're likely to need before too long. Convenient airplane work.

### Related issues

#378 

### Additional Notes

N/A