### PR TITLE
Use Ubuntu 20.04 for glibc based builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,7 @@ jobs:
           # Linux Aarch64 cross build. librdkafka needs explicit cc/cxx in the
           # env.
           - target: aarch64-unknown-linux-gnu
-            os: ubuntu-latest
+            os: ubuntu-20.04
             features: kafka
             cc: 'aarch64-linux-gnu-gcc'
             cxx: 'aarch64-linux-gnu-g++'
@@ -44,7 +44,7 @@ jobs:
 
           # Normal x86-64 Linux build
           - target: x86_64-unknown-linux-gnu
-            os: ubuntu-latest
+            os: ubuntu-20.04
             features: kafka
 
           # Musl x86-64 Linux build. Assume librdkafka needs cc/cxx.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- glibc based releases are now built on ubuntu-20.04 rather than ubuntu-latest
 
 ## [0.11.1] - 2022-11-22
 ### Added


### PR DESCRIPTION
### What does this PR do?

Build release binaries with Ubuntu 20.04. We don't want any surprises with Github Actions rolling out the next LTS sometime soon.

### Motivation

Stability

### Related issues

N/A

### Additional Notes

N/A