### PR TITLE
Optionally pass lading's environment to targets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Targets can inherit lading's environment variables using the
+`--target-inherit-environment` flag
+
 ### Changed
 - glibc based releases are now built on ubuntu-20.04 rather than ubuntu-latest
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -871,7 +871,7 @@ dependencies = [
 
 [[package]]
 name = "lading"
-version = "0.11.1"
+version = "0.11.2"
 dependencies = [
  "arbitrary",
  "async-pidfd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 
 [package]
 name = "lading"
-version = "0.11.1"
+version = "0.11.2"
 authors = ["Brian L. Troutwine <brian@troutwine.us>"]
 edition = "2021"
 license = "MIT"

--- a/src/bin/lading.rs
+++ b/src/bin/lading.rs
@@ -86,6 +86,9 @@ struct Opts {
     /// the path of the target executable
     #[clap(long, group = "binary-target")]
     target_path: Option<PathBuf>,
+    /// inherit the target environment variables from lading's environment
+    #[clap(long, requires = "binary-target", action)]
+    target_inherit_environment: bool,
     /// additional environment variables to apply to the target, format
     /// KEY=VAL,KEY2=VAL
     #[clap(long, requires = "binary-target")]
@@ -142,6 +145,7 @@ fn get_config() -> (Opts, Config) {
         target::Config::Binary(target::BinaryConfig {
             command: path.clone(),
             arguments: ops.target_arguments.clone(),
+            inherit_environment: ops.target_inherit_environment,
             environment_variables: ops
                 .target_environment_variables
                 .clone()

--- a/src/target.rs
+++ b/src/target.rs
@@ -72,8 +72,11 @@ pub struct BinaryConfig {
     pub command: PathBuf,
     /// Arguments for the target sub-process.
     pub arguments: Vec<String>,
+    /// Inherit the environment variables from lading's environment.
+    pub inherit_environment: bool,
     /// Environment variables to set for the target sub-process. Lading's own
-    /// environment variables are not propagated to the target sub-process.
+    /// environment variables are only propagated to the target sub-process if
+    /// `inherit_environment` is set.
     pub environment_variables: HashMap<String, String>,
     /// Manages stderr, stdout of the target sub-process.
     pub output: Output,
@@ -240,8 +243,11 @@ impl Server {
         target_cmd
             .stdin(Stdio::null())
             .stdout(stdio(&config.output.stdout))
-            .stderr(stdio(&config.output.stderr))
-            .env_clear()
+            .stderr(stdio(&config.output.stderr));
+        if !config.inherit_environment {
+            target_cmd.env_clear();
+        }
+        target_cmd
             .kill_on_drop(true)
             .args(config.arguments)
             .envs(config.environment_variables.iter());


### PR DESCRIPTION
### What does this PR do?

Allow lading to pass its environment variables into the target process.

### Motivation

Some targets expect to use environment variables that are set in the container. This was less of an issue when we were running in bespoke containers.

### Related issues

SMP-242

### Additional Notes

N/A