### PR TITLE
Remove prometheus export of metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## Removed
+- Removed prometheus export for metrics, leaving logs as the only option.
 
 ## [0.13.0]
 ## Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -761,12 +761,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ipnet"
-version = "2.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30e22bd8629359895450b59ea7a776c850561b96a3b1d31321c1949d9e6c9146"
-
-[[package]]
 name = "is_executable"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -801,7 +795,7 @@ dependencies = [
 
 [[package]]
 name = "lading"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "arbitrary",
  "async-pidfd",
@@ -817,7 +811,6 @@ dependencies = [
  "hyper",
  "is_executable",
  "metrics",
- "metrics-exporter-prometheus",
  "metrics-util",
  "nix",
  "once_cell",
@@ -935,24 +928,6 @@ dependencies = [
  "ahash",
  "metrics-macros",
  "portable-atomic",
-]
-
-[[package]]
-name = "metrics-exporter-prometheus"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8603921e1f54ef386189335f288441af761e0fc61bcb552168d9cedfe63ebc70"
-dependencies = [
- "hyper",
- "indexmap",
- "ipnet",
- "metrics",
- "metrics-util",
- "parking_lot",
- "portable-atomic",
- "quanta",
- "thiserror",
- "tokio",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 
 [package]
 name = "lading"
-version = "0.13.0"
+version = "0.14.0"
 authors = ["Brian L. Troutwine <brian@troutwine.us>"]
 edition = "2021"
 license = "MIT"
@@ -30,7 +30,6 @@ http-serde = "1.1"
 hyper = { version = "0.14", features = ["client"] }
 is_executable = "1.0.1"
 metrics = { version = "0.20", default-features = false }
-metrics-exporter-prometheus = { version = "0.11.0", default-features = false, features = ["http-listener"] }
 metrics-util = { version = "0.14" }
 nix = { version = "0.26" }
 once_cell = "1.17"

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,7 +1,7 @@
 //! This module controls configuration parsing from the end user, providing a
 //! convenience mechanism for the rest of the program. Crashes are most likely
 //! to originate from this code, intentionally.
-use std::{collections::HashMap, net::SocketAddr, path::PathBuf};
+use std::{collections::HashMap, path::PathBuf};
 
 use serde::Deserialize;
 
@@ -35,14 +35,6 @@ pub struct Config {
 #[serde(untagged)]
 /// Defines the manner of lading's telemetry.
 pub enum Telemetry {
-    /// In prometheus mode lading will emit its internal telemetry for scraping
-    /// at a prometheus poll endpoint.
-    Prometheus {
-        /// Address and port for prometheus exporter
-        prometheus_addr: SocketAddr,
-        /// Additional labels to include in every metric
-        global_labels: HashMap<String, String>,
-    },
     /// In log mode lading will emit its internal telemetry to a structured log
     /// file, the "capture" file.
     Log {
@@ -55,8 +47,8 @@ pub enum Telemetry {
 
 impl Default for Telemetry {
     fn default() -> Self {
-        Self::Prometheus {
-            prometheus_addr: "0.0.0.0:9000".parse().unwrap(),
+        Self::Log {
+            path: PathBuf::from("/tmp/lading.capture"),
             global_labels: HashMap::default(),
         }
     }


### PR DESCRIPTION
### What does this PR do?

The use of the prometheus exporter was a convenience early on in this project but has not seen use for at least six months by our known user-base. 

### Motivation

Removing this resolves a ding we have for
[RUSTSEC-2020-0168](https://rustsec.org/advisories/RUSTSEC-2020-0168) and slightly simplifies our CLI flags.
