### PR TITLE
Unify limiting under a `Throttle` type

### DIFF
--- a/src/block.rs
+++ b/src/block.rs
@@ -8,8 +8,9 @@ use rand::{prelude::SliceRandom, Rng};
 
 use crate::payload::{self, Serialize};
 
-#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+#[derive(Debug, PartialEq, Eq, Clone, Copy, thiserror::Error)]
 pub enum Error {
+    #[error("Chunk error: {0}")]
     Chunk(ChunkError),
 }
 
@@ -18,15 +19,6 @@ impl From<ChunkError> for Error {
         Error::Chunk(error)
     }
 }
-
-impl std::fmt::Display for Error {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match &self {
-            Error::Chunk(e) => std::fmt::Display::fmt(e, f),
-        }
-    }
-}
-impl std::error::Error for Error {}
 
 #[derive(Debug)]
 pub(crate) struct Block {

--- a/src/generator/splunk_hec/acknowledgements.rs
+++ b/src/generator/splunk_hec/acknowledgements.rs
@@ -16,7 +16,7 @@ use super::{AckSettings, SPLUNK_HEC_CHANNEL_HEADER};
 
 type AckId = u64;
 
-#[derive(Debug, Clone, Copy)]
+#[derive(thiserror::Error, Debug, Clone, Copy)]
 pub enum Error {}
 
 #[derive(Debug, Clone)]

--- a/src/generator/udp.rs
+++ b/src/generator/udp.rs
@@ -7,11 +7,6 @@ use std::{
 };
 
 use byte_unit::{Byte, ByteUnit};
-use governor::{
-    clock, state,
-    state::direct::{self, InsufficientCapacity},
-    Quota, RateLimiter,
-};
 use metrics::{counter, gauge};
 use rand::{rngs::StdRng, SeedableRng};
 use serde::Deserialize;
@@ -22,7 +17,7 @@ use crate::{
     block::{self, chunk_bytes, construct_block_cache, Block},
     payload,
     signals::Shutdown,
-    target,
+    throttle::Throttle,
 };
 
 #[derive(Debug, Deserialize, PartialEq, Eq)]
@@ -45,10 +40,6 @@ pub struct Config {
 /// Errors produced by [`Udp`].
 #[derive(thiserror::Error, Debug)]
 pub enum Error {
-    /// Rate limiter has insuficient capacity for payload. Indicates a serious
-    /// bug.
-    #[error("Rate limiter has insufficient capacity for payload: {0}")]
-    Governor(#[from] InsufficientCapacity),
     /// Creation of payload blocks failed.
     #[error("Creation of payload blocks failed: {0}")]
     Block(#[from] block::Error),
@@ -63,7 +54,7 @@ pub enum Error {
 /// This generator is responsible for sending data to the target via UDP
 pub struct Udp {
     addr: SocketAddr,
-    rate_limiter: RateLimiter<direct::NotKeyed, state::InMemoryState, clock::QuantaClock>,
+    throttle: Throttle,
     block_cache: Vec<Block>,
     metric_labels: Vec<(String, String)>,
     shutdown: Shutdown,
@@ -113,7 +104,6 @@ impl Udp {
             &labels
         );
 
-        let rate_limiter = RateLimiter::direct(Quota::per_second(bytes_per_second));
         let block_chunks = chunk_bytes(
             &mut rng,
             NonZeroUsize::new(config.maximum_prebuild_cache_size_bytes.get_bytes() as usize)
@@ -131,7 +121,7 @@ impl Udp {
         Ok(Self {
             addr,
             block_cache,
-            rate_limiter,
+            throttle: Throttle::new(bytes_per_second),
             metric_labels: labels,
             shutdown,
         })
@@ -179,12 +169,7 @@ impl Udp {
                         }
                     }
                 }
-                _ = self.rate_limiter.until_n_ready(total_bytes), if connection.is_some() => {
-                    if target::Meta::rss_bytes_limit_exceeded() {
-                        info!("RSS byte limit exceeded, backing off...");
-                        tokio::time::sleep(tokio::time::Duration::from_secs(1)).await;
-                        continue;
-                    }
+                _ = self.throttle.wait_for(total_bytes), if connection.is_some() => {
                     let sock = connection.unwrap();
                     let blk = blocks.next().unwrap(); // actually advance through the blocks
                     match sock.send_to(&blk.bytes, self.addr).await {

--- a/src/generator/unix_datagram.rs
+++ b/src/generator/unix_datagram.rs
@@ -4,14 +4,9 @@ use crate::{
     block::{self, chunk_bytes, construct_block_cache, Block},
     payload,
     signals::Shutdown,
-    target,
+    throttle::Throttle,
 };
 use byte_unit::{Byte, ByteUnit};
-use governor::{
-    clock,
-    state::{self, direct, InsufficientCapacity},
-    Quota, RateLimiter,
-};
 use metrics::{counter, gauge};
 use rand::{rngs::StdRng, SeedableRng};
 use serde::Deserialize;
@@ -42,10 +37,6 @@ pub struct Config {
 /// Errors produced by [`UnixDatagram`].
 #[derive(thiserror::Error, Debug)]
 pub enum Error {
-    /// Rate limiter has insuficient capacity for payload. Indicates a serious
-    /// bug.
-    #[error("Rate limiter has insufficient capacity for payload: {0}")]
-    Governor(#[from] InsufficientCapacity),
     /// Creation of payload blocks failed.
     #[error("Creation of payload blocks failed: {0}")]
     Block(#[from] block::Error),
@@ -64,7 +55,7 @@ pub enum Error {
 /// datagrams.
 pub struct UnixDatagram {
     path: PathBuf,
-    rate_limiter: RateLimiter<direct::NotKeyed, state::InMemoryState, clock::QuantaClock>,
+    throttle: Throttle,
     block_cache: Vec<Block>,
     metric_labels: Vec<(String, String)>,
     shutdown: Shutdown,
@@ -114,7 +105,6 @@ impl UnixDatagram {
             &labels
         );
 
-        let rate_limiter = RateLimiter::direct(Quota::per_second(bytes_per_second));
         let block_chunks = chunk_bytes(
             &mut rng,
             NonZeroUsize::new(config.maximum_prebuild_cache_size_bytes.get_bytes() as usize)
@@ -126,7 +116,7 @@ impl UnixDatagram {
         Ok(Self {
             path: config.path,
             block_cache,
-            rate_limiter,
+            throttle: Throttle::new(bytes_per_second),
             metric_labels: labels,
             shutdown,
         })
@@ -173,12 +163,7 @@ impl UnixDatagram {
             let total_bytes = blk.total_bytes;
 
             tokio::select! {
-                _ = self.rate_limiter.until_n_ready(total_bytes) => {
-                    if target::Meta::rss_bytes_limit_exceeded() {
-                        info!("RSS byte limit exceeded, backing off...");
-                        tokio::time::sleep(tokio::time::Duration::from_secs(1)).await;
-                        continue;
-                    }
+                _ = self.throttle.wait_for(total_bytes) => {
                     // NOTE When we write into a unix socket it may be that only
                     // some of the written bytes make it through in which case we
                     // must cycle back around and try to write the remainder of the

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,3 +31,4 @@ pub mod observer;
 pub(crate) mod payload;
 pub mod signals;
 pub mod target;
+pub(crate) mod throttle;

--- a/src/throttle.rs
+++ b/src/throttle.rs
@@ -50,6 +50,7 @@ impl Throttle {
             if target::Meta::rss_bytes_limit_exceeded() {
                 info!("RSS byte limit exceeded, backing off...");
                 tokio::time::sleep(tokio::time::Duration::from_secs(1)).await;
+            } else {
                 break;
             }
         }

--- a/src/throttle.rs
+++ b/src/throttle.rs
@@ -1,0 +1,63 @@
+//! A throttle for input into the target program.
+
+use std::num::NonZeroU32;
+
+use governor::{
+    clock,
+    state::{self, direct},
+    Quota, RateLimiter,
+};
+use tracing::info;
+
+use crate::target;
+
+/// Errors produced by [`Throttle`].
+#[derive(thiserror::Error, Debug)]
+pub(crate) enum Error {
+    /// Requested capacity is greater than maximum allowed capacity.
+    #[error("Capacity")]
+    Capacity,
+}
+
+#[derive(Debug)]
+pub(crate) struct Throttle {
+    maximum_capacity: NonZeroU32,
+    rate_limiter: RateLimiter<direct::NotKeyed, state::InMemoryState, clock::QuantaClock>,
+}
+
+impl Throttle {
+    pub(crate) fn new(maximum_capacity: NonZeroU32) -> Self {
+        Self {
+            maximum_capacity,
+            rate_limiter: RateLimiter::direct(Quota::per_second(maximum_capacity)),
+        }
+    }
+
+    pub(crate) async fn wait(&self) -> Result<(), Error> {
+        loop {
+            if target::Meta::rss_bytes_limit_exceeded() {
+                info!("RSS byte limit exceeded, backing off...");
+                tokio::time::sleep(tokio::time::Duration::from_secs(1)).await;
+                break;
+            }
+        }
+        self.rate_limiter.until_ready().await;
+        Ok(())
+    }
+
+    pub(crate) async fn wait_for(&self, capacity: NonZeroU32) -> Result<(), Error> {
+        loop {
+            if target::Meta::rss_bytes_limit_exceeded() {
+                info!("RSS byte limit exceeded, backing off...");
+                tokio::time::sleep(tokio::time::Duration::from_secs(1)).await;
+                break;
+            }
+        }
+        if capacity > self.maximum_capacity {
+            Err(Error::Capacity)
+        } else {
+            self.rate_limiter.until_n_ready(capacity).await.unwrap();
+            Ok(())
+        }
+    }
+}


### PR DESCRIPTION
This commit takes our use of governor crate as well as the recent RSS limiter and hides it inside a `Throttle` type that all generators now reference. I have needed to spread `thiserror::Error` implementations around through this work, which also unifies that aspect of our error handling.

There should be no happy-path functional change here. The ambition is to allow us to hunt for setpoints in generation but making changes in ten distinct generators to support that goal is, well, a dead-end.

REF SMP-372

Signed-off-by: Brian L. Troutwine <brian.troutwine@datadoghq.com>