### PR TITLE
Use saturating addition in observer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## Fixed
+- Use saturating addition in observer stats gathering routine
 
 ## [0.12.0]
 ## Added

--- a/src/observer.rs
+++ b/src/observer.rs
@@ -174,9 +174,9 @@ impl Server {
                         // The uptime of the process in fractional seconds.
                         gauge!("uptime_seconds", process_uptime_seconds);
 
-                        let rss: u64 = all_stats.iter().map(|stat| stat.rss).sum();
-                        let rsslim: u64 = all_stats.iter().map(|stat| stat.rsslim).sum();
-                        let vsize: u64 = all_stats.iter().map(|stat| stat.vsize).sum();
+                        let rss: u64 = all_stats.iter().fold(0, |val, stat| val.saturating_add(stat.rss));
+                        let rsslim: u64 = all_stats.iter().fold(0, |val, stat| val.saturating_add(stat.rsslim));
+                        let vsize: u64 = all_stats.iter().fold(0, |val, stat| val.saturating_add(stat.vsize));
                         let num_threads: u64 = all_stats.iter().map(|stat| <i64 as std::convert::TryInto<u64>>::try_into(stat.num_threads).unwrap()).sum();
 
                         let rss_bytes: u64 = rss*page_size;


### PR DESCRIPTION
### What does this PR do?

Use saturating addition in the observer's stats gathering routine. This fixes a panic when the target process doesn't have a memory limit (`rsslim == u64::MAX`)

### Motivation

Fix the panic reported in https://github.com/DataDog/lading/issues/463

### Related issues

https://github.com/DataDog/lading/issues/463

### Additional Notes

N/A
