### PR TITLE
Allow for back-off based on target memory limits

### DIFF
--- a/src/bin/lading.rs
+++ b/src/bin/lading.rs
@@ -107,6 +107,9 @@ struct Opts {
     /// the path to write target's stderr
     #[clap(long, default_value_t = default_target_behavior(), requires = "binary-target")]
     target_stderr_path: Behavior,
+    /// the maximum amount of RSS bytes the target may consume before lading backs off load
+    #[clap(long)]
+    target_rss_bytes_limit: Option<byte_unit::Byte>,
     /// path on disk to write captures, will override prometheus-addr if both
     /// are set
     #[clap(long)]
@@ -167,6 +170,9 @@ fn get_config(ops: &Opts) -> Config {
     file.read_to_string(&mut contents).unwrap();
     let mut config: Config = serde_yaml::from_str(&contents).unwrap();
 
+    if let Some(rss_bytes_limit) = ops.target_rss_bytes_limit {
+        target::Meta::set_rss_bytes_limit(rss_bytes_limit).unwrap();
+    }
     let target = if let Some(pid) = ops.target_pid {
         target::Config::Pid(target::PidConfig { pid })
     } else if let Some(path) = &ops.target_path {

--- a/src/generator/http.rs
+++ b/src/generator/http.rs
@@ -27,6 +27,7 @@ use crate::{
     block::{self, chunk_bytes, construct_block_cache, Block},
     payload,
     signals::Shutdown,
+    target,
 };
 
 static CONNECTION_SEMAPHORE: OnceCell<Semaphore> = OnceCell::new();
@@ -228,7 +229,7 @@ impl Http {
             let total_bytes = blk.total_bytes;
 
             tokio::select! {
-                _ = rate_limiter.until_n_ready(total_bytes) => {
+                _ = rate_limiter.until_n_ready(total_bytes), if !target::Meta::rss_bytes_limit_exceeded() => {
                     let client = client.clone();
                     let labels = labels.clone();
                     let method = method.clone();

--- a/src/generator/tcp.rs
+++ b/src/generator/tcp.rs
@@ -21,6 +21,7 @@ use crate::{
     block::{self, chunk_bytes, construct_block_cache, Block},
     payload,
     signals::Shutdown,
+    target,
 };
 
 #[derive(Debug, Deserialize, PartialEq, Eq)]
@@ -176,7 +177,9 @@ impl Tcp {
                         }
                     }
                 }
-                _ = self.rate_limiter.until_n_ready(total_bytes), if connection.is_some() => {
+                _ = self.rate_limiter.until_n_ready(total_bytes), if
+                    connection.is_some() && !target::Meta::rss_bytes_limit_exceeded()
+                => {
                     let mut client = connection.unwrap();
                     let blk = blocks.next().unwrap(); // actually advance through the blocks
                     match client.write_all(&blk.bytes).await {

--- a/src/generator/unix_datagram.rs
+++ b/src/generator/unix_datagram.rs
@@ -4,6 +4,7 @@ use crate::{
     block::{self, chunk_bytes, construct_block_cache, Block},
     payload,
     signals::Shutdown,
+    target,
 };
 use byte_unit::{Byte, ByteUnit};
 use governor::{
@@ -172,7 +173,7 @@ impl UnixDatagram {
             let total_bytes = blk.total_bytes;
 
             tokio::select! {
-                _ = self.rate_limiter.until_n_ready(total_bytes) => {
+                _ = self.rate_limiter.until_n_ready(total_bytes), if !target::Meta::rss_bytes_limit_exceeded() => {
                     // NOTE When we write into a unix socket it may be that only
                     // some of the written bytes make it through in which case we
                     // must cycle back around and try to write the remainder of the

--- a/src/generator/unix_datagram.rs
+++ b/src/generator/unix_datagram.rs
@@ -173,7 +173,12 @@ impl UnixDatagram {
             let total_bytes = blk.total_bytes;
 
             tokio::select! {
-                _ = self.rate_limiter.until_n_ready(total_bytes), if !target::Meta::rss_bytes_limit_exceeded() => {
+                _ = self.rate_limiter.until_n_ready(total_bytes) => {
+                    if target::Meta::rss_bytes_limit_exceeded() {
+                        info!("RSS byte limit exceeded, backing off...");
+                        tokio::time::sleep(tokio::time::Duration::from_secs(1)).await;
+                        continue;
+                    }
                     // NOTE When we write into a unix socket it may be that only
                     // some of the written bytes make it through in which case we
                     // must cycle back around and try to write the remainder of the

--- a/src/generator/unix_stream.rs
+++ b/src/generator/unix_stream.rs
@@ -4,6 +4,7 @@ use crate::{
     block::{self, chunk_bytes, construct_block_cache, Block},
     payload,
     signals::Shutdown,
+    target,
 };
 use byte_unit::{Byte, ByteUnit};
 use governor::{
@@ -167,7 +168,7 @@ impl UnixStream {
                         }
                     }
                 }
-                _ = self.rate_limiter.until_n_ready(total_bytes), if unix_stream.is_some() => {
+                _ = self.rate_limiter.until_n_ready(total_bytes), if unix_stream.is_some() && !target::Meta::rss_bytes_limit_exceeded() => {
                     tokio::task::yield_now().await;
 
                     // NOTE When we write into a unix stream it may be that only

--- a/src/target.rs
+++ b/src/target.rs
@@ -54,10 +54,16 @@ pub struct Meta {}
 
 impl Meta {
     /// Set the maximum RSS bytes limit
+    ///
+    /// # Errors
+    ///
+    /// Will fail if the `byte_unit::Byte` value given is larger than `u64::MAX`
+    /// bytes.
     #[inline]
+    #[allow(clippy::cast_possible_truncation)]
     pub fn set_rss_bytes_limit(limit: byte_unit::Byte) -> Result<(), MetaError> {
         let raw_limit: u128 = limit.get_bytes();
-        if raw_limit > (u64::MAX as u128) {
+        if raw_limit > u128::from(u64::MAX) {
             return Err(MetaError::ByteLimitTooLarge);
         }
 

--- a/src/target.rs
+++ b/src/target.rs
@@ -21,6 +21,7 @@ use std::{
     num::NonZeroU32,
     path::PathBuf,
     process::{ExitStatus, Stdio},
+    sync::atomic::{AtomicU64, Ordering},
 };
 
 use nix::{
@@ -32,7 +33,44 @@ use tokio::{process::Command, sync::broadcast::Sender};
 use tracing::{error, info};
 
 pub use crate::common::{Behavior, Output};
-use crate::{common::stdio, signals::Shutdown};
+use crate::{common::stdio, observer::RSS_BYTES, signals::Shutdown};
+
+/// Expose the process' current RSS consumption, allowing abstractions to be
+/// built on top in the Target implementation.
+pub(crate) static RSS_BYTES_LIMIT: AtomicU64 = AtomicU64::new(u64::MAX);
+
+/// Errors produced by [`Meta`]
+#[derive(thiserror::Error, Debug, Clone, Copy)]
+pub enum MetaError {
+    /// Unable to support byte limits greater than u64::MAX
+    #[error("unable to support bytes greater than u64::MAX")]
+    ByteLimitTooLarge,
+}
+
+/// Source for live metadata about the running target.
+#[derive(Debug, Clone, Copy)]
+pub struct Meta {}
+
+impl Meta {
+    /// Set the maximum RSS bytes limit
+    #[inline]
+    pub fn set_rss_bytes_limit(limit: byte_unit::Byte) -> Result<(), MetaError> {
+        let raw_limit: u128 = limit.get_bytes();
+        if raw_limit > (u64::MAX as u128) {
+            return Err(MetaError::ByteLimitTooLarge);
+        }
+        RSS_BYTES_LIMIT.store(raw_limit as u64, Ordering::Relaxed);
+        Ok(())
+    }
+
+    #[inline]
+    pub(crate) fn rss_bytes_limit_exceeded() -> bool {
+        let limit: u64 = RSS_BYTES_LIMIT.load(Ordering::Relaxed);
+        let current: u64 = RSS_BYTES.load(Ordering::Relaxed);
+
+        current > limit
+    }
+}
 
 /// Errors produced by [`Server`]
 #[derive(thiserror::Error, Debug)]


### PR DESCRIPTION
### What does this PR do?

This commit adds the ability for lading generators to back off from pushing load if the target program gets close to a user-supplied memory limit. 

### Additional Notes

This implementation is stop/start. I think in the future it'd be a boon if we made back-off scale back attempted throughput, although we'll also have to administer a scale-up. We've discussed that a PID would work just great for this kind of thing but I think achieving that is outside the scope of this PR for now.

REF SMP-329

Signed-off-by: Brian L. Troutwine <brian.troutwine@datadoghq.com>
