### PR TITLE
Capacity threshold search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [0.13.0-rc1]
+## Added
+- Introduced automatic throttling into generators to search for stable target load.
 ## Fixed
 - Use saturating addition in observer stats gathering routine
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -595,12 +595,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dcf79a1bf610b10f42aea489289c5a2c478a786509693b80cd39c44ccd936366"
 
 [[package]]
-name = "futures-timer"
-version = "3.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e64b03909df88034c26dc1547e8970b91f98bdb65165d6a4e9110d94263dbb2c"
-
-[[package]]
 name = "futures-util"
 version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -651,24 +645,6 @@ dependencies = [
  "bitflags",
  "ignore",
  "walkdir",
-]
-
-[[package]]
-name = "governor"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c390a940a5d157878dd057c78680a33ce3415bcd05b4799509ea44210914b4d5"
-dependencies = [
- "cfg-if",
- "dashmap",
- "futures",
- "futures-timer",
- "no-std-compat",
- "nonzero_ext",
- "parking_lot",
- "quanta 0.9.3",
- "rand",
- "smallvec",
 ]
 
 [[package]]
@@ -912,7 +888,6 @@ dependencies = [
  "clap",
  "flate2",
  "futures",
- "governor",
  "http",
  "http-serde",
  "hyper",
@@ -1051,7 +1026,7 @@ dependencies = [
  "metrics-util",
  "parking_lot",
  "portable-atomic",
- "quanta 0.10.1",
+ "quanta",
  "thiserror",
  "tokio",
 ]
@@ -1083,7 +1058,7 @@ dependencies = [
  "ordered-float",
  "parking_lot",
  "portable-atomic",
- "quanta 0.10.1",
+ "quanta",
  "radix_trie",
  "sketches-ddsketch",
 ]
@@ -1143,18 +1118,6 @@ dependencies = [
  "pin-utils",
  "static_assertions",
 ]
-
-[[package]]
-name = "no-std-compat"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b93853da6d84c2e3c7d730d6473e8817692dd89be387eb01b94d7f108ecb5b8c"
-
-[[package]]
-name = "nonzero_ext"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38bf9645c8b145698bb0b18a4637dcacbc421ea49bef2317e4fd8065a387cf21"
 
 [[package]]
 name = "nu-ansi-term"
@@ -1554,22 +1517,6 @@ checksum = "a5e0526209433e96d83d750dd81a99118edbc55739e7e61a46764fd2ad537788"
 dependencies = [
  "bytes",
  "prost",
-]
-
-[[package]]
-name = "quanta"
-version = "0.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20afe714292d5e879d8b12740aa223c6a88f118af41870e8b6196e39a02238a8"
-dependencies = [
- "crossbeam-utils",
- "libc",
- "mach",
- "once_cell",
- "raw-cpuid",
- "wasi 0.10.2+wasi-snapshot-preview1",
- "web-sys",
- "winapi",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -882,6 +882,7 @@ version = "0.12.0"
 dependencies = [
  "arbitrary",
  "async-pidfd",
+ "async-trait",
  "byte-unit",
  "bytecount",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ categories = ["development-tools::profiling"]
 description = "A tool for load testing daemons."
 
 [dependencies]
+async-trait = { version = "0.1", default-features = false, features = [] }
 arbitrary = { version = "1", default-features = false, features = ["derive"] }
 byte-unit = { version = "4.0", features = ["serde"] }
 bytecount = "0.6"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,6 @@ bytes = { version = "1.4.0", default-features = false }
 clap = { version = "3.2", default-features = false, features = ["std", "color", "suggestions", "derive"] }
 flate2 = { version = "1.0.25", default-features = false, features = ["rust_backend"] }
 futures = "0.3.26"
-governor = { version = "0.5", features = ["std", "jitter", "quanta"] }
 http = "0.2"
 http-serde = "1.1"
 hyper = { version = "0.14", features = ["client"] }

--- a/integration/sheepdog/src/lib.rs
+++ b/integration/sheepdog/src/lib.rs
@@ -257,7 +257,11 @@ generator:
 
         let reqs = test.run().await?;
 
-        assert!(reqs.http.request_count > 10);
+        debug_assert!(
+            reqs.http.request_count > 10,
+            "Request count: {request_count}",
+            request_count = reqs.http.request_count
+        );
         Ok(())
     }
 
@@ -289,7 +293,11 @@ generator:
 
         let reqs = test.run().await?;
 
-        assert!(reqs.http.request_count > 10);
+        debug_assert!(
+            reqs.http.request_count > 10,
+            "Request count: {request_count}",
+            request_count = reqs.http.request_count
+        );
         Ok(())
     }
 
@@ -321,7 +329,11 @@ generator:
 
         let reqs = test.run().await?;
 
-        assert!(reqs.http.request_count > 10);
+        debug_assert!(
+            reqs.http.request_count > 10,
+            "Request count: {request_count}",
+            request_count = reqs.http.request_count
+        );
         Ok(())
     }
 
@@ -353,7 +365,11 @@ generator:
 
         let reqs = test.run().await?;
 
-        assert!(reqs.http.request_count > 10);
+        debug_assert!(
+            reqs.http.request_count > 10,
+            "Request count: {request_count}",
+            request_count = reqs.http.request_count
+        );
         Ok(())
     }
 

--- a/integration/sheepdog/src/lib.rs
+++ b/integration/sheepdog/src/lib.rs
@@ -217,6 +217,7 @@ generator:
         headers: {}
         target_uri: "http://localhost:{{port_number}}/"
         bytes_per_second: "100 Mb"
+        block_sizes: ["1Mb", "0.5Mb", "0.25Mb", "0.125Mb", "128Kb"]
         parallel_connections: 5
         method:
           post:
@@ -251,6 +252,7 @@ generator:
         headers: {}
         target_uri: "http://localhost:{{port_number}}/"
         bytes_per_second: "100 Mb"
+        block_sizes: ["1Mb", "0.5Mb", "0.25Mb", "0.125Mb", "128Kb"]
         parallel_connections: 5
         method:
           post:
@@ -285,6 +287,7 @@ generator:
         headers: {}
         target_uri: "http://localhost:{{port_number}}/v1/logs"
         bytes_per_second: "100 Mb"
+        block_sizes: ["1Mb", "0.5Mb", "0.25Mb", "0.125Mb", "128Kb"]
         parallel_connections: 5
         method:
           post:
@@ -321,6 +324,7 @@ generator:
         headers: {}
         target_uri: "http://localhost:{{port_number}}/v1/traces"
         bytes_per_second: "100 Mb"
+        block_sizes: ["1Mb", "0.5Mb", "0.25Mb", "0.125Mb", "128Kb"]
         parallel_connections: 5
         method:
           post:
@@ -357,6 +361,7 @@ generator:
         headers: {}
         target_uri: "http://localhost:{{port_number}}/v1/metrics"
         bytes_per_second: "100 Mb"
+        block_sizes: ["1Mb", "0.5Mb", "0.25Mb", "0.125Mb", "128Kb"]
         parallel_connections: 5
         method:
           post:

--- a/integration/sheepdog/src/lib.rs
+++ b/integration/sheepdog/src/lib.rs
@@ -227,7 +227,11 @@ generator:
 
         let reqs = test.run().await?;
 
-        assert!(reqs.http.request_count > 10);
+        debug_assert!(
+            reqs.http.request_count > 10,
+            "Request count: {request_count}",
+            request_count = reqs.http.request_count
+        );
         Ok(())
     }
 

--- a/src/generator/file_tree.rs
+++ b/src/generator/file_tree.rs
@@ -149,8 +149,8 @@ impl FileTree {
     ///
     /// Function will panic if one node is not path is not populated properly
     pub async fn spin(mut self) -> Result<(), Error> {
-        let open_throttle = Throttle::new(self.open_per_second);
-        let rename_throttle = Throttle::new(self.rename_per_second);
+        let mut open_throttle = Throttle::new(self.open_per_second);
+        let mut rename_throttle = Throttle::new(self.rename_per_second);
 
         let mut iter = self.nodes.iter().cycle();
         let mut folders = Vec::with_capacity(self.total_folder);

--- a/src/generator/process_tree.rs
+++ b/src/generator/process_tree.rs
@@ -311,7 +311,7 @@ impl ProcessTree {
     /// Panic if the lading path can't determine.
     ///
     pub async fn spin(mut self) -> Result<(), Error> {
-        let process_throttle = Throttle::new(self.max_tree_per_second);
+        let mut process_throttle = Throttle::new(self.max_tree_per_second);
         let lading_path = self.lading_path.to_str().unwrap();
 
         loop {

--- a/src/throttle.rs
+++ b/src/throttle.rs
@@ -1,15 +1,14 @@
 //! A throttle for input into the target program.
 
-use std::num::NonZeroU32;
+// There are three signals that are obeyed in this Throttle,
 
-use governor::{
-    clock,
-    state::{self, direct},
-    Quota, RateLimiter,
-};
+use std::{cmp, num::NonZeroU32};
+use tokio::time::{self, Duration, Instant};
 use tracing::info;
 
 use crate::target;
+
+const INTERVAL_TICKS: u128 = 1_000_000;
 
 /// Errors produced by [`Throttle`].
 #[derive(thiserror::Error, Debug)]
@@ -19,46 +18,226 @@ pub(crate) enum Error {
     Capacity,
 }
 
+// // Knuth TAOCP vol 2, 3rd edition, page 232, discussed
+// // https://www.johndcook.com/blog/standard_deviation/ and
+// // https://math.stackexchange.com/a/116344.
+// #[derive(Default, Debug)]
+// struct Welford {
+//     m_n: u64,
+//     m_oldM: f64,
+//     m_newM: f64,
+//     m_oldS: f64,
+//     m_newS: f64,
+// }
+
+// impl Welford {
+//     fn push(&mut self, value: f64) {
+//         self.m_n += 1;
+//         if self.m_n == 1 {
+//             self.m_newM = value;
+//             self.m_oldM = value;
+//             self.m_oldS = 0.0;
+//         } else {
+//             self.m_newM = self.m_oldM + (value - self.m_oldM) / (self.m_n as f64);
+//             self.m_newS = self.m_oldS + (value - self.m_oldM) * (value - self.m_newM);
+
+//             self.m_oldM = self.m_newM;
+//             self.m_oldS = self.m_newS;
+//         }
+//     }
+
+//     fn mean(&self) -> f64 {
+//         if self.m_n == 0 {
+//             0.0
+//         } else {
+//             self.m_newM
+//         }
+//     }
+
+//     fn variance(&self) -> f64 {
+//         if self.m_n > 1 {
+//             let shifted_m_n = self.m_n - 1;
+//             self.m_newS / (shifted_m_n as f64)
+//         } else {
+//             0.0
+//         }
+//     }
+
+//     fn stdev(&self) -> f64 {
+//         self.variance().sqrt()
+//     }
+// }
+
 #[derive(Debug)]
+/// A throttle type.
+///
+/// This throttle participates in three signals:
+///
+/// * time-based allocation of capacity, with user draw-down of that capacity,
+/// * binary back-off based on RSS consumption of the target and
+/// * a 'bean counter' approach to searching for target throughput setpoint.
+///
+/// The last is based on a budget allocation heuristic in large political organizations:
+///
+/// * Given parties Consumer, Provider and Budget which Provider dictates the
+///   maximum of, doles out to Consumer. Allow the initial state of Budget to be
+///   X.
+/// * At each negotiation interval Consumer advertises to Provider that its
+///   actual consumption of budget was Y, its new desired budget is Z.
+///   - If Y < X then new budget is Y, discarding Z.
+///   - If Y >= X then new budget is Z * 125%.
+///
+/// In `Throttle` consumer does not advertise its desired budget. Instead
+/// `Throttle` keeps track keep track of the actual budget consumption would
+/// have been were every request satisfied and, once a second, sets the new
+/// budget as the midway point between the previous budget and actual
 pub(crate) struct Throttle {
-    maximum_capacity: NonZeroU32,
-    rate_limiter: RateLimiter<direct::NotKeyed, state::InMemoryState, clock::QuantaClock>,
+    spare_capacity: u128,
+
+    maximum_capacity: u128,
+    /// The budget that was requested in the interval, whether it was satisfied
+    /// or not.
+    requested_budget: u128,
+    projected_budget: u128,
+    /// The instance the current interval began.
+    interval_start: Instant,
+    /// The interval number, primarily useful for testing and debugging.
+    interval: u128,
+    //    rate_limiter: RateLimiter<direct::NotKeyed, state::InMemoryState, clock::QuantaClock>,
 }
 
 impl Throttle {
     pub(crate) fn new(maximum_capacity: NonZeroU32) -> Self {
+        // We set the maximum capacity of the bucket, X. We say that an
+        // 'interval' happens once every second. If we allow for the tick of
+        // Throttle to be one per microsecond that's 1x10^6 ticks per interval.
+
+        // let refill_per_tick = (maximum_capacity.get() as f64) / 1_000_000.0;
+
+        // let rate_limiter = RateLimiter::direct(Quota::per_second(maximum_capacity));
+        // let maximum_capacity = maximum_capacity.get();
+        // let interval_actual_budget = maximum_capacity / 10;
+
         Self {
-            maximum_capacity,
-            rate_limiter: RateLimiter::direct(Quota::per_second(maximum_capacity)),
+            maximum_capacity: maximum_capacity.get() as u128,
+
+            //            rate_limiter,
+            // interval_actual_budget,
+            requested_budget: 0,
+            projected_budget: maximum_capacity.get() as u128 / 2,
+            interval_start: Instant::now(),
+            interval: 0,
+            spare_capacity: 0,
         }
     }
 
-    pub(crate) async fn wait(&self) -> Result<(), Error> {
-        loop {
-            if target::Meta::rss_bytes_limit_exceeded() {
-                info!("RSS byte limit exceeded, backing off...");
-                tokio::time::sleep(tokio::time::Duration::from_secs(1)).await;
-                break;
-            }
-        }
-        self.rate_limiter.until_ready().await;
-        Ok(())
+    #[inline]
+    pub(crate) async fn wait(&mut self) -> Result<(), Error> {
+        // SAFETY: 1_u32 is a non-zero u32.
+        let one = unsafe { NonZeroU32::new_unchecked(1_u32) };
+        self.wait_for(one).await
     }
 
-    pub(crate) async fn wait_for(&self, capacity: NonZeroU32) -> Result<(), Error> {
+    pub(crate) async fn wait_for(&mut self, request: NonZeroU32) -> Result<(), Error> {
         loop {
             if target::Meta::rss_bytes_limit_exceeded() {
                 info!("RSS byte limit exceeded, backing off...");
-                tokio::time::sleep(tokio::time::Duration::from_secs(1)).await;
+                time::sleep(Duration::from_secs(1)).await;
             } else {
                 break;
             }
         }
-        if capacity > self.maximum_capacity {
-            Err(Error::Capacity)
-        } else {
-            self.rate_limiter.until_n_ready(capacity).await.unwrap();
-            Ok(())
+
+        // Fast bail-out. There's no way for this to ever be satisfied and is a
+        // bug on the part of the caller, arguably.
+        if request.get() as u128 > self.maximum_capacity {
+            return Err(Error::Capacity);
         }
+
+        // Determine if its time for the budget to be recalculated. If we have
+        // passed the second boundary since the budget anchor was set we look to see if the previous budget was used. If not, we reset to the actual used budget, if yes we
+
+        // Wake up and compute how much the throttle capacity is refilled since
+        // we were last called.
+        let now = Instant::now();
+        let ticks_since = now.duration_since(self.interval_start).as_micros();
+        let refilled_capacity: u128 = cmp::max(
+            ticks_since.wrapping_mul(f64::MAX as u128) + self.spare_capacity,
+            self.projected_budget,
+        );
+
+        // Figure out if we're in the same interval or not. If we are, increase
+        // interval_requested_budget. If we are not see if the client ended the
+        // interval with budget remaining, adjust refill rate downward, else
+        // upward.
+        let current_interval = ticks_since % INTERVAL_TICKS;
+        if current_interval != self.interval {
+            // interval elapsed
+            self.interval = current_interval;
+            // If the client requested budget is lower than the projected budget
+            // we set the next interval's projected budget to the requested
+            // one. If it's higher, we creep up from the projected budget.
+            if self.requested_budget <= self.projected_budget {
+                self.projected_budget = self.requested_budget;
+            } else {
+                self.projected_budget = cmp::max(
+                    self.projected_budget + (self.projected_budget / 4),
+                    self.maximum_capacity,
+                );
+            }
+            self.requested_budget = 0;
+        }
+
+        self.requested_budget = self.requested_budget.wrapping_add(request.get() as u128);
+
+        let capacity_request = request.get() as u128;
+        if refilled_capacity > capacity_request {
+            self.spare_capacity = refilled_capacity - capacity_request;
+        } else {
+            let slop = capacity_request - refilled_capacity;
+            time::sleep(Duration::from_micros(slop as u64)).await;
+        }
+        Ok(())
+
+        // satisfy
+        // the request or wait enough ticks to do so. Either way we increase the requested If we are not,
+
+        // let seconds_elapsed = self.interval_start.elapsed().as_secs();
+        // if seconds_elapsed > 0 {
+        //     self.interval += seconds_elapsed;
+        // }
+
+        // Are we in the same interval or not?
+
+        // When the refilled_capacity is greater than the user requested capacity we settle the request, adjusting capacity and budget
+        // if refilled_capacity >
+
+        // // We check whether we're within the current interval or have moved
+        // // beyond it. If we are within the current interval we bump the
+        // // requested_budget and then wait for the inner rate limiter,
+        // // returning. This will potentially push us into the next interval but
+        // // avoids the situation where we accumulate in the interior rate limiter
+        // // overmuch and then burst at the start of each interval.
+        // //
+        // // If we are beyond `interval` then we bump the interval, recording its
+        // // new instant, and fiddle with the budget based on previous requests.
+        // if self.interval_start.elapsed() <= self.interval_width {
+        //     self.interval += 1;
+        //     self.interval_requested_budget =
+        //         self.interval_actual_budget.wrapping_add(capacity.get());
+
+        //     // Wait for the rate limiter, then check that the budget requested
+        //     // has not exceeded the budget for the interval.
+        //     self.rate_limiter.until_n_ready(capacity).await.unwrap();
+        //     if self.interval_requested_budget > self.interval_actual_budget {
+        //         return Ok(None);
+        //     }
+        //     unimplemented!()
+        // } else {
+        //     unimplemented!()
+        // }
+
+        // self.rate_limiter.until_n_ready(capacity).await.unwrap();
+        // Ok(())
     }
 }

--- a/src/throttle.rs
+++ b/src/throttle.rs
@@ -232,12 +232,12 @@ where
             // between requested one. and the projected one. If it's higher, we
             // creep up from the projected budget.
             if self.requested_budget <= self.projected_budget {
-                self.projected_budget = (self.projected_budget - self.requested_budget) / 2;
+                let diff = self.projected_budget - self.requested_budget;
+                self.projected_budget = self.projected_budget - (diff / 8);
             } else {
-                self.projected_budget = cmp::min(
-                    self.projected_budget + (self.projected_budget / 4),
-                    self.maximum_capacity,
-                );
+                let diff = self.requested_budget - self.projected_budget;
+                self.projected_budget =
+                    cmp::min(self.projected_budget + (diff / 4), self.maximum_capacity);
             }
             self.requested_budget = 0;
         } else {

--- a/src/throttle.rs
+++ b/src/throttle.rs
@@ -130,7 +130,7 @@ where
             maximum_capacity: maximum_capacity.get() as u64,
             refill_per_tick,
             requested_budget: 0,
-            projected_budget: maximum_capacity.get() as u64 / 2,
+            projected_budget: maximum_capacity.get() as u64,
             interval: 0,
             spare_capacity: 0,
             clock,
@@ -228,10 +228,11 @@ where
             // We are not in the same interval.
             self.interval = current_interval;
             // If the client requested budget is lower than the projected budget
-            // we set the next interval's projected budget to the requested
-            // one. If it's higher, we creep up from the projected budget.
+            // we set the next interval's projected budget to the midway point
+            // between requested one. and the projected one. If it's higher, we
+            // creep up from the projected budget.
             if self.requested_budget <= self.projected_budget {
-                self.projected_budget = self.requested_budget;
+                self.projected_budget = (self.projected_budget - self.requested_budget) / 2;
             } else {
                 self.projected_budget = cmp::min(
                     self.projected_budget + (self.projected_budget / 4),
@@ -440,7 +441,4 @@ mod test {
             }
         }
     }
-
-    // TODO is time advancing correctly? As we make requests is the interval
-    // being updated properly.
 }


### PR DESCRIPTION
### What does this PR do?

This pull request replaces our throttle mechanism based on [governor](https://docs.rs/governor/latest/governor/) with a similar cell rate algorithm but one where the 'capacity' of the leaky bucket shifts in response to actual use. This allows lading to automatically search out stable throughput points in clients. 

### Motivation

We're experimenting on Agent and discovered that in some configurations -- UDS with DogStatsD, notably -- we could force the Agent's ingress throughput to demonstrate high standard deviation. At low throughput -- 256 KiB/sec -- this problem went away, implying there was stable point somewhere between 1 GiB/sec and 256 KiB/sec. We want lading to search this point out automatically.

### Related issues

REF SMP-372

### Additional Notes

