### PR TITLE
Attempt to recreate UDS stream if not available, rather than crash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Fixed
 - Fix OpenTelemetry message length calculation for some messages.
 
+## [0.12.0-rc4]
+## Fixed
+- Lading's UDS will now re-attempt to connect to a UDS socket, rather than
+  erroring.
+
 ## [0.12.0-rc3]
 ## Changed
 - **Breaking change:** Added support for DogStatsD payload.

--- a/src/generator/udp.rs
+++ b/src/generator/udp.rs
@@ -152,13 +152,14 @@ impl Udp {
             let mut blocks = self.block_cache.iter().cycle();
             let mut connection = Option::<UdpSocket>::None;
             loop {
-                let blk = blocks.next().unwrap();
-                let total_bytes = blk.total_bytes;
-                assert!(
-                    total_bytes.get() <= 65507,
-                    "UDP packet too large (over 65507 B)"
-                );
                 if let Some(sock) = &connection {
+                    let blk = blocks.next().unwrap();
+                    let total_bytes = blk.total_bytes;
+                    assert!(
+                        total_bytes.get() <= 65507,
+                        "UDP packet too large (over 65507 B)"
+                    );
+
                     tokio::task::yield_now().await;
                     self.rate_limiter.until_n_ready(total_bytes).await.unwrap();
 


### PR DESCRIPTION
### What does this PR do?

This commit adjusts the UDS generator spin implementation to be more like the UDP implementation in that we no longer crash a subtask if the UDS socket is not available for opening yet. In instances where Datadog Agent is concerned the socket can be available relatively late, harming reliable inspection.

Signed-off-by: Brian L. Troutwine <brian.troutwine@datadoghq.com>