### PR TITLE
Introduce DogStatsD payload generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.12.0-rc3]
+## Changed
+- **Breaking change:** Added support for DogStatsD payload.
+
 ## [0.12.0]
 ## Changed
 - **Breaking change:** Support for Kafka generator is removed.

--- a/src/block.rs
+++ b/src/block.rs
@@ -131,6 +131,12 @@ where
             block_chunks,
             labels,
         ),
+        payload::Config::DogStatsD => construct_block_cache_inner(
+            &mut rng,
+            &payload::DogStatsD::default(),
+            block_chunks,
+            labels,
+        ),
         payload::Config::Fluent => {
             construct_block_cache_inner(&mut rng, &payload::Fluent::default(), block_chunks, labels)
         }

--- a/src/payload.rs
+++ b/src/payload.rs
@@ -118,6 +118,7 @@ pub enum Config {
     /// Generates OpenTelemetry metrics
     OpentelemetryMetrics,
     /// Generates DogStatsD
+    #[serde(rename = "dogstatsd")]
     DogStatsD,
 }
 

--- a/src/payload.rs
+++ b/src/payload.rs
@@ -9,6 +9,7 @@ use serde::Deserialize;
 pub(crate) use apache_common::ApacheCommon;
 pub(crate) use ascii::Ascii;
 pub(crate) use datadog_logs::DatadogLog;
+pub(crate) use dogstatsd::DogStatsD;
 pub(crate) use fluent::Fluent;
 pub(crate) use foundationdb::FoundationDb;
 pub(crate) use json::Json;
@@ -23,6 +24,7 @@ mod apache_common;
 mod ascii;
 mod common;
 mod datadog_logs;
+mod dogstatsd;
 mod fluent;
 mod foundationdb;
 mod json;
@@ -115,6 +117,8 @@ pub enum Config {
     OpentelemetryLogs,
     /// Generates OpenTelemetry metrics
     OpentelemetryMetrics,
+    /// Generates DogStatsD
+    DogStatsD,
 }
 
 #[derive(Debug)]
@@ -136,6 +140,7 @@ pub(crate) enum Payload {
     OtelTraces(OpentelemetryTraces),
     OtelLogs(OpentelemetryLogs),
     OtelMetrics(OpentelemetryMetrics),
+    DogStatsdD(DogStatsD),
 }
 
 impl Payload {}
@@ -159,6 +164,7 @@ impl Serialize for Payload {
             Payload::OtelTraces(ser) => ser.to_bytes(rng, max_bytes, writer),
             Payload::OtelLogs(ser) => ser.to_bytes(rng, max_bytes, writer),
             Payload::OtelMetrics(ser) => ser.to_bytes(rng, max_bytes, writer),
+            Payload::DogStatsdD(ser) => ser.to_bytes(rng, max_bytes, writer),
         }
     }
 }

--- a/src/payload/datadog_logs.rs
+++ b/src/payload/datadog_logs.rs
@@ -1,11 +1,11 @@
 use std::io::Write;
 
-use arbitrary::{size_hint, Unstructured};
+use arbitrary::{size_hint, Arbitrary, Unstructured};
 use rand::Rng;
 
 use crate::payload::{common::AsciiStr, Error, Serialize};
 
-#[derive(Debug, serde::Serialize, serde::Deserialize)]
+#[derive(Debug, serde::Serialize, serde::Deserialize, Arbitrary)]
 #[serde(rename_all = "lowercase")]
 enum Status {
     Notice,
@@ -13,20 +13,7 @@ enum Status {
     Warning,
 }
 
-impl<'a> arbitrary::Arbitrary<'a> for Status {
-    fn arbitrary(u: &mut Unstructured<'a>) -> arbitrary::Result<Self> {
-        let choice = u.arbitrary::<u8>()?;
-        let res = match choice % 3 {
-            0 => Status::Notice,
-            1 => Status::Info,
-            2 => Status::Warning,
-            _ => unreachable!(),
-        };
-        Ok(res)
-    }
-}
-
-#[derive(Debug, serde::Serialize, serde::Deserialize)]
+#[derive(Debug, serde::Serialize, serde::Deserialize, Arbitrary)]
 #[serde(rename_all = "lowercase")]
 enum Hostname {
     Alpha,
@@ -35,21 +22,7 @@ enum Hostname {
     Localhost,
 }
 
-impl<'a> arbitrary::Arbitrary<'a> for Hostname {
-    fn arbitrary(u: &mut Unstructured<'a>) -> arbitrary::Result<Self> {
-        let choice = u.arbitrary::<u8>()?;
-        let res = match choice % 4 {
-            0 => Hostname::Alpha,
-            1 => Hostname::Beta,
-            2 => Hostname::Gamma,
-            3 => Hostname::Localhost,
-            _ => unreachable!(),
-        };
-        Ok(res)
-    }
-}
-
-#[derive(Debug, serde::Serialize, serde::Deserialize)]
+#[derive(Debug, serde::Serialize, serde::Deserialize, Arbitrary)]
 #[serde(rename_all = "lowercase")]
 enum Service {
     Vector,
@@ -57,20 +30,7 @@ enum Service {
     Cernan,
 }
 
-impl<'a> arbitrary::Arbitrary<'a> for Service {
-    fn arbitrary(u: &mut Unstructured<'a>) -> arbitrary::Result<Self> {
-        let choice = u.arbitrary::<u8>()?;
-        let res = match choice % 3 {
-            0 => Service::Vector,
-            1 => Service::Lading,
-            2 => Service::Cernan,
-            _ => unreachable!(),
-        };
-        Ok(res)
-    }
-}
-
-#[derive(Debug, serde::Serialize, serde::Deserialize)]
+#[derive(Debug, serde::Serialize, serde::Deserialize, Arbitrary)]
 #[serde(rename_all = "lowercase")]
 enum Source {
     Bergman,
@@ -79,22 +39,6 @@ enum Source {
     Lynch,
     Waters,
     Tarkovsky,
-}
-
-impl<'a> arbitrary::Arbitrary<'a> for Source {
-    fn arbitrary(u: &mut Unstructured<'a>) -> arbitrary::Result<Self> {
-        let choice = u.arbitrary::<u8>()?;
-        let res = match choice % 6 {
-            0 => Source::Bergman,
-            1 => Source::Keaton,
-            2 => Source::Kurosawa,
-            3 => Source::Lynch,
-            4 => Source::Waters,
-            5 => Source::Tarkovsky,
-            _ => unreachable!(),
-        };
-        Ok(res)
-    }
 }
 
 const TAG_OPTIONS: [&str; 4] = ["", "env:prod", "env:dev", "env:prod,version:1.1"];

--- a/src/payload/dogstatsd.rs
+++ b/src/payload/dogstatsd.rs
@@ -1,0 +1,61 @@
+use std::{io::Write, time::SystemTime};
+
+use arbitrary::{size_hint, Unstructured};
+use rand::Rng;
+use time::{format_description::well_known::Rfc3339, OffsetDateTime};
+
+use crate::payload::{Error, Serialize};
+
+mod common;
+mod event;
+mod metric;
+mod service_check;
+
+// https://docs.datadoghq.com/developers/dogstatsd/datagram_shell/
+enum Member {
+    Metric(metric::Metric),
+    Event(event::Event),
+    // ServiceCheck(ServiceCheck),
+}
+
+#[derive(Debug, Default, Clone, Copy)]
+#[allow(clippy::module_name_repetitions)]
+#[cfg_attr(test, derive(proptest_derive::Arbitrary))]
+pub(crate) struct DogStatsD {}
+
+impl Serialize for DogStatsD {
+    fn to_bytes<W, R>(&self, mut rng: R, max_bytes: usize, writer: &mut W) -> Result<(), Error>
+    where
+        R: Rng + Sized,
+        W: Write,
+    {
+        unimplemented!()
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use proptest::prelude::*;
+    use rand::{rngs::SmallRng, SeedableRng};
+
+    use crate::payload::{DogStatsD, Serialize};
+
+    // We want to be sure that the serialized size of the payload does not
+    // exceed `max_bytes`.
+    proptest! {
+        #[test]
+        fn payload_not_exceed_max_bytes(seed: u64, max_bytes: u16) {
+            let max_bytes = max_bytes as usize;
+            let rng = SmallRng::seed_from_u64(seed);
+            let dogstatsd = DogStatsD::default();
+
+            let mut bytes = Vec::with_capacity(max_bytes);
+            syslog.to_bytes(rng, max_bytes, &mut bytes).unwrap();
+            debug_assert!(
+                bytes.len() <= max_bytes,
+                "{:?}",
+                std::str::from_utf8(&bytes).unwrap()
+            );
+        }
+    }
+}

--- a/src/payload/dogstatsd/common.rs
+++ b/src/payload/dogstatsd/common.rs
@@ -1,0 +1,154 @@
+use std::{collections::HashMap, mem};
+
+use arbitrary::Unstructured;
+
+const MAX_SMALLVEC: usize = 8;
+const MAX_TAGS: usize = 16;
+const SIZES: [usize; 8] = [1, 2, 4, 8, 16, 32, 64, 128];
+const CHARSET: &[u8] = b"abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ";
+#[allow(clippy::cast_possible_truncation)]
+const CHARSET_LEN: u8 = CHARSET.len() as u8;
+
+#[derive(Hash, PartialEq, Eq)]
+pub(crate) struct MetricTagStr {
+    bytes: Vec<u8>,
+}
+
+impl MetricTagStr {
+    pub(crate) fn len(&self) -> usize {
+        self.bytes.len()
+    }
+
+    pub(crate) fn as_str(&self) -> &str {
+        // Safety: given that CHARSET is where we derive members from
+        // `self.bytes` is always valid UTF-8.
+        unsafe { std::str::from_utf8_unchecked(&self.bytes) }
+    }
+}
+
+impl<'a> arbitrary::Arbitrary<'a> for MetricTagStr {
+    fn arbitrary(u: &mut Unstructured<'a>) -> arbitrary::Result<Self> {
+        let choice: u8 = u.arbitrary()?;
+        let size = SIZES[(choice as usize) % SIZES.len()];
+        let mut bytes: Vec<u8> = vec![0; size];
+        u.fill_buffer(&mut bytes)?;
+        bytes
+            .iter_mut()
+            .for_each(|item| *item = CHARSET[(*item % CHARSET_LEN) as usize]);
+        Ok(Self { bytes })
+    }
+
+    fn size_hint(_depth: usize) -> (usize, Option<usize>) {
+        let empty_sz = mem::size_of::<Self>();
+        let full_bytes_sz = mem::size_of::<u8>() * 128; // max in SIZES
+
+        (empty_sz, Some(empty_sz + full_bytes_sz))
+    }
+}
+
+pub(crate) enum NumValue {
+    Float(f64),
+    Int(i64),
+}
+
+impl<'a> arbitrary::Arbitrary<'a> for NumValue {
+    fn arbitrary(u: &mut Unstructured<'a>) -> arbitrary::Result<Self> {
+        let is_float: bool = u.arbitrary()?;
+        let nv = if is_float {
+            Self::Float(u.arbitrary()?)
+        } else {
+            Self::Int(u.arbitrary()?)
+        };
+
+        Ok(nv)
+    }
+
+    fn size_hint(_depth: usize) -> (usize, Option<usize>) {
+        (1, Some(mem::size_of::<i64>()))
+    }
+}
+
+#[derive(Clone, Copy)]
+pub(crate) enum ZeroToOne {
+    One,
+    Frac(u32),
+}
+
+impl ZeroToOne {
+    pub(crate) fn as_f64(self) -> f64 {
+        match self {
+            Self::One => 1.0,
+            Self::Frac(inner) => {
+                if inner == 0 {
+                    0.0
+                } else {
+                    1.0 / (inner as f64)
+                }
+            }
+        }
+    }
+}
+
+impl<'a> arbitrary::Arbitrary<'a> for ZeroToOne {
+    fn arbitrary(u: &mut Unstructured<'a>) -> arbitrary::Result<Self> {
+        let is_one = u.arbitrary()?;
+        let zto = if is_one {
+            Self::One
+        } else {
+            Self::Frac(u.arbitrary()?)
+        };
+        Ok(zto)
+    }
+
+    fn size_hint(_depth: usize) -> (usize, Option<usize>) {
+        (
+            mem::size_of::<ZeroToOne>(),
+            Some(mem::size_of::<ZeroToOne>()),
+        )
+    }
+}
+
+pub(crate) struct Tags {
+    inner: HashMap<MetricTagStr, MetricTagStr>,
+}
+
+impl<'a> arbitrary::Arbitrary<'a> for Tags {
+    fn arbitrary(u: &mut Unstructured<'a>) -> arbitrary::Result<Self> {
+        let total: usize = u.arbitrary::<usize>()? % MAX_TAGS;
+        let mut inner = HashMap::with_capacity(total);
+        for _ in 0..total {
+            let key = u.arbitrary()?;
+            let val = u.arbitrary()?;
+            inner.insert(key, val);
+        }
+        Ok(Self { inner })
+    }
+
+    fn size_hint(depth: usize) -> (usize, Option<usize>) {
+        let (low, upper) = MetricTagStr::size_hint(depth);
+        (low * MAX_TAGS, upper.map(|u| u * MAX_TAGS))
+    }
+}
+
+pub(crate) struct SmallVec<T> {
+    inner: Vec<T>,
+}
+
+impl<'a, T> arbitrary::Arbitrary<'a> for SmallVec<T>
+where
+    T: arbitrary::Arbitrary<'a>,
+{
+    fn arbitrary(u: &mut Unstructured<'a>) -> arbitrary::Result<Self> {
+        let total: usize = u.arbitrary::<usize>()? % MAX_SMALLVEC;
+        let mut inner = Vec::with_capacity(total);
+        for _ in 0..total {
+            inner.push(u.arbitrary()?);
+        }
+        Ok(Self { inner })
+    }
+
+    fn size_hint(depth: usize) -> (usize, Option<usize>) {
+        let (low, upper) = T::size_hint(depth);
+        (low * MAX_SMALLVEC, upper.map(|u| u * MAX_SMALLVEC))
+    }
+}

--- a/src/payload/dogstatsd/event.rs
+++ b/src/payload/dogstatsd/event.rs
@@ -1,0 +1,106 @@
+use std::mem;
+
+use arbitrary::{size_hint::and_all, Unstructured};
+
+use super::common;
+
+pub(crate) struct Event {
+    title: common::MetricTagStr,
+    text: common::MetricTagStr,
+    title_utf8_length: usize,
+    text_utf8_length: usize,
+    timestamp_second: Option<u32>,
+    hostname: Option<common::MetricTagStr>,
+    aggregation_key: Option<common::MetricTagStr>,
+    priority: Option<Priority>,
+    source_type_name: Option<common::MetricTagStr>,
+    alert_type: Option<Alert>,
+    tags: Option<common::Tags>,
+}
+
+impl<'a> arbitrary::Arbitrary<'a> for Event {
+    fn arbitrary(u: &mut Unstructured<'a>) -> arbitrary::Result<Self> {
+        let title: common::MetricTagStr = u.arbitrary()?;
+        let text: common::MetricTagStr = u.arbitrary()?;
+        Ok(Self {
+            title_utf8_length: title.len(),
+            text_utf8_length: text.len(),
+            title,
+            text,
+            timestamp_second: u.arbitrary()?,
+            hostname: u.arbitrary()?,
+            aggregation_key: u.arbitrary()?,
+            priority: u.arbitrary()?,
+            source_type_name: u.arbitrary()?,
+            alert_type: u.arbitrary()?,
+            tags: u.arbitrary()?,
+        })
+    }
+
+    fn size_hint(depth: usize) -> (usize, Option<usize>) {
+        let title_sz = common::MetricTagStr::size_hint(depth);
+        let text_sz = common::MetricTagStr::size_hint(depth);
+        let title_len_sz = usize::size_hint(depth);
+        let text_len_sz = usize::size_hint(depth);
+        let timestamp_sz = u32::size_hint(depth);
+        let hostname_sz = common::MetricTagStr::size_hint(depth);
+        let aggregation_sz = common::MetricTagStr::size_hint(depth);
+        let priority_sz = Priority::size_hint(depth);
+        let source_type_sz = common::MetricTagStr::size_hint(depth);
+        let alert_sz = Alert::size_hint(depth);
+        let tags = common::Tags::size_hint(depth);
+
+        and_all(&[
+            title_sz,
+            text_sz,
+            title_len_sz,
+            text_len_sz,
+            timestamp_sz,
+            hostname_sz,
+            aggregation_sz,
+            priority_sz,
+            source_type_sz,
+            alert_sz,
+            tags,
+        ])
+    }
+}
+
+enum Priority {
+    Normal,
+    Low,
+}
+
+impl<'a> arbitrary::Arbitrary<'a> for Priority {
+    fn arbitrary(u: &mut Unstructured<'a>) -> arbitrary::Result<Self> {
+        let is_normal = u.arbitrary()?;
+        if is_normal {
+            Ok(Self::Normal)
+        } else {
+            Ok(Self::Low)
+        }
+    }
+
+    fn size_hint(depth: usize) -> (usize, Option<usize>) {
+        (mem::size_of::<Self>(), Some(mem::size_of::<Self>()))
+    }
+}
+
+#[derive(Clone, Copy)]
+enum Alert {
+    Error,
+    Warning,
+    Info,
+    Success,
+}
+
+impl<'a> arbitrary::Arbitrary<'a> for Alert {
+    fn arbitrary(u: &mut Unstructured<'a>) -> arbitrary::Result<Self> {
+        let options = [Alert::Error, Alert::Warning, Alert::Info, Alert::Success];
+        Ok(*u.choose(&options)?)
+    }
+
+    fn size_hint(depth: usize) -> (usize, Option<usize>) {
+        (mem::size_of::<Self>(), Some(mem::size_of::<Self>()))
+    }
+}

--- a/src/payload/dogstatsd/event.rs
+++ b/src/payload/dogstatsd/event.rs
@@ -1,6 +1,6 @@
-use std::{fmt, mem};
+use std::fmt;
 
-use arbitrary::{size_hint::and_all, Unstructured};
+use arbitrary::{size_hint::and_all, Arbitrary, Unstructured};
 
 use super::common;
 
@@ -112,6 +112,7 @@ impl<'a> arbitrary::Arbitrary<'a> for Event {
     }
 }
 
+#[derive(Arbitrary)]
 enum Priority {
     Normal,
     Low,
@@ -126,22 +127,7 @@ impl fmt::Display for Priority {
     }
 }
 
-impl<'a> arbitrary::Arbitrary<'a> for Priority {
-    fn arbitrary(u: &mut Unstructured<'a>) -> arbitrary::Result<Self> {
-        let is_normal = u.arbitrary()?;
-        if is_normal {
-            Ok(Self::Normal)
-        } else {
-            Ok(Self::Low)
-        }
-    }
-
-    fn size_hint(_depth: usize) -> (usize, Option<usize>) {
-        (mem::size_of::<Self>(), Some(mem::size_of::<Self>()))
-    }
-}
-
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Arbitrary)]
 enum Alert {
     Error,
     Warning,
@@ -157,16 +143,5 @@ impl fmt::Display for Alert {
             Self::Info => write!(f, "info"),
             Self::Success => write!(f, "success"),
         }
-    }
-}
-
-impl<'a> arbitrary::Arbitrary<'a> for Alert {
-    fn arbitrary(u: &mut Unstructured<'a>) -> arbitrary::Result<Self> {
-        let options = [Alert::Error, Alert::Warning, Alert::Info, Alert::Success];
-        Ok(*u.choose(&options)?)
-    }
-
-    fn size_hint(_depth: usize) -> (usize, Option<usize>) {
-        (mem::size_of::<Self>(), Some(mem::size_of::<Self>()))
     }
 }

--- a/src/payload/dogstatsd/metric.rs
+++ b/src/payload/dogstatsd/metric.rs
@@ -1,0 +1,206 @@
+use arbitrary::{size_hint::and_all, Unstructured};
+
+use super::common;
+
+const MAX_VALUES: usize = 8;
+
+pub(crate) enum Metric {
+    Count(Count),
+    Gauge(Gauge),
+    Timer(Timer),
+    Histogram(Histogram),
+    Set(Set),
+    Distribution(Distribution),
+}
+
+impl ToString for Metric {
+    fn to_string(&self) -> String {
+        unimplemented!()
+    }
+}
+
+pub(crate) struct Count {
+    name: common::MetricTagStr,
+    value: Vec<common::NumValue>,
+    sample_rate: Option<common::ZeroToOne>,
+    tags: Option<common::Tags>,
+    container_id: Option<common::MetricTagStr>,
+}
+
+impl<'a> arbitrary::Arbitrary<'a> for Count {
+    fn arbitrary(u: &mut Unstructured<'a>) -> arbitrary::Result<Self> {
+        Ok(Self {
+            name: u.arbitrary()?,
+            value: u.arbitrary()?,
+            sample_rate: u.arbitrary()?,
+            tags: u.arbitrary()?,
+            container_id: u.arbitrary()?,
+        })
+    }
+
+    fn size_hint(depth: usize) -> (usize, Option<usize>) {
+        let name_sz = common::MetricTagStr::size_hint(depth);
+        let value_sz = {
+            let (low, upper) = common::NumValue::size_hint(depth);
+            (low * MAX_VALUES, upper.map(|u| u * MAX_VALUES))
+        };
+        let sample_sz = common::ZeroToOne::size_hint(depth);
+        let tags_sz = common::Tags::size_hint(depth);
+        let container_id_sz = common::MetricTagStr::size_hint(depth);
+        and_all(&[name_sz, value_sz, sample_sz, tags_sz, container_id_sz])
+    }
+}
+
+pub(crate) struct Gauge {
+    name: common::MetricTagStr,
+    value: Vec<common::NumValue>,
+    tags: Option<common::Tags>,
+    container_id: Option<common::MetricTagStr>,
+}
+
+impl<'a> arbitrary::Arbitrary<'a> for Gauge {
+    fn arbitrary(u: &mut Unstructured<'a>) -> arbitrary::Result<Self> {
+        Ok(Self {
+            name: u.arbitrary()?,
+            value: u.arbitrary()?,
+            tags: u.arbitrary()?,
+            container_id: u.arbitrary()?,
+        })
+    }
+
+    fn size_hint(depth: usize) -> (usize, Option<usize>) {
+        let name_sz = common::MetricTagStr::size_hint(depth);
+        let value_sz = {
+            let (low, upper) = common::NumValue::size_hint(depth);
+            (low * MAX_VALUES, upper.map(|u| u * MAX_VALUES))
+        };
+        let tags_sz = common::Tags::size_hint(depth);
+        let container_id_sz = common::MetricTagStr::size_hint(depth);
+        and_all(&[name_sz, value_sz, tags_sz, container_id_sz])
+    }
+}
+
+pub(crate) struct Timer {
+    name: common::MetricTagStr,
+    value: Vec<common::NumValue>,
+    sample_rate: Option<common::ZeroToOne>,
+    tags: Option<common::Tags>,
+    container_id: Option<common::MetricTagStr>,
+}
+
+impl<'a> arbitrary::Arbitrary<'a> for Timer {
+    fn arbitrary(u: &mut Unstructured<'a>) -> arbitrary::Result<Self> {
+        Ok(Self {
+            name: u.arbitrary()?,
+            value: u.arbitrary()?,
+            sample_rate: u.arbitrary()?,
+            tags: u.arbitrary()?,
+            container_id: u.arbitrary()?,
+        })
+    }
+
+    fn size_hint(depth: usize) -> (usize, Option<usize>) {
+        let name_sz = common::MetricTagStr::size_hint(depth);
+        let value_sz = {
+            let (low, upper) = common::NumValue::size_hint(depth);
+            (low * MAX_VALUES, upper.map(|u| u * MAX_VALUES))
+        };
+        let sample_sz = common::ZeroToOne::size_hint(depth);
+        let tags_sz = common::Tags::size_hint(depth);
+        let container_id_sz = common::MetricTagStr::size_hint(depth);
+        and_all(&[name_sz, value_sz, sample_sz, tags_sz, container_id_sz])
+    }
+}
+
+pub(crate) struct Distribution {
+    name: common::MetricTagStr,
+    value: Vec<common::NumValue>,
+    sample_rate: Option<common::ZeroToOne>,
+    tags: Option<common::Tags>,
+    container_id: Option<common::MetricTagStr>,
+}
+
+impl<'a> arbitrary::Arbitrary<'a> for Distribution {
+    fn arbitrary(u: &mut Unstructured<'a>) -> arbitrary::Result<Self> {
+        Ok(Self {
+            name: u.arbitrary()?,
+            value: u.arbitrary()?,
+            sample_rate: u.arbitrary()?,
+            tags: u.arbitrary()?,
+            container_id: u.arbitrary()?,
+        })
+    }
+
+    fn size_hint(depth: usize) -> (usize, Option<usize>) {
+        let name_sz = common::MetricTagStr::size_hint(depth);
+        let value_sz = {
+            let (low, upper) = common::NumValue::size_hint(depth);
+            (low * MAX_VALUES, upper.map(|u| u * MAX_VALUES))
+        };
+        let sample_sz = common::ZeroToOne::size_hint(depth);
+        let tags_sz = common::Tags::size_hint(depth);
+        let container_id_sz = common::MetricTagStr::size_hint(depth);
+        and_all(&[name_sz, value_sz, sample_sz, tags_sz, container_id_sz])
+    }
+}
+
+pub(crate) struct Set {
+    name: common::MetricTagStr,
+    value: Vec<common::NumValue>,
+    tags: Option<common::Tags>,
+    container_id: Option<common::MetricTagStr>,
+}
+
+impl<'a> arbitrary::Arbitrary<'a> for Set {
+    fn arbitrary(u: &mut Unstructured<'a>) -> arbitrary::Result<Self> {
+        Ok(Self {
+            name: u.arbitrary()?,
+            value: u.arbitrary()?,
+            tags: u.arbitrary()?,
+            container_id: u.arbitrary()?,
+        })
+    }
+
+    fn size_hint(depth: usize) -> (usize, Option<usize>) {
+        let name_sz = common::MetricTagStr::size_hint(depth);
+        let value_sz = {
+            let (low, upper) = common::NumValue::size_hint(depth);
+            (low * MAX_VALUES, upper.map(|u| u * MAX_VALUES))
+        };
+        let tags_sz = common::Tags::size_hint(depth);
+        let container_id_sz = common::MetricTagStr::size_hint(depth);
+        and_all(&[name_sz, value_sz, tags_sz, container_id_sz])
+    }
+}
+
+pub(crate) struct Histogram {
+    name: common::MetricTagStr,
+    value: Vec<common::NumValue>,
+    sample_rate: Option<common::ZeroToOne>,
+    tags: Option<common::Tags>,
+    container_id: Option<common::MetricTagStr>,
+}
+
+impl<'a> arbitrary::Arbitrary<'a> for Histogram {
+    fn arbitrary(u: &mut Unstructured<'a>) -> arbitrary::Result<Self> {
+        Ok(Self {
+            name: u.arbitrary()?,
+            value: u.arbitrary()?,
+            sample_rate: u.arbitrary()?,
+            tags: u.arbitrary()?,
+            container_id: u.arbitrary()?,
+        })
+    }
+
+    fn size_hint(depth: usize) -> (usize, Option<usize>) {
+        let name_sz = common::MetricTagStr::size_hint(depth);
+        let value_sz = {
+            let (low, upper) = common::NumValue::size_hint(depth);
+            (low * MAX_VALUES, upper.map(|u| u * MAX_VALUES))
+        };
+        let sample_sz = common::ZeroToOne::size_hint(depth);
+        let tags_sz = common::Tags::size_hint(depth);
+        let container_id_sz = common::MetricTagStr::size_hint(depth);
+        and_all(&[name_sz, value_sz, sample_sz, tags_sz, container_id_sz])
+    }
+}

--- a/src/payload/dogstatsd/metric.rs
+++ b/src/payload/dogstatsd/metric.rs
@@ -1,9 +1,12 @@
-use arbitrary::{size_hint::and_all, Unstructured};
+use std::fmt;
 
-use super::common;
+use arbitrary::{size_hint::and_all, Arbitrary, Unstructured};
+
+use super::common::{self, NonEmptyVec};
 
 const MAX_VALUES: usize = 8;
 
+#[derive(Arbitrary)]
 pub(crate) enum Metric {
     Count(Count),
     Gauge(Gauge),
@@ -13,18 +16,63 @@ pub(crate) enum Metric {
     Distribution(Distribution),
 }
 
-impl ToString for Metric {
-    fn to_string(&self) -> String {
-        unimplemented!()
+impl fmt::Display for Metric {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Count(ref count) => write!(f, "{count}"),
+            Self::Gauge(ref gauge) => write!(f, "{gauge}"),
+            Self::Timer(ref timer) => write!(f, "{timer}"),
+            Self::Histogram(ref histogram) => write!(f, "{histogram}"),
+            Self::Set(ref set) => write!(f, "{set}"),
+            Self::Distribution(ref distribution) => write!(f, "{distribution}"),
+        }
     }
 }
 
 pub(crate) struct Count {
     name: common::MetricTagStr,
-    value: Vec<common::NumValue>,
+    value: NonEmptyVec<common::NumValue>,
     sample_rate: Option<common::ZeroToOne>,
     tags: Option<common::Tags>,
     container_id: Option<common::MetricTagStr>,
+}
+
+impl fmt::Display for Count {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        // <METRIC_NAME>:<VALUE>|<TYPE>|#<TAG_KEY_1>:<TAG_VALUE_1>,<TAG_2>|c:<CONTAINER_ID>
+        // <METRIC_NAME>:<VALUE1>:<VALUE2>:<VALUE3>|<TYPE>|@<SAMPLE_RATE>|#<TAG_KEY_1>:<TAG_VALUE_1>,<TAG_2>
+        write!(f, "{name}", name = self.name)?;
+        let mut colons_needed = self.value.inner.len() - 1;
+        for val in &self.value.inner {
+            write!(f, "{val}")?;
+            if colons_needed != 0 {
+                write!(f, ":")?;
+                colons_needed -= 1;
+            }
+        }
+        write!(f, "|c")?;
+        if let Some(ref sample_rate) = self.sample_rate {
+            write!(f, "|@{sample_rate}")?;
+        }
+        if let Some(ref tags) = self.tags {
+            if !tags.inner.is_empty() {
+                write!(f, "|#")?;
+                let mut commas_remaining = tags.inner.len() - 1;
+                for (k, v) in &tags.inner {
+                    write!(f, "{k}:{v}")?;
+                    if commas_remaining != 0 {
+                        write!(f, ",")?;
+                        commas_remaining -= 1;
+                    }
+                }
+            }
+        }
+        if let Some(ref container_id) = self.container_id {
+            write!(f, "|c:{container_id}")?;
+        }
+
+        Ok(())
+    }
 }
 
 impl<'a> arbitrary::Arbitrary<'a> for Count {
@@ -53,9 +101,44 @@ impl<'a> arbitrary::Arbitrary<'a> for Count {
 
 pub(crate) struct Gauge {
     name: common::MetricTagStr,
-    value: Vec<common::NumValue>,
+    value: NonEmptyVec<common::NumValue>,
     tags: Option<common::Tags>,
     container_id: Option<common::MetricTagStr>,
+}
+
+impl fmt::Display for Gauge {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        // <METRIC_NAME>:<VALUE>|<TYPE>|#<TAG_KEY_1>:<TAG_VALUE_1>,<TAG_2>|c:<CONTAINER_ID>
+        // <METRIC_NAME>:<VALUE1>:<VALUE2>:<VALUE3>|<TYPE>|#<TAG_KEY_1>:<TAG_VALUE_1>,<TAG_2>
+        write!(f, "{name}", name = self.name)?;
+        let mut colons_needed = self.value.inner.len() - 1;
+        for val in &self.value.inner {
+            write!(f, "{val}")?;
+            if colons_needed != 0 {
+                write!(f, ":")?;
+                colons_needed -= 1;
+            }
+        }
+        write!(f, "|g")?;
+        if let Some(ref tags) = self.tags {
+            if !tags.inner.is_empty() {
+                write!(f, "|#")?;
+                let mut commas_remaining = tags.inner.len() - 1;
+                for (k, v) in &tags.inner {
+                    write!(f, "{k}:{v}")?;
+                    if commas_remaining != 0 {
+                        write!(f, ",")?;
+                        commas_remaining -= 1;
+                    }
+                }
+            }
+        }
+        if let Some(ref container_id) = self.container_id {
+            write!(f, "|c:{container_id}")?;
+        }
+
+        Ok(())
+    }
 }
 
 impl<'a> arbitrary::Arbitrary<'a> for Gauge {
@@ -82,10 +165,48 @@ impl<'a> arbitrary::Arbitrary<'a> for Gauge {
 
 pub(crate) struct Timer {
     name: common::MetricTagStr,
-    value: Vec<common::NumValue>,
+    value: NonEmptyVec<common::NumValue>,
     sample_rate: Option<common::ZeroToOne>,
     tags: Option<common::Tags>,
     container_id: Option<common::MetricTagStr>,
+}
+
+impl fmt::Display for Timer {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        // <METRIC_NAME>:<VALUE>|<TYPE>|#<TAG_KEY_1>:<TAG_VALUE_1>,<TAG_2>|c:<CONTAINER_ID>
+        // <METRIC_NAME>:<VALUE1>:<VALUE2>:<VALUE3>|<TYPE>|@<SAMPLE_RATE>|#<TAG_KEY_1>:<TAG_VALUE_1>,<TAG_2>
+        write!(f, "{name}", name = self.name)?;
+        let mut colons_needed = self.value.inner.len() - 1;
+        for val in &self.value.inner {
+            write!(f, "{val}")?;
+            if colons_needed != 0 {
+                write!(f, ":")?;
+                colons_needed -= 1;
+            }
+        }
+        write!(f, "|ms")?;
+        if let Some(ref sample_rate) = self.sample_rate {
+            write!(f, "|@{sample_rate}")?;
+        }
+        if let Some(ref tags) = self.tags {
+            if !tags.inner.is_empty() {
+                write!(f, "|#")?;
+                let mut commas_remaining = tags.inner.len() - 1;
+                for (k, v) in &tags.inner {
+                    write!(f, "{k}:{v}")?;
+                    if commas_remaining != 0 {
+                        write!(f, ",")?;
+                        commas_remaining -= 1;
+                    }
+                }
+            }
+        }
+        if let Some(ref container_id) = self.container_id {
+            write!(f, "|c:{container_id}")?;
+        }
+
+        Ok(())
+    }
 }
 
 impl<'a> arbitrary::Arbitrary<'a> for Timer {
@@ -114,10 +235,48 @@ impl<'a> arbitrary::Arbitrary<'a> for Timer {
 
 pub(crate) struct Distribution {
     name: common::MetricTagStr,
-    value: Vec<common::NumValue>,
+    value: NonEmptyVec<common::NumValue>,
     sample_rate: Option<common::ZeroToOne>,
     tags: Option<common::Tags>,
     container_id: Option<common::MetricTagStr>,
+}
+
+impl fmt::Display for Distribution {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        // <METRIC_NAME>:<VALUE>|<TYPE>|#<TAG_KEY_1>:<TAG_VALUE_1>,<TAG_2>|c:<CONTAINER_ID>
+        // <METRIC_NAME>:<VALUE1>:<VALUE2>:<VALUE3>|<TYPE>|@<SAMPLE_RATE>|#<TAG_KEY_1>:<TAG_VALUE_1>,<TAG_2>
+        write!(f, "{name}", name = self.name)?;
+        let mut colons_needed = self.value.inner.len() - 1;
+        for val in &self.value.inner {
+            write!(f, "{val}")?;
+            if colons_needed != 0 {
+                write!(f, ":")?;
+                colons_needed -= 1;
+            }
+        }
+        write!(f, "|d")?;
+        if let Some(ref sample_rate) = self.sample_rate {
+            write!(f, "|@{sample_rate}")?;
+        }
+        if let Some(ref tags) = self.tags {
+            if !tags.inner.is_empty() {
+                write!(f, "|#")?;
+                let mut commas_remaining = tags.inner.len() - 1;
+                for (k, v) in &tags.inner {
+                    write!(f, "{k}:{v}")?;
+                    if commas_remaining != 0 {
+                        write!(f, ",")?;
+                        commas_remaining -= 1;
+                    }
+                }
+            }
+        }
+        if let Some(ref container_id) = self.container_id {
+            write!(f, "|c:{container_id}")?;
+        }
+
+        Ok(())
+    }
 }
 
 impl<'a> arbitrary::Arbitrary<'a> for Distribution {
@@ -146,9 +305,44 @@ impl<'a> arbitrary::Arbitrary<'a> for Distribution {
 
 pub(crate) struct Set {
     name: common::MetricTagStr,
-    value: Vec<common::NumValue>,
+    value: NonEmptyVec<common::NumValue>,
     tags: Option<common::Tags>,
     container_id: Option<common::MetricTagStr>,
+}
+
+impl fmt::Display for Set {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        // <METRIC_NAME>:<VALUE>|<TYPE>|#<TAG_KEY_1>:<TAG_VALUE_1>,<TAG_2>|c:<CONTAINER_ID>
+        // <METRIC_NAME>:<VALUE1>:<VALUE2>:<VALUE3>|<TYPE>|@<SAMPLE_RATE>|#<TAG_KEY_1>:<TAG_VALUE_1>,<TAG_2>
+        write!(f, "{name}", name = self.name)?;
+        let mut colons_needed = self.value.inner.len() - 1;
+        for val in &self.value.inner {
+            write!(f, "{val}")?;
+            if colons_needed != 0 {
+                write!(f, ":")?;
+                colons_needed -= 1;
+            }
+        }
+        write!(f, "|s")?;
+        if let Some(ref tags) = self.tags {
+            if !tags.inner.is_empty() {
+                write!(f, "|#")?;
+                let mut commas_remaining = tags.inner.len() - 1;
+                for (k, v) in &tags.inner {
+                    write!(f, "{k}:{v}")?;
+                    if commas_remaining != 0 {
+                        write!(f, ",")?;
+                        commas_remaining -= 1;
+                    }
+                }
+            }
+        }
+        if let Some(ref container_id) = self.container_id {
+            write!(f, "|c:{container_id}")?;
+        }
+
+        Ok(())
+    }
 }
 
 impl<'a> arbitrary::Arbitrary<'a> for Set {
@@ -175,10 +369,48 @@ impl<'a> arbitrary::Arbitrary<'a> for Set {
 
 pub(crate) struct Histogram {
     name: common::MetricTagStr,
-    value: Vec<common::NumValue>,
+    value: NonEmptyVec<common::NumValue>,
     sample_rate: Option<common::ZeroToOne>,
     tags: Option<common::Tags>,
     container_id: Option<common::MetricTagStr>,
+}
+
+impl fmt::Display for Histogram {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        // <METRIC_NAME>:<VALUE>|<TYPE>|#<TAG_KEY_1>:<TAG_VALUE_1>,<TAG_2>|c:<CONTAINER_ID>
+        // <METRIC_NAME>:<VALUE1>:<VALUE2>:<VALUE3>|<TYPE>|@<SAMPLE_RATE>|#<TAG_KEY_1>:<TAG_VALUE_1>,<TAG_2>
+        write!(f, "{name}", name = self.name)?;
+        let mut colons_needed = self.value.inner.len() - 1;
+        for val in &self.value.inner {
+            write!(f, "{val}")?;
+            if colons_needed != 0 {
+                write!(f, ":")?;
+                colons_needed -= 1;
+            }
+        }
+        write!(f, "|h")?;
+        if let Some(ref sample_rate) = self.sample_rate {
+            write!(f, "|@{sample_rate}")?;
+        }
+        if let Some(ref tags) = self.tags {
+            if !tags.inner.is_empty() {
+                write!(f, "|#")?;
+                let mut commas_remaining = tags.inner.len() - 1;
+                for (k, v) in &tags.inner {
+                    write!(f, "{k}:{v}")?;
+                    if commas_remaining != 0 {
+                        write!(f, ",")?;
+                        commas_remaining -= 1;
+                    }
+                }
+            }
+        }
+        if let Some(ref container_id) = self.container_id {
+            write!(f, "|c:{container_id}")?;
+        }
+
+        Ok(())
+    }
 }
 
 impl<'a> arbitrary::Arbitrary<'a> for Histogram {

--- a/src/payload/dogstatsd/service_check.rs
+++ b/src/payload/dogstatsd/service_check.rs
@@ -1,6 +1,6 @@
-use std::{fmt, mem};
+use std::fmt;
 
-use arbitrary::{size_hint::and_all, Unstructured};
+use arbitrary::{size_hint::and_all, Arbitrary, Unstructured};
 
 use super::common;
 
@@ -79,7 +79,7 @@ impl<'a> arbitrary::Arbitrary<'a> for ServiceCheck {
     }
 }
 
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Arbitrary)]
 enum Status {
     Ok,
     Warning,
@@ -103,21 +103,5 @@ impl fmt::Display for Status {
                 write!(f, "unknown")
             }
         }
-    }
-}
-
-impl<'a> arbitrary::Arbitrary<'a> for Status {
-    fn arbitrary(u: &mut Unstructured<'a>) -> arbitrary::Result<Self> {
-        let options = [
-            Status::Ok,
-            Status::Warning,
-            Status::Critical,
-            Status::Unknown,
-        ];
-        Ok(*u.choose(&options)?)
-    }
-
-    fn size_hint(_depth: usize) -> (usize, Option<usize>) {
-        (mem::size_of::<Self>(), Some(mem::size_of::<Self>()))
     }
 }

--- a/src/payload/dogstatsd/service_check.rs
+++ b/src/payload/dogstatsd/service_check.rs
@@ -1,0 +1,72 @@
+use std::mem;
+
+use arbitrary::{
+    size_hint::{self, and_all},
+    Unstructured,
+};
+
+use super::common;
+
+pub(crate) struct ServiceCheck {
+    name: common::MetricTagStr,
+    status: Status,
+    timestamp_second: Option<u32>,
+    hostname: Option<common::MetricTagStr>,
+    tags: Option<common::Tags>,
+    message: Option<common::MetricTagStr>,
+}
+
+impl<'a> arbitrary::Arbitrary<'a> for ServiceCheck {
+    fn arbitrary(u: &mut Unstructured<'a>) -> arbitrary::Result<Self> {
+        Ok(Self {
+            name: u.arbitrary()?,
+            status: u.arbitrary()?,
+            timestamp_second: u.arbitrary()?,
+            hostname: u.arbitrary()?,
+            tags: u.arbitrary()?,
+            message: u.arbitrary()?,
+        })
+    }
+
+    fn size_hint(depth: usize) -> (usize, Option<usize>) {
+        let name_sz = common::MetricTagStr::size_hint(depth);
+        let status_sz = Status::size_hint(depth);
+        let timestamp_sz = u32::size_hint(depth);
+        let hostname_sz = common::MetricTagStr::size_hint(depth);
+        let tags_sz = common::Tags::size_hint(depth);
+        let message_sz = common::MetricTagStr::size_hint(depth);
+
+        and_all(&[
+            name_sz,
+            status_sz,
+            timestamp_sz,
+            hostname_sz,
+            tags_sz,
+            message_sz,
+        ])
+    }
+}
+
+#[derive(Clone, Copy)]
+enum Status {
+    Ok,
+    Warning,
+    Critical,
+    Unknown,
+}
+
+impl<'a> arbitrary::Arbitrary<'a> for Status {
+    fn arbitrary(u: &mut Unstructured<'a>) -> arbitrary::Result<Self> {
+        let options = [
+            Status::Ok,
+            Status::Warning,
+            Status::Critical,
+            Status::Unknown,
+        ];
+        Ok(*u.choose(&options)?)
+    }
+
+    fn size_hint(depth: usize) -> (usize, Option<usize>) {
+        (mem::size_of::<Self>(), Some(mem::size_of::<Self>()))
+    }
+}


### PR DESCRIPTION
This commit introduces DogStatsD payload generation into lading. We support all the variants described [here](https://docs.datadoghq.com/developers/dogstatsd/datagram_shell/?tab=metrics). 

Signed-off-by: Brian L. Troutwine <brian.troutwine@datadoghq.com>
