### PR TITLE
Allow unix datagram generator to have parallel connections

### DIFF
--- a/src/generator.rs
+++ b/src/generator.rs
@@ -135,7 +135,7 @@ impl Server {
                 unix_stream::UnixStream::new(conf, shutdown).map_err(Error::UnixStream)?,
             ),
             Config::UnixDatagram(conf) => Self::UnixDatagram(
-                unix_datagram::UnixDatagram::new(conf, shutdown).map_err(Error::UnixDatagram)?,
+                unix_datagram::UnixDatagram::new(&conf, shutdown).map_err(Error::UnixDatagram)?,
             ),
             Config::ProcessTree(conf) => Self::ProcessTree(
                 process_tree::ProcessTree::new(&conf, shutdown).map_err(Error::ProcessTree)?,

--- a/src/generator/unix_datagram.rs
+++ b/src/generator/unix_datagram.rs
@@ -84,7 +84,7 @@ impl UnixDatagram {
     /// Function will panic if user has passed zero values for any byte
     /// values. Sharp corners.
     #[allow(clippy::cast_possible_truncation)]
-    pub fn new(config: Config, shutdown: Shutdown) -> Result<Self, Error> {
+    pub fn new(config: &Config, shutdown: Shutdown) -> Result<Self, Error> {
         let mut rng = StdRng::from_seed(config.seed);
         let block_sizes: Vec<NonZeroUsize> = config
             .block_sizes


### PR DESCRIPTION
This commit allows `unix_datagram` users to configure parallel connections, akin to our gRPC and HTTP generators. This came about while working on #466 at the suggestion of @GeorgeHahn and it struck me as a good, very achievable improvement.

Signed-off-by: Brian L. Troutwine <brian.troutwine@datadoghq.com>
