### PR TITLE
Prefer to peek blocks

### DIFF
--- a/src/generator/splunk_hec.rs
+++ b/src/generator/splunk_hec.rs
@@ -234,12 +234,12 @@ impl SplunkHec {
             f64::from(self.parallel_connections),
             &labels
         );
-        let mut blocks = self.block_cache.iter().cycle();
+        let mut blocks = self.block_cache.iter().cycle().peekable();
         let mut channels = self.channels.iter().cycle();
 
         loop {
             let channel: Channel = channels.next().unwrap().clone();
-            let blk = blocks.next().unwrap();
+            let blk = blocks.peek().unwrap();
             let total_bytes = blk.total_bytes;
 
             tokio::select! {
@@ -248,6 +248,7 @@ impl SplunkHec {
                     let labels = labels.clone();
                     let uri = uri.clone();
 
+                    let blk = blocks.next().unwrap(); // actually advance through the blocks
                     let body = Body::from(blk.bytes.clone());
                     let block_length = blk.bytes.len();
 

--- a/src/generator/tcp.rs
+++ b/src/generator/tcp.rs
@@ -155,10 +155,10 @@ impl Tcp {
         let labels = self.metric_labels;
 
         let mut connection = None;
-        let mut blocks = self.block_cache.iter().cycle();
+        let mut blocks = self.block_cache.iter().cycle().peekable();
 
         loop {
-            let blk = blocks.next().unwrap();
+            let blk = blocks.peek().unwrap();
             let total_bytes = blk.total_bytes;
 
             tokio::select! {
@@ -178,6 +178,7 @@ impl Tcp {
                 }
                 _ = self.rate_limiter.until_n_ready(total_bytes), if connection.is_some() => {
                     let mut client = connection.unwrap();
+                    let blk = blocks.next().unwrap(); // actually advance through the blocks
                     match client.write_all(&blk.bytes).await {
                         Ok(()) => {
                             counter!(

--- a/src/generator/unix_datagram.rs
+++ b/src/generator/unix_datagram.rs
@@ -165,10 +165,10 @@ impl UnixDatagram {
             }
         }
 
-        let mut blocks = self.block_cache.iter().cycle();
+        let mut blocks = self.block_cache.iter().cycle().peekable();
 
         loop {
-            let blk = blocks.next().unwrap();
+            let blk = blocks.peek().unwrap();
             let total_bytes = blk.total_bytes;
 
             tokio::select! {
@@ -177,6 +177,7 @@ impl UnixDatagram {
                     // some of the written bytes make it through in which case we
                     // must cycle back around and try to write the remainder of the
                     // buffer.
+                    let blk = blocks.next().unwrap(); // actually advance through the blocks
                     let blk_max: usize = total_bytes.get() as usize;
                     let mut blk_offset = 0;
                     while blk_offset < blk_max {


### PR DESCRIPTION
It's long nagged at me that we're too aggressive about popping blocks of a block cache. Consider that previously we would pull a block off the cache, realize we had no connection, drop the block, establish a connection and _then_ pop a block and use that. It's not wasteful per se since we're cycling through no matter what but it doesn't sit right, considering that the goal is for our cycle to be consistent each time.

Signed-off-by: Brian L. Troutwine <brian.troutwine@datadoghq.com>