### PR TITLE
Pretty bad hierarchical process observer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - HTTP blackhole can be configured with arbitrary response body, headers and
 status code
 - gRPC HTTP2 client concurrency can now be configured
+- Observer now measures child processes of the target
 
 ## [0.10.3] - 2022-11-02
 ### Fixed

--- a/src/observer.rs
+++ b/src/observer.rs
@@ -66,6 +66,7 @@ impl Server {
         Ok(Self { config, shutdown })
     }
 
+    #[cfg(target_os = "linux")]
     fn get_tree(process: Process) -> Result<Vec<Process>, Error> {
         let tree = process
             .tasks() // threads of `process` / item is result-wrapped
@@ -82,6 +83,7 @@ impl Server {
         Ok(tree)
     }
 
+    #[cfg(target_os = "linux")]
     fn get_proc_stats(process: &Process) -> Result<Vec<procfs::process::Stat>, Error> {
         let target_process = Process::new(process.pid()).map_err(Error::ProcError)?;
         let target_and_children = Self::get_tree(target_process)?;
@@ -215,6 +217,7 @@ mod tests {
     use std::{process::Command, time::Duration};
 
     #[test]
+    #[cfg(target_os = "linux")]
     fn observer_observes_process_hierarchy() {
         let mut test_proc = Command::new("/bin/sh")
             .args(["-c", "sleep 1"])

--- a/src/observer.rs
+++ b/src/observer.rs
@@ -218,12 +218,12 @@ impl Server {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-    use std::{process::Command, time::Duration};
-
     #[test]
     #[cfg(target_os = "linux")]
     fn observer_observes_process_hierarchy() {
+        use super::*;
+        use std::{process::Command, time::Duration};
+
         let mut test_proc = Command::new("/bin/sh")
             .args(["-c", "sleep 1"])
             .spawn()


### PR DESCRIPTION
### What does this PR do?

This is the bare minimum observer for a hierarchy of processes. This will be inaccurate if processes start and stop frequently. It will also panic. I'll resolve the latter issue before marking this PR ready.

### Motivation

We would like to be able to measure static trees of processes. The official Agent containers run an `s6-init` process and one or more `agent` processes. Assumption: these are mostly long-lived.

### Related issues

SMP-237

### Additional Notes

N/A
