### PR TITLE
Write `bytes_received` from UDP blackhole

### DIFF
--- a/src/blackhole/udp.rs
+++ b/src/blackhole/udp.rs
@@ -61,8 +61,9 @@ impl Udp {
         loop {
             tokio::select! {
                 packet = socket.recv_from(&mut buf) => {
+                    let (bytes, _) = packet.map_err(Error::Io)?;
                     counter!("packet_received", 1);
-                    packet.map_err(Error::Io)?;
+                    counter!("bytes_received", bytes as u64);
                 }
                 _ = self.shutdown.recv() => {
                     info!("shutdown signal received");


### PR DESCRIPTION
### What does this PR do?

While working on #428 I realized that the UDP blackhole does not write out `bytes_received`. All the other blackholes do write out this metric and it's an oversight that UDP does not.

Signed-off-by: Brian L. Troutwine <brian.troutwine@datadoghq.com>
