### PR TITLE
Use specific rust action tag

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
         os: [ubuntu-latest, macos-latest]
     steps:
       - uses: actions/checkout@v2
-      - uses: actions-rust-lang/setup-rust-toolchain@v1
+      - uses: actions-rust-lang/setup-rust-toolchain@v1.3.7
       - name: Install protobuf (Apt)
         run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
         if: matrix.os == 'ubuntu-latest'
@@ -38,7 +38,7 @@ jobs:
         os: [ubuntu-latest, macos-latest]
     steps:
       - uses: actions/checkout@v2
-      - uses: actions-rust-lang/setup-rust-toolchain@v1
+      - uses: actions-rust-lang/setup-rust-toolchain@v1.3.7
       - name: Install protobuf (Apt)
         run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
         if: matrix.os == 'ubuntu-latest'
@@ -55,7 +55,7 @@ jobs:
         os: [ubuntu-latest, macos-latest]
     steps:
       - uses: actions/checkout@v2
-      - uses: actions-rust-lang/setup-rust-toolchain@v1
+      - uses: actions-rust-lang/setup-rust-toolchain@v1.3.7
         with:
           components: rustfmt
       - run: rustup component add rustfmt
@@ -68,7 +68,7 @@ jobs:
         os: [ubuntu-latest, macos-latest]
     steps:
       - uses: actions/checkout@v3
-      - uses: actions-rust-lang/setup-rust-toolchain@v1
+      - uses: actions-rust-lang/setup-rust-toolchain@v1.3.7
         with:
           components: clippy
       - name: Install protobuf (Apt)
@@ -87,7 +87,7 @@ jobs:
         os: [ubuntu-latest, macos-latest]
     steps:
       - uses: actions/checkout@v2
-      - uses: actions-rust-lang/setup-rust-toolchain@v1
+      - uses: actions-rust-lang/setup-rust-toolchain@v1.3.7
       - name: Install protobuf (Apt)
         run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
         if: matrix.os == 'ubuntu-latest'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,7 +60,7 @@ jobs:
       - uses: actions/checkout@v2
 
       # Install cross compilation rust toolchain for Arm64 Mac
-      - uses: actions-rust-lang/setup-rust-toolchain@v1
+      - uses: actions-rust-lang/setup-rust-toolchain@v1.3.7
         with:
           target: ${{ matrix.target }}
         if: matrix.target == 'aarch64-apple-darwin'


### PR DESCRIPTION
### What does this PR do?

The 1.4.0 release of the [Rust toolchain action](https://github.com/actions-rust-lang/setup-rust-toolchain) we use broke CI. Pin to a specific version & roll back to the last working version.

### Motivation

Fix CI

### Related issues

Upstream issue: https://github.com/actions-rust-lang/setup-rust-toolchain/issues/9

### Additional Notes

N/A
