### PR TITLE
Add S3 release flow & prepare 0.10.4 release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -96,3 +96,16 @@ jobs:
           target: ${{ matrix.target }}
           checksum: sha256
           token: ${{ secrets.GITHUB_TOKEN }}
+
+      # Auth for the S3 upload
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v1-node16
+        with:
+          aws-access-key-id: ${{ secrets.LADING_RELEASE_BOT_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.LADING_RELEASE_BOT_SECRET_ACCESS_KEY }}
+          aws-region: us-west-2
+
+      # Copy from cargo target directory to S3 release bucket
+      - name: Upload binary to S3
+        run: |
+          aws s3 cp target/${{ matrix.target }}/release/lading s3://lading-releases/${{  github.ref_name }}/${{ matrix.target }}/lading

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.10.4] - 2022-11-16
+## [0.10.4-rc] - 2022-11-16
 ### Added
 - HTTP blackhole can be configured with arbitrary response body, headers and
 status code

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [0.10.4] - 2022-11-16
 ### Added
 - HTTP blackhole can be configured with arbitrary response body, headers and
 status code

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.10.4-rc] - 2022-11-16
+## [0.10.4] - 2022-11-16
 ### Added
 - HTTP blackhole can be configured with arbitrary response body, headers and
 status code

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -870,7 +870,7 @@ dependencies = [
 
 [[package]]
 name = "lading"
-version = "0.10.3"
+version = "0.10.4"
 dependencies = [
  "arbitrary",
  "async-pidfd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 
 [package]
 name = "lading"
-version = "0.10.3"
+version = "0.10.4"
 authors = ["Brian L. Troutwine <brian@troutwine.us>"]
 edition = "2021"
 license = "MIT"


### PR DESCRIPTION
### What does this PR do?

Add an S3 release flow for `lading`.

I'll make a release candidate release from this branch before merging.

### Motivation

This is somewhat preferable for some internal use cases.

### Related issues

SMP-230

### Additional Notes

N/A