### PR TITLE
Release musl builds + prepare 0.11.1 release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,6 +28,7 @@ jobs:
           # env.
           - target: aarch64-unknown-linux-gnu
             os: ubuntu-latest
+            features: kafka
             cc: 'aarch64-linux-gnu-gcc'
             cxx: 'aarch64-linux-gnu-g++'
 
@@ -35,6 +36,7 @@ jobs:
           # needs explicit cross env vars.
           - target: aarch64-apple-darwin
             os: macos-latest
+            features: kafka
             cflags: '-target arm64-apple-macos'
             cxxflags: '-target arm64-apple-macos'
             cc: 'clang'
@@ -43,16 +45,20 @@ jobs:
           # Normal x86-64 Linux build
           - target: x86_64-unknown-linux-gnu
             os: ubuntu-latest
+            features: kafka
 
           # Musl x86-64 Linux build. Assume librdkafka needs cc/cxx.
           - target: x86_64-unknown-linux-musl
             os: ubuntu-latest
+            # the musl build does not support kafka
+            features: ''
             cc: 'musl-gcc'
             cxx: 'explicitly-unset'
 
           # Normal Intel Mac build
           - target: x86_64-apple-darwin
             os: macos-latest
+            features: kafka
 
       # Try to complete every job in the matrix, even if one fails.
       fail-fast: false
@@ -94,6 +100,8 @@ jobs:
 
         with:
           bin: lading
+          no_default_features: true
+          features: ${{ matrix.features || '' }}
           target: ${{ matrix.target }}
           checksum: sha256
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -82,16 +82,6 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y musl-tools
         if: matrix.target == 'x86_64-unknown-linux-musl'
 
-      # Install the protobuf compiler for linux builds
-      - name: Install protobuf (Apt)
-        run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
-        if: matrix.os == 'ubuntu-latest'
-
-      # Install the protobuf compiler for mac builds
-      - name: Install protobuf (Brew)
-        run: brew install protobuf
-        if: matrix.os == 'macos-latest'
-
       # Run the build & upload artifacts
       - name: Build and upload lading binaries
         uses: taiki-e/upload-rust-binary-action@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,6 +44,12 @@ jobs:
           - target: x86_64-unknown-linux-gnu
             os: ubuntu-latest
 
+          # Musl x86-64 Linux build. Assume librdkafka needs cc/cxx.
+          - target: x86_64-unknown-linux-musl
+            os: ubuntu-latest
+            cc: 'musl-gcc'
+            cxx: 'explicitly-unset'
+
           # Normal Intel Mac build
           - target: x86_64-apple-darwin
             os: macos-latest
@@ -70,6 +76,11 @@ jobs:
         with:
           target: ${{ matrix.target }}
         if: matrix.target == 'aarch64-unknown-linux-gnu'
+
+      # Install musl tools for musl builds
+      - name: Install musl tools
+        run: sudo apt-get update && sudo apt-get install -y musl-tools
+        if: matrix.target == 'x86_64-unknown-linux-musl'
 
       # Install the protobuf compiler for linux builds
       - name: Install protobuf (Apt)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.11.1-rc2] - 2022-11-22
+## [0.11.1-rc3] - 2022-11-22
 ### Added
 - Releases now include x86-64 musl binaries
+- The musl build does not support kafka
 
 ### Changed
 - The Protobuf compiler is no longer required to build lading

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.11.1-rc1] - 2022-11-22
+## [0.11.1-rc2] - 2022-11-22
 ### Added
 - Releases now include x86-64 musl binaries
