### PR TITLE
Instrument `bytes_per_seconds`

### DIFF
--- a/src/generator/file_gen.rs
+++ b/src/generator/file_gen.rs
@@ -146,8 +146,18 @@ impl FileGen {
             .iter()
             .map(|sz| NonZeroUsize::new(sz.get_bytes() as usize).expect("bytes must be non-zero"))
             .collect();
+        let labels = vec![
+            ("component".to_string(), "generator".to_string()),
+            ("component_name".to_string(), "file_gen".to_string()),
+        ];
 
         let bytes_per_second = NonZeroU32::new(config.bytes_per_second.get_bytes() as u32).unwrap();
+        gauge!(
+            "bytes_per_second",
+            f64::from(bytes_per_second.get()),
+            &labels
+        );
+
         let maximum_bytes_per_file =
             NonZeroU32::new(config.maximum_bytes_per_file.get_bytes() as u32).unwrap();
         let maximum_prebuild_cache_size_bytes =
@@ -160,7 +170,6 @@ impl FileGen {
             &block_sizes,
         )?;
 
-        let labels = vec![];
         let mut handles = Vec::new();
         let file_index = Arc::new(AtomicU32::new(0));
         for _ in 0..config.duplicates {

--- a/src/generator/grpc.rs
+++ b/src/generator/grpc.rs
@@ -202,7 +202,7 @@ impl Grpc {
 
         let bytes_per_second = NonZeroU32::new(config.bytes_per_second.get_bytes() as u32).unwrap();
         gauge!(
-            "Bytes_per_second",
+            "bytes_per_second",
             f64::from(bytes_per_second.get()),
             &labels
         );

--- a/src/generator/kafka.rs
+++ b/src/generator/kafka.rs
@@ -172,7 +172,7 @@ impl Kafka {
                 gauge!("bytes_per_second", amount.get_bytes() as f64, &labels);
             }
             Throughput::Unlimited => {
-                // The rate limiter we takes a NonZeroU32. Our 'unlimited'
+                // The rate limiter we use takes a NonZeroU32. Our 'unlimited'
                 // throughput has a high-ish but decidedly not unlimited maximim
                 // throughput.
                 gauge!("bytes_per_second", f64::from(u32::MAX), &labels);

--- a/src/generator/splunk_hec.rs
+++ b/src/generator/splunk_hec.rs
@@ -154,9 +154,19 @@ impl SplunkHec {
             .iter()
             .map(|sz| NonZeroUsize::new(sz.get_bytes() as usize).expect("bytes must be non-zero"))
             .collect();
+        let labels = vec![
+            ("component".to_string(), "generator".to_string()),
+            ("component_name".to_string(), "splunk_hec".to_string()),
+        ];
+
         let bytes_per_second = NonZeroU32::new(config.bytes_per_second.get_bytes() as u32).unwrap();
+        gauge!(
+            "bytes_per_second",
+            f64::from(bytes_per_second.get()),
+            &labels
+        );
+
         let rate_limiter = RateLimiter::direct(Quota::per_second(bytes_per_second));
-        let labels = vec![];
         let uri = get_uri_by_format(&config.target_uri, config.format);
 
         let block_chunks = chunk_bytes(

--- a/src/generator/tcp.rs
+++ b/src/generator/tcp.rs
@@ -11,7 +11,7 @@ use governor::{
     state::direct::{self, InsufficientCapacity},
     Quota, RateLimiter,
 };
-use metrics::counter;
+use metrics::{counter, gauge};
 use rand::{rngs::StdRng, SeedableRng};
 use serde::Deserialize;
 use tokio::{io::AsyncWriteExt, net::TcpStream};
@@ -106,9 +106,19 @@ impl Tcp {
             .iter()
             .map(|sz| NonZeroUsize::new(sz.get_bytes() as usize).expect("bytes must be non-zero"))
             .collect();
+        let labels = vec![
+            ("component".to_string(), "generator".to_string()),
+            ("component_name".to_string(), "tcp".to_string()),
+        ];
+
         let bytes_per_second = NonZeroU32::new(config.bytes_per_second.get_bytes() as u32).unwrap();
+        gauge!(
+            "bytes_per_second",
+            f64::from(bytes_per_second.get()),
+            &labels
+        );
+
         let rate_limiter = RateLimiter::direct(Quota::per_second(bytes_per_second));
-        let labels = vec![];
         let block_chunks = chunk_bytes(
             &mut rng,
             NonZeroUsize::new(config.maximum_prebuild_cache_size_bytes.get_bytes() as usize)


### PR DESCRIPTION
### What does this PR do?

This PR instruments the bytes per seconds of each generator, save `file_tree`.

### Motivation

We would like to write out the maximum throughput that can be expected for a given
generator, where appropriate, into capture files to aid later analysis. Only
`file_tree` generator is not included here as its throughput concept is
completely alien to the network oriented generators.

Signed-off-by: Brian L. Troutwine <brian.troutwine@datadoghq.com>