### PR TITLE
Fix gRPC generator for endpoints that return data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [0.11.3] - 2022-12-12
 ### Fixed
 - gRPC calls that respond with data are now handled correctly. This previously
 emitted an error and dropped the response.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- gRPC calls that respond with data are now handled correctly. This previously
+emitted an error and dropped the response.
 
 ## [0.11.2] - 2022-12-01
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -875,7 +875,7 @@ dependencies = [
 
 [[package]]
 name = "lading"
-version = "0.11.2"
+version = "0.11.3"
 dependencies = [
  "arbitrary",
  "async-pidfd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 
 [package]
 name = "lading"
-version = "0.11.2"
+version = "0.11.3"
 authors = ["Brian L. Troutwine <brian@troutwine.us>"]
 edition = "2021"
 license = "MIT"

--- a/src/generator/grpc.rs
+++ b/src/generator/grpc.rs
@@ -137,7 +137,13 @@ impl Decoder for CountingDecoder {
     type Error = Status;
 
     fn decode(&mut self, buf: &mut DecodeBuf<'_>) -> Result<Option<usize>, Self::Error> {
-        Ok(Some(buf.remaining()))
+        let response_bytes = buf.remaining();
+
+        // Consume the provided response buffer. If this isn't done, tonic will
+        // throw an unexpected EOF error while processing the response.
+        buf.advance(response_bytes);
+
+        Ok(Some(response_bytes))
     }
 }
 


### PR DESCRIPTION
### What does this PR do?

Correctly handle gRPC endpoints that return a non-empty response.

### Motivation

The gRPC generator would previously emit an error and drop the response if a non-empty response were returned.

### Related issues

SMP-298

### Additional Notes

Tonic expects the response decoder to consume the buffer it is provided. It will throw a fairly inscrutible error if this isn't upheld. This isn't normally a problem because most decoders are codegenned.