+
+### Changed
+- The Protobuf compiler is no longer required to build lading
 
 ## [0.11.0] - 2022-11-16
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.11.1-rc3] - 2022-11-22
+## [0.11.1] - 2022-11-22
 ### Added
 - Releases now include x86-64 musl binaries
 - The musl build does not support kafka

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.11.1-rc1] - 2022-11-22
+### Added
+- Releases now include x86-64 musl binaries
+
 ## [0.11.0] - 2022-11-16
 ### Added
 - Observer now measures child processes of the target

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -870,7 +870,7 @@ dependencies = [
 
 [[package]]
 name = "lading"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "arbitrary",
  "async-pidfd",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1189,8 +1189,7 @@ checksum = "86f0b0d4bf799edbc74508c1e8bf170ff5f41238e5f8225603ca7caaae2b7860"
 [[package]]
 name = "opentelemetry"
 version = "0.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69d6c3d7288a106c0a363e4b0e8d308058d56902adefb16f4936f417ffef086e"
+source = "git+https://github.com/open-telemetry/opentelemetry-rust/?rev=6078e32#6078e32ab4d19d5978e97025fdd2e7c75264d36d"
 dependencies = [
  "opentelemetry_api",
  "opentelemetry_sdk",
@@ -1199,22 +1198,19 @@ dependencies = [
 [[package]]
 name = "opentelemetry-proto"
 version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d61a2f56df5574508dd86aaca016c917489e589ece4141df1b5e349af8d66c28"
+source = "git+https://github.com/open-telemetry/opentelemetry-rust/?rev=6078e32#6078e32ab4d19d5978e97025fdd2e7c75264d36d"
 dependencies = [
  "futures",
  "futures-util",
  "opentelemetry",
  "prost",
  "tonic",
- "tonic-build",
 ]
 
 [[package]]
 name = "opentelemetry_api"
 version = "0.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c24f96e21e7acc813c7a8394ee94978929db2bcc46cf6b5014fc612bf7760c22"
+source = "git+https://github.com/open-telemetry/opentelemetry-rust/?rev=6078e32#6078e32ab4d19d5978e97025fdd2e7c75264d36d"
 dependencies = [
  "fnv",
  "futures-channel",
@@ -1229,8 +1225,7 @@ dependencies = [
 [[package]]
 name = "opentelemetry_sdk"
 version = "0.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ca41c4933371b61c2a2f214bf16931499af4ec90543604ec828f7a625c09113"
+source = "git+https://github.com/open-telemetry/opentelemetry-rust/?rev=6078e32#6078e32ab4d19d5978e97025fdd2e7c75264d36d"
 dependencies = [
  "async-trait",
  "crossbeam-channel",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ metrics-exporter-prometheus = { version = "0.11.0", default-features = false, fe
 metrics-util = { version = "0.14" }
 nix = { version = "0.25" }
 once_cell = "1.16"
-opentelemetry-proto = { version = "0.1", features = ["traces", "metrics", "logs", "gen-tonic"] }
+opentelemetry-proto = { git = "https://github.com/open-telemetry/opentelemetry-rust/", rev = "6078e32", features = ["traces", "metrics", "logs", "gen-tonic"] }
 prost = "0.11"
 rand = { version = "0.8", default-features = false, features = ["small_rng", "std", "std_rng"] }
 rdkafka = "0.28"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ once_cell = "1.16"
 opentelemetry-proto = { git = "https://github.com/open-telemetry/opentelemetry-rust/", rev = "6078e32", features = ["traces", "metrics", "logs", "gen-tonic"] }
 prost = "0.11"
 rand = { version = "0.8", default-features = false, features = ["small_rng", "std", "std_rng"] }
-rdkafka = "0.28"
+rdkafka = { version = "0.28", optional = true }
 rmp-serde = { version = "1.1", default-features = false }
 serde = { version = "1.0", features = ["std", "derive"] }
 serde_json = { version = "1.0", features = ["std"] }
@@ -60,6 +60,10 @@ async-pidfd = "0.1"
 [dev-dependencies]
 proptest = "1.0"
 proptest-derive = "0.3.0"
+
+[features]
+default = ["kafka"]
+kafka = ["rdkafka"]
 
 [[bin]]
 name = "lading"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 
 [package]
 name = "lading"
-version = "0.11.0"
+version = "0.11.1"
 authors = ["Brian L. Troutwine <brian@troutwine.us>"]
 edition = "2021"
 license = "MIT"

--- a/src/generator.rs
+++ b/src/generator.rs
@@ -20,10 +20,12 @@ pub mod file_gen;
 pub mod file_tree;
 pub mod grpc;
 pub mod http;
-pub mod kafka;
 pub mod splunk_hec;
 pub mod tcp;
 pub mod udp;
+
+#[cfg(feature = "kafka")]
+pub mod kafka;
 
 #[derive(Debug)]
 /// Errors produced by [`Server`].
@@ -37,6 +39,7 @@ pub enum Error {
     /// See [`crate::generator::splunk_hec::Error`] for details.
     SplunkHec(splunk_hec::Error),
     /// See [`crate::generator::kafka::Error`] for details.
+    #[cfg(feature = "kafka")]
     Kafka(kafka::Error),
     /// See [`crate::generator::file_gen::Error`] for details.
     FileGen(file_gen::Error),
@@ -59,6 +62,7 @@ pub enum Config {
     /// See [`crate::generator::splunk_hec::Config`] for details.
     SplunkHec(splunk_hec::Config),
     /// See [`crate::generator::kafka::Config`] for details.
+    #[cfg(feature = "kafka")]
     Kafka(kafka::Config),
     /// See [`crate::generator::file_gen::Config`] for details.
     FileGen(file_gen::Config),
@@ -83,6 +87,7 @@ pub enum Server {
     /// See [`crate::generator::splunk_hec::SplunkHec`] for details.
     SplunkHec(splunk_hec::SplunkHec),
     /// See [`crate::generator::kafka::Kafka`] for details.
+    #[cfg(feature = "kafka")]
     Kafka(kafka::Kafka),
     /// See [`crate::generator::file_gen::FileGen`] for details.
     FileGen(file_gen::FileGen),
@@ -110,6 +115,7 @@ impl Server {
             Config::SplunkHec(conf) => Self::SplunkHec(
                 splunk_hec::SplunkHec::new(conf, shutdown).map_err(Error::SplunkHec)?,
             ),
+            #[cfg(feature = "kafka")]
             Config::Kafka(conf) => {
                 Self::Kafka(kafka::Kafka::new(conf, shutdown).map_err(Error::Kafka)?)
             }
@@ -147,6 +153,7 @@ impl Server {
             Server::Udp(inner) => inner.spin().await.map_err(Error::Udp),
             Server::Http(inner) => inner.spin().await.map_err(Error::Http),
             Server::SplunkHec(inner) => inner.spin().await.map_err(Error::SplunkHec),
+            #[cfg(feature = "kafka")]
             Server::Kafka(inner) => inner.spin().await.map_err(Error::Kafka),
             Server::FileGen(inner) => inner.spin().await.map_err(Error::FileGen),
             Server::FileTree(inner) => inner.spin().await.map_err(Error::FileTree),


### PR DESCRIPTION
### What does this PR do?

Release 0.11.1 with:

- Add an x86-64 musl build
- Update `opentelemetry-proto` to remove the `protoc` dependency
- Make kafka support optional

### Motivation

We would like a musl build for compatibility with non-glibc environments.

### Related issues

SMP-242

### Additional Notes

[RC release](https://github.com/DataDog/lading/releases/tag/v0.11.1-rc3) ([log](https://github.com/DataDog/lading/actions/runs/3526983488))