### PR TITLE
Make Unix Datagram, Stream distinct, fix DogStatsD bugs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-## Fixed
-- Fix OpenTelemetry message length calculation for some messages.
+
+## [0.12.0-rc5]
+## Changed
+- Fixed: OpenTelemetry message length calculation corrected for some messages.
+- **Breaking change:** Split UDS support between explict datagram and stream modules.
+- Fixed: Corrected mistakes in the DogStatsD payload implementation.
 
 ## [0.12.0-rc4]
 ## Fixed

--- a/src/blackhole.rs
+++ b/src/blackhole.rs
@@ -14,7 +14,8 @@ pub mod splunk_hec;
 pub mod sqs;
 pub mod tcp;
 pub mod udp;
-pub mod uds;
+pub mod unix_datagram;
+pub mod unix_stream;
 
 #[derive(Debug)]
 /// Errors produced by [`Server`].
@@ -27,8 +28,10 @@ pub enum Error {
     SplunkHec(splunk_hec::Error),
     /// See [`crate::blackhole::udp::Error`] for details.
     Udp(udp::Error),
-    /// See [`crate::blackhole::uds::Error`] for details.
-    Uds(uds::Error),
+    /// See [`crate::blackhole::unix_stream::Error`] for details.
+    UnixStream(unix_stream::Error),
+    /// See [`crate::blackhole::unix_datagram::Error`] for details.
+    UnixDatagram(unix_datagram::Error),
     /// See [`crate::blackhole::sqs::Error`] for details.
     Sqs(sqs::Error),
 }
@@ -45,8 +48,10 @@ pub enum Config {
     SplunkHec(splunk_hec::Config),
     /// See [`crate::blackhole::udp::Config`] for details.
     Udp(udp::Config),
-    /// See [`crate::blackhole::uds::Config`] for details.
-    Uds(uds::Config),
+    /// See [`crate::blackhole::unix_stream::Config`] for details.
+    UnixStream(unix_stream::Config),
+    /// See [`crate::blackhole::unix_datagram::Config`] for details.
+    UnixDatagram(unix_datagram::Config),
     /// See [`crate::blackhole::sqs::Config`] for details.
     Sqs(sqs::Config),
 }
@@ -65,8 +70,10 @@ pub enum Server {
     SplunkHec(splunk_hec::SplunkHec),
     /// See [`crate::blackhole::udp::Udp`] for details.
     Udp(udp::Udp),
-    /// See [`crate::blackhole::uds::Uds`] for details.
-    Uds(uds::Uds),
+    /// See [`crate::blackhole::unix_stream::UnixStream`] for details.
+    UnixStream(unix_stream::UnixStream),
+    /// See [`crate::blackhole::unix_datagram::UnixDatagram`] for details.
+    UnixDatagram(unix_datagram::UnixDatagram),
     /// See [`crate::blackhole::sqs::Sqs`] for details.
     Sqs(sqs::Sqs),
 }
@@ -88,7 +95,12 @@ impl Server {
                 Self::Http(http::Http::new(&conf, shutdown).map_err(Error::Http)?)
             }
             Config::Udp(conf) => Self::Udp(udp::Udp::new(&conf, shutdown)),
-            Config::Uds(conf) => Self::Uds(uds::Uds::new(conf, shutdown)),
+            Config::UnixStream(conf) => {
+                Self::UnixStream(unix_stream::UnixStream::new(conf, shutdown))
+            }
+            Config::UnixDatagram(conf) => {
+                Self::UnixDatagram(unix_datagram::UnixDatagram::new(conf, shutdown))
+            }
             Config::Sqs(conf) => Self::Sqs(sqs::Sqs::new(&conf, shutdown)),
             Config::SplunkHec(conf) => Self::SplunkHec(splunk_hec::SplunkHec::new(&conf, shutdown)),
         };
@@ -109,7 +121,8 @@ impl Server {
             Server::Tcp(inner) => inner.run().await.map_err(Error::Tcp),
             Server::Http(inner) => inner.run().await.map_err(Error::Http),
             Server::Udp(inner) => inner.run().await.map_err(Error::Udp),
-            Server::Uds(inner) => inner.run().await.map_err(Error::Uds),
+            Server::UnixStream(inner) => inner.run().await.map_err(Error::UnixStream),
+            Server::UnixDatagram(inner) => inner.run().await.map_err(Error::UnixDatagram),
             Server::Sqs(inner) => inner.run().await.map_err(Error::Sqs),
             Server::SplunkHec(inner) => inner.run().await.map_err(Error::SplunkHec),
         }

--- a/src/blackhole/unix_datagram.rs
+++ b/src/blackhole/unix_datagram.rs
@@ -25,7 +25,7 @@ pub struct Config {
 }
 
 #[derive(Debug)]
-/// The UnixDatagram blackhole.
+/// The `UnixDatagram` blackhole.
 pub struct UnixDatagram {
     path: PathBuf,
     shutdown: Shutdown,
@@ -56,7 +56,7 @@ impl UnixDatagram {
     pub async fn run(mut self) -> Result<(), Error> {
         // Sockets cannot be rebound if they existed previously. Delete the
         // socket, ignore any errors.
-        let _ = tokio::fs::remove_file(&self.path).map_err(Error::Io);
+        let _res = tokio::fs::remove_file(&self.path).map_err(Error::Io);
         let socket = net::UnixDatagram::bind(&self.path).map_err(Error::Io)?;
 
         loop {

--- a/src/blackhole/unix_stream.rs
+++ b/src/blackhole/unix_stream.rs
@@ -26,7 +26,7 @@ pub struct Config {
 }
 
 #[derive(Debug)]
-/// The UnixStream blackhole.
+/// The `UnixStream` blackhole.
 pub struct UnixStream {
     path: PathBuf,
     shutdown: Shutdown,

--- a/src/blackhole/unix_stream.rs
+++ b/src/blackhole/unix_stream.rs
@@ -1,0 +1,87 @@
+//! The Unix Domain Socket stream speaking blackhole.
+
+use std::{io, path::PathBuf};
+
+use futures::StreamExt;
+use metrics::counter;
+use serde::Deserialize;
+use tokio::net;
+use tokio_util::io::ReaderStream;
+use tracing::info;
+
+use crate::signals::Shutdown;
+
+#[derive(Debug)]
+/// Errors produced by [`UnixStream`].
+pub enum Error {
+    /// Wrapper for [`std::io::Error`].
+    Io(io::Error),
+}
+
+#[derive(Debug, Deserialize, Clone, PartialEq, Eq)]
+/// Configuration for [`UnixStream`].
+pub struct Config {
+    /// The path of the socket to read from.
+    pub path: PathBuf,
+}
+
+#[derive(Debug)]
+/// The UnixStream blackhole.
+pub struct UnixStream {
+    path: PathBuf,
+    shutdown: Shutdown,
+}
+
+impl UnixStream {
+    /// Create a new [`UnixStream`] server instance
+    #[must_use]
+    pub fn new(config: Config, shutdown: Shutdown) -> Self {
+        Self {
+            path: config.path,
+            shutdown,
+        }
+    }
+
+    /// Run [`UnixStream`] to completion
+    ///
+    /// This function runs the UDS server forever, unless a shutdown signal is
+    /// received or an unrecoverable error is encountered.
+    ///
+    /// # Errors
+    ///
+    /// Function will return an error if receiving a packet fails.
+    ///
+    /// # Panics
+    ///
+    /// None known.
+    pub async fn run(mut self) -> Result<(), Error> {
+        let listener = net::UnixListener::bind(&self.path).map_err(Error::Io)?;
+
+        loop {
+            tokio::select! {
+                conn = listener.accept() => {
+                    let (socket, _) = conn.map_err(Error::Io)?;
+                    counter!("connection_accepted", 1);
+                    tokio::spawn(async move {
+                        Self::handle_connection(socket).await;
+                    });
+                }
+                _ = self.shutdown.recv() => {
+                    info!("shutdown signal received");
+                    return Ok(())
+                }
+            }
+        }
+    }
+
+    async fn handle_connection(socket: net::UnixStream) {
+        let mut stream = ReaderStream::new(socket);
+
+        while let Some(msg) = stream.next().await {
+            counter!("message_received", 1);
+            if let Ok(msg) = msg {
+                counter!("bytes_received", msg.len() as u64);
+            }
+        }
+    }
+}

--- a/src/generator/udp.rs
+++ b/src/generator/udp.rs
@@ -3,6 +3,7 @@
 use std::{
     net::{SocketAddr, ToSocketAddrs},
     num::{NonZeroU32, NonZeroUsize},
+    time::Duration,
 };
 
 use byte_unit::{Byte, ByteUnit};
@@ -188,6 +189,8 @@ impl Udp {
                             let mut error_labels = labels.clone();
                             error_labels.push(("error".to_string(), err.to_string()));
                             counter!("connection_failure", 1, &error_labels);
+
+                            tokio::time::sleep(Duration::from_secs(1)).await;
                         }
                     }
                 }

--- a/src/generator/unix_stream.rs
+++ b/src/generator/unix_stream.rs
@@ -1,0 +1,226 @@
+//! The Unix Domain Socket stream speaking generator.
+
+use crate::{
+    block::{self, chunk_bytes, construct_block_cache, Block},
+    payload,
+    signals::Shutdown,
+};
+use byte_unit::{Byte, ByteUnit};
+use governor::{
+    clock,
+    state::{self, direct, InsufficientCapacity},
+    Quota, RateLimiter,
+};
+use metrics::{counter, gauge};
+use rand::{rngs::StdRng, SeedableRng};
+use serde::Deserialize;
+use std::{
+    num::{NonZeroU32, NonZeroUsize},
+    path::PathBuf,
+};
+use tokio::{net, task::JoinError};
+use tracing::{debug, error, info};
+
+#[derive(Debug, Deserialize, PartialEq, Eq)]
+/// Configuration of this generator.
+pub struct Config {
+    /// The seed for random operations against this target
+    pub seed: [u8; 32],
+    /// The path of the socket to write to.
+    pub path: PathBuf,
+    /// The payload variant
+    pub variant: payload::Config,
+    /// The bytes per second to send or receive from the target
+    pub bytes_per_second: byte_unit::Byte,
+    /// The block sizes for messages to this target
+    pub block_sizes: Option<Vec<byte_unit::Byte>>,
+    /// The maximum size in bytes of the cache of prebuilt messages
+    pub maximum_prebuild_cache_size_bytes: byte_unit::Byte,
+}
+
+/// Errors produced by [`UnixStream`].
+#[derive(thiserror::Error, Debug)]
+pub enum Error {
+    /// Rate limiter has insuficient capacity for payload. Indicates a serious
+    /// bug.
+    #[error("Rate limiter has insufficient capacity for payload: {0}")]
+    Governor(#[from] InsufficientCapacity),
+    /// Creation of payload blocks failed.
+    #[error("Creation of payload blocks failed: {0}")]
+    Block(#[from] block::Error),
+    /// Generic IO error
+    #[error("IO error: {0}")]
+    Io(#[from] std::io::Error),
+    /// Subtask error
+    #[error("Subtask failure: {0}")]
+    Subtask(#[from] JoinError),
+}
+
+#[derive(Debug)]
+/// The Unix Domain Socket stream generator.
+///
+/// This generator is responsible for sending data to the target via UDS
+/// streams.
+pub struct UnixStream {
+    path: PathBuf,
+    rate_limiter: RateLimiter<direct::NotKeyed, state::InMemoryState, clock::QuantaClock>,
+    block_cache: Vec<Block>,
+    metric_labels: Vec<(String, String)>,
+    shutdown: Shutdown,
+}
+
+impl UnixStream {
+    /// Create a new [`UnixStream`] instance
+    ///
+    /// # Errors
+    ///
+    /// Creation will fail if the underlying governor capacity exceeds u32.
+    ///
+    /// # Panics
+    ///
+    /// Function will panic if user has passed zero values for any byte
+    /// values. Sharp corners.
+    #[allow(clippy::cast_possible_truncation)]
+    pub fn new(config: Config, shutdown: Shutdown) -> Result<Self, Error> {
+        let mut rng = StdRng::from_seed(config.seed);
+        let block_sizes: Vec<NonZeroUsize> = config
+            .block_sizes
+            .clone()
+            .unwrap_or_else(|| {
+                vec![
+                    Byte::from_unit(1.0 / 32.0, ByteUnit::MB).unwrap(),
+                    Byte::from_unit(1.0 / 16.0, ByteUnit::MB).unwrap(),
+                    Byte::from_unit(1.0 / 8.0, ByteUnit::MB).unwrap(),
+                    Byte::from_unit(1.0 / 4.0, ByteUnit::MB).unwrap(),
+                    Byte::from_unit(1.0 / 2.0, ByteUnit::MB).unwrap(),
+                    Byte::from_unit(1_f64, ByteUnit::MB).unwrap(),
+                    Byte::from_unit(2_f64, ByteUnit::MB).unwrap(),
+                    Byte::from_unit(4_f64, ByteUnit::MB).unwrap(),
+                ]
+            })
+            .iter()
+            .map(|sz| NonZeroUsize::new(sz.get_bytes() as usize).expect("bytes must be non-zero"))
+            .collect();
+        let labels = vec![
+            ("component".to_string(), "generator".to_string()),
+            ("component_name".to_string(), "uds".to_string()),
+        ];
+
+        let bytes_per_second = NonZeroU32::new(config.bytes_per_second.get_bytes() as u32).unwrap();
+        gauge!(
+            "bytes_per_second",
+            f64::from(bytes_per_second.get()),
+            &labels
+        );
+
+        let rate_limiter = RateLimiter::direct(Quota::per_second(bytes_per_second));
+        let block_chunks = chunk_bytes(
+            &mut rng,
+            NonZeroUsize::new(config.maximum_prebuild_cache_size_bytes.get_bytes() as usize)
+                .expect("bytes must be non-zero"),
+            &block_sizes,
+        )?;
+        let block_cache = construct_block_cache(&mut rng, &config.variant, &block_chunks, &labels);
+
+        Ok(Self {
+            path: config.path,
+            block_cache,
+            rate_limiter,
+            metric_labels: labels,
+            shutdown,
+        })
+    }
+
+    /// Run [`UnixStream`] to completion or until a shutdown signal is received.
+    ///
+    /// # Errors
+    ///
+    /// Function will return an error when the UDS socket cannot be written to.
+    ///
+    /// # Panics
+    ///
+    /// Function will panic if underlying byte capacity is not available.
+    pub async fn spin(mut self) -> Result<(), Error> {
+        debug!("UnixStream generator running");
+        let labels = self.metric_labels;
+
+        let mut blocks = self.block_cache.iter().cycle();
+        let mut unix_stream = Option::<net::UnixStream>::None;
+
+        loop {
+            let blk = blocks.next().unwrap();
+            let total_bytes = blk.total_bytes;
+
+            tokio::select! {
+                sock = net::UnixStream::connect(&self.path), if unix_stream.is_none() => {
+                    match sock {
+                        Ok(stream) => {
+                            debug!("UDS socket opened for writing.");
+                            unix_stream = Some(stream);
+                        }
+                        Err(err) => {
+                            error!("Opening UDS path failed: {}", err);
+
+                            let mut error_labels = labels.clone();
+                            error_labels.push(("error".to_string(), err.to_string()));
+                            counter!("connection_failure", 1, &error_labels);
+                        }
+                    }
+                }
+                _ = self.rate_limiter.until_n_ready(total_bytes), if unix_stream.is_some() => {
+                    tokio::task::yield_now().await;
+
+                    // NOTE When we write into a unix stream it may be that only
+                    // some of the written bytes make it through in which case we
+                    // must cycle back around and try to write the remainder of the
+                    // buffer.
+                    let blk_max: usize = total_bytes.get() as usize;
+                    let mut blk_offset = 0;
+                    while blk_offset < blk_max {
+                        let stream = unix_stream.unwrap();
+                        unix_stream = None;
+
+                        let ready = stream
+                            .ready(tokio::io::Interest::WRITABLE)
+                            .await
+                            .map_err(Error::Io)
+                            .unwrap(); // Cannot ? in a spawned task :<. Mimics UDP generator.
+                        if ready.is_writable() {
+                            // Try to write data, this may still fail with `WouldBlock`
+                            // if the readiness event is a false positive.
+                            match stream.try_write(&blk.bytes[blk_offset..]) {
+                                Ok(bytes) => {
+                                    counter!("bytes_written", bytes as u64, &labels);
+                                    blk_offset = bytes;
+                                }
+                                Err(ref e) if e.kind() == tokio::io::ErrorKind::WouldBlock => {
+                                    // If the read side has hung up we will never
+                                    // know and will keep attempting to write into
+                                    // the stream. This yield means we won't hog the
+                                    // whole CPU.
+                                    tokio::task::yield_now().await;
+                                }
+                                Err(err) => {
+                                    debug!("write failed: {}", err);
+
+                                    let mut error_labels = labels.clone();
+                                    error_labels.push(("error".to_string(), err.to_string()));
+                                    counter!("request_failure", 1, &error_labels);
+                                    // NOTE we here skip replacing `stream` into
+                                    // `unix_stream` and will attempt a new
+                                    // connection.
+                                    break;
+                                }
+                            }
+                        }
+                        unix_stream = Some(stream);
+                    }
+                }
+                _ = self.shutdown.recv() => {
+                    info!("shutdown signal received");
+                    return Ok(());
+                },
+            }
+        }
+    }
+}

--- a/src/payload/dogstatsd/common.rs
+++ b/src/payload/dogstatsd/common.rs
@@ -4,10 +4,8 @@ use arbitrary::{Arbitrary, Unstructured};
 
 const MAX_SMALLVEC: usize = 8;
 const MAX_TAGS: usize = 16;
-const SIZES: [usize; 8] = [1, 2, 4, 8, 16, 32, 64, 128];
+const SIZES: [usize; 6] = [1, 2, 4, 8, 16, 32];
 const CHARSET: &[u8] = b"abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ";
-#[allow(clippy::cast_possible_truncation)]
-const CHARSET_LEN: u8 = CHARSET.len() as u8;
 
 #[derive(Hash, PartialEq, Eq)]
 pub(crate) struct MetricTagStr {
@@ -34,12 +32,10 @@ impl fmt::Display for MetricTagStr {
 
 impl<'a> arbitrary::Arbitrary<'a> for MetricTagStr {
     fn arbitrary(u: &mut Unstructured<'a>) -> arbitrary::Result<Self> {
-        let size = u.choose(&SIZES)?;
-        let mut bytes: Vec<u8> = vec![0; *size];
-        u.fill_buffer(&mut bytes)?;
-        bytes
-            .iter_mut()
-            .for_each(|item| *item = CHARSET[(*item % CHARSET_LEN) as usize]);
+        let mut bytes: Vec<u8> = Vec::new();
+        for _ in 0..*u.choose(&SIZES)? {
+            bytes.push(*u.choose(&CHARSET)?);
+        }
         Ok(Self { bytes })
     }
 

--- a/src/payload/dogstatsd/common.rs
+++ b/src/payload/dogstatsd/common.rs
@@ -34,7 +34,7 @@ impl<'a> arbitrary::Arbitrary<'a> for MetricTagStr {
     fn arbitrary(u: &mut Unstructured<'a>) -> arbitrary::Result<Self> {
         let mut bytes: Vec<u8> = Vec::new();
         for _ in 0..*u.choose(&SIZES)? {
-            bytes.push(*u.choose(&CHARSET)?);
+            bytes.push(*u.choose(CHARSET)?);
         }
         Ok(Self { bytes })
     }

--- a/src/payload/dogstatsd/event.rs
+++ b/src/payload/dogstatsd/event.rs
@@ -23,7 +23,7 @@ impl fmt::Display for Event {
         // _e{<TITLE_UTF8_LENGTH>,<TEXT_UTF8_LENGTH>}:<TITLE>|<TEXT>|d:<TIMESTAMP>|h:<HOSTNAME>|p:<PRIORITY>|t:<ALERT_TYPE>|#<TAG_KEY_1>:<TAG_VALUE_1>,<TAG_2>
         write!(
             f,
-            "_e{title_utf8_length},{text_utf8_length}:{title}|{text}",
+            "_e{{{title_utf8_length},{text_utf8_length}}}:{title}|{text}",
             title_utf8_length = self.title_utf8_length,
             text_utf8_length = self.text_utf8_length,
             title = self.title,

--- a/src/payload/dogstatsd/metric.rs
+++ b/src/payload/dogstatsd/metric.rs
@@ -42,13 +42,8 @@ impl fmt::Display for Count {
         // <METRIC_NAME>:<VALUE>|<TYPE>|#<TAG_KEY_1>:<TAG_VALUE_1>,<TAG_2>|c:<CONTAINER_ID>
         // <METRIC_NAME>:<VALUE1>:<VALUE2>:<VALUE3>|<TYPE>|@<SAMPLE_RATE>|#<TAG_KEY_1>:<TAG_VALUE_1>,<TAG_2>
         write!(f, "{name}", name = self.name)?;
-        let mut colons_needed = self.value.inner.len() - 1;
         for val in &self.value.inner {
-            write!(f, "{val}")?;
-            if colons_needed != 0 {
-                write!(f, ":")?;
-                colons_needed -= 1;
-            }
+            write!(f, ":{val}")?;
         }
         write!(f, "|c")?;
         if let Some(ref sample_rate) = self.sample_rate {
@@ -111,13 +106,8 @@ impl fmt::Display for Gauge {
         // <METRIC_NAME>:<VALUE>|<TYPE>|#<TAG_KEY_1>:<TAG_VALUE_1>,<TAG_2>|c:<CONTAINER_ID>
         // <METRIC_NAME>:<VALUE1>:<VALUE2>:<VALUE3>|<TYPE>|#<TAG_KEY_1>:<TAG_VALUE_1>,<TAG_2>
         write!(f, "{name}", name = self.name)?;
-        let mut colons_needed = self.value.inner.len() - 1;
         for val in &self.value.inner {
-            write!(f, "{val}")?;
-            if colons_needed != 0 {
-                write!(f, ":")?;
-                colons_needed -= 1;
-            }
+            write!(f, ":{val}")?;
         }
         write!(f, "|g")?;
         if let Some(ref tags) = self.tags {
@@ -176,13 +166,8 @@ impl fmt::Display for Timer {
         // <METRIC_NAME>:<VALUE>|<TYPE>|#<TAG_KEY_1>:<TAG_VALUE_1>,<TAG_2>|c:<CONTAINER_ID>
         // <METRIC_NAME>:<VALUE1>:<VALUE2>:<VALUE3>|<TYPE>|@<SAMPLE_RATE>|#<TAG_KEY_1>:<TAG_VALUE_1>,<TAG_2>
         write!(f, "{name}", name = self.name)?;
-        let mut colons_needed = self.value.inner.len() - 1;
         for val in &self.value.inner {
-            write!(f, "{val}")?;
-            if colons_needed != 0 {
-                write!(f, ":")?;
-                colons_needed -= 1;
-            }
+            write!(f, ":{val}")?;
         }
         write!(f, "|ms")?;
         if let Some(ref sample_rate) = self.sample_rate {
@@ -246,13 +231,8 @@ impl fmt::Display for Distribution {
         // <METRIC_NAME>:<VALUE>|<TYPE>|#<TAG_KEY_1>:<TAG_VALUE_1>,<TAG_2>|c:<CONTAINER_ID>
         // <METRIC_NAME>:<VALUE1>:<VALUE2>:<VALUE3>|<TYPE>|@<SAMPLE_RATE>|#<TAG_KEY_1>:<TAG_VALUE_1>,<TAG_2>
         write!(f, "{name}", name = self.name)?;
-        let mut colons_needed = self.value.inner.len() - 1;
         for val in &self.value.inner {
-            write!(f, "{val}")?;
-            if colons_needed != 0 {
-                write!(f, ":")?;
-                colons_needed -= 1;
-            }
+            write!(f, ":{val}")?;
         }
         write!(f, "|d")?;
         if let Some(ref sample_rate) = self.sample_rate {
@@ -315,13 +295,8 @@ impl fmt::Display for Set {
         // <METRIC_NAME>:<VALUE>|<TYPE>|#<TAG_KEY_1>:<TAG_VALUE_1>,<TAG_2>|c:<CONTAINER_ID>
         // <METRIC_NAME>:<VALUE1>:<VALUE2>:<VALUE3>|<TYPE>|@<SAMPLE_RATE>|#<TAG_KEY_1>:<TAG_VALUE_1>,<TAG_2>
         write!(f, "{name}", name = self.name)?;
-        let mut colons_needed = self.value.inner.len() - 1;
         for val in &self.value.inner {
-            write!(f, "{val}")?;
-            if colons_needed != 0 {
-                write!(f, ":")?;
-                colons_needed -= 1;
-            }
+            write!(f, ":{val}")?;
         }
         write!(f, "|s")?;
         if let Some(ref tags) = self.tags {
@@ -380,13 +355,8 @@ impl fmt::Display for Histogram {
         // <METRIC_NAME>:<VALUE>|<TYPE>|#<TAG_KEY_1>:<TAG_VALUE_1>,<TAG_2>|c:<CONTAINER_ID>
         // <METRIC_NAME>:<VALUE1>:<VALUE2>:<VALUE3>|<TYPE>|@<SAMPLE_RATE>|#<TAG_KEY_1>:<TAG_VALUE_1>,<TAG_2>
         write!(f, "{name}", name = self.name)?;
-        let mut colons_needed = self.value.inner.len() - 1;
         for val in &self.value.inner {
-            write!(f, "{val}")?;
-            if colons_needed != 0 {
-                write!(f, ":")?;
-                colons_needed -= 1;
-            }
+            write!(f, ":{val}")?;
         }
         write!(f, "|h")?;
         if let Some(ref sample_rate) = self.sample_rate {

--- a/src/payload/dogstatsd/service_check.rs
+++ b/src/payload/dogstatsd/service_check.rs
@@ -91,16 +91,16 @@ impl fmt::Display for Status {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::Ok => {
-                write!(f, "ok")
+                write!(f, "0")
             }
             Self::Warning => {
-                write!(f, "warning")
+                write!(f, "1")
             }
             Self::Critical => {
-                write!(f, "critical")
+                write!(f, "2")
             }
             Self::Unknown => {
-                write!(f, "unknown")
+                write!(f, "3")
             }
         }
     }


### PR DESCRIPTION
### What does this PR do?

This commit improves over the UDS generator, splitting it firmly between stream and datagram implementations. I have confirmed that this works now against Datadog Agent, requiring some fixes to the DogStatsD payload generation.

Signed-off-by: Brian L. Troutwine <brian.troutwine@datadoghq.com>