### PR TITLE
Fix varint length calculation in OTel payloads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## Fixed
+- Fix OpenTelemetry message length calculation for some messages.
 
 ## [0.12.0]
 ## Changed

--- a/proptest-regressions/payload/opentelemetry_metric.txt
+++ b/proptest-regressions/payload/opentelemetry_metric.txt
@@ -1,0 +1,7 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+cc 39803632d5c6543a1f796ab17d44b86bfadb85fdc0a0d1f851c66c75365959f1 # shrinks to seed = 11374604432742766758, max_bytes = 214

--- a/src/payload.rs
+++ b/src/payload.rs
@@ -167,7 +167,7 @@ impl Serialize for Payload {
 /// positive infinity.
 ///
 /// Adapted from rustc `int_roundings` implementation. Replace upon
-/// stabilization: https://github.com/rust-lang/rust/issues/88581
+/// stabilization: <https://github.com/rust-lang/rust/issues/88581>
 ///
 /// # Panics
 ///

--- a/src/payload.rs
+++ b/src/payload.rs
@@ -163,6 +163,25 @@ impl Serialize for Payload {
     }
 }
 
+/// Calculates the quotient of `lhs` and `rhs`, rounding the result towards
+/// positive infinity.
+///
+/// Adapted from rustc `int_roundings` implementation. Replace upon
+/// stabilization: https://github.com/rust-lang/rust/issues/88581
+///
+/// # Panics
+///
+/// This function will panic if `rhs` is 0 or the division results in overflow.
+const fn div_ceil(lhs: usize, rhs: usize) -> usize {
+    let d = lhs / rhs;
+    let r = lhs % rhs;
+    if r > 0 && rhs > 0 {
+        d + 1
+    } else {
+        d
+    }
+}
+
 #[cfg(test)]
 mod test {
     use proptest::prelude::*;

--- a/src/payload/opentelemetry_log.rs
+++ b/src/payload/opentelemetry_log.rs
@@ -97,10 +97,10 @@ impl Serialize for OpentelemetryLogs {
         rng.fill_bytes(&mut entropy);
         let mut unstructured = Unstructured::new(&entropy);
 
-        // An Export*ServiceRequest message has ~5 bytes of fixed values and
-        // includes a varint-encoded message length. Use the worst case for this
-        // length value.
-        let bytes_remaining = max_bytes.checked_sub(5 + max_bytes / 0x7F);
+        // An Export*ServiceRequest message has 5 bytes of fixed values plus
+        // a varint-encoded message length field. The worst case for the message
+        // length field is the max message size divided by 0x7F.
+        let bytes_remaining = max_bytes.checked_sub(5 + super::div_ceil(max_bytes, 0x7F));
         let mut bytes_remaining = if let Some(val) = bytes_remaining {
             val
         } else {

--- a/src/payload/opentelemetry_metric.rs
+++ b/src/payload/opentelemetry_metric.rs
@@ -186,10 +186,10 @@ impl Serialize for OpentelemetryMetrics {
         rng.fill_bytes(&mut entropy);
         let mut unstructured = Unstructured::new(&entropy);
 
-        // An Export*ServiceRequest message has ~5 bytes of fixed values and
-        // includes a varint-encoded message length. Use the worst case for this
-        // length value.
-        let bytes_remaining = max_bytes.checked_sub(4 + 1 + max_bytes / 0x7F);
+        // An Export*ServiceRequest message has 5 bytes of fixed values plus
+        // a varint-encoded message length field. The worst case for the message
+        // length field is the max message size divided by 0x7F.
+        let bytes_remaining = max_bytes.checked_sub(5 + super::div_ceil(max_bytes, 0x7F));
         let mut bytes_remaining = if let Some(val) = bytes_remaining {
             val
         } else {

--- a/src/payload/opentelemetry_trace.rs
+++ b/src/payload/opentelemetry_trace.rs
@@ -109,10 +109,10 @@ impl Serialize for OpentelemetryTraces {
         rng.fill_bytes(&mut entropy);
         let mut unstructured = Unstructured::new(&entropy);
 
-        // An Export*ServiceRequest message has ~5 bytes of fixed values and
-        // includes a varint-encoded message length. Use the worst case for this
-        // length value.
-        let bytes_remaining = max_bytes.checked_sub(5 + max_bytes / 0x7F);
+        // An Export*ServiceRequest message has 5 bytes of fixed values plus
+        // a varint-encoded message length field. The worst case for the message
+        // length field is the max message size divided by 0x7F.
+        let bytes_remaining = max_bytes.checked_sub(5 + super::div_ceil(max_bytes, 0x7F));
         let mut bytes_remaining = if let Some(val) = bytes_remaining {
             val
         } else {


### PR DESCRIPTION
### What does this PR do?

This fixes a rounding error in the varint length calculation.

### Motivation

Fix this error: https://github.com/DataDog/lading/actions/runs/3878993580/jobs/6615728387

### Related issues

N/A

### Additional Notes

N/A