### PR TITLE
Configurable gRPC concurrency limit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - HTTP blackhole can be configured with arbitrary response body, headers and
 status code
+- gRPC HTTP2 client concurrency can now be configured
 
 ## [0.10.3] - 2022-11-02
 ### Fixed


### PR DESCRIPTION
### What does this PR do?

Offer configurable concurrency limit in gRPC generator.

### Motivation

Fill in a notably missing config knob.

### Related issues

N/A

### Additional Notes

N/A
