### PR TITLE
Introduce support for TraceAgent payload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.13.1-rc1]
+##
+- Introduce Datadog trace-agent payload support in JSON and MsgPack serialization.
+
 ## [0.13.0]
 ## Added
 - Introduced automatic throttling into generators to search for stable target load.

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.66.0"
+channel = "1.68.0"
 profile = "default"

--- a/src/blackhole/sqs.rs
+++ b/src/blackhole/sqs.rs
@@ -251,8 +251,7 @@ fn random_string(len: usize) -> String {
 
 fn generate_delete_message_response() -> String {
     let request_id = random_string(52);
-    format!("<DeleteMessageResponse><ResponseMetadata><RequestId>{}</RequestId></ResponseMetadata></DeleteMessageResponse>",
-    request_id)
+    format!("<DeleteMessageResponse><ResponseMetadata><RequestId>{request_id}</RequestId></ResponseMetadata></DeleteMessageResponse>")
 }
 
 fn generate_receive_message_response(num_messages: u32) -> String {
@@ -261,8 +260,7 @@ fn generate_receive_message_response(num_messages: u32) -> String {
         messages += &generate_message();
     }
     format!(
-        r#"<ReceiveMessageResponse><ReceiveMessageResult>{}</ReceiveMessageResult><ResponseMetadata><RequestId>XG851KHKN09CRHBGHVD2VHCRE0JR5AKHOPR4GVBCPZT1LYKYY606</RequestId></ResponseMetadata></ReceiveMessageResponse>"#,
-        messages
+        r#"<ReceiveMessageResponse><ReceiveMessageResult>{messages}</ReceiveMessageResult><ResponseMetadata><RequestId>XG851KHKN09CRHBGHVD2VHCRE0JR5AKHOPR4GVBCPZT1LYKYY606</RequestId></ResponseMetadata></ReceiveMessageResponse>"#
     )
 }
 
@@ -272,7 +270,6 @@ fn generate_message() -> String {
     let md5 = "8de06d40d5d9a2ec1c6b9a8d80faf135";
     let body = r#"{"host":"31.16.132.149","user-identifier":"jesseddy","datetime":"04/Nov/2021:15:31:28","method":"PUT","request":"/controller/setup","protocol":"HTTP/1.1","status":"400","bytes":31776,"referer":"https://up.de/booper/bopper/mooper/mopper"}"#;
     format!(
-        r#"<Message><MessageId>{}</MessageId><ReceiptHandle>{}</ReceiptHandle><MD5OfBody>{}</MD5OfBody><Body>{}</Body><Attribute><Name>SenderId</Name><Value>AIDAIT2UOQQY3AUEKVGXU</Value></Attribute><Attribute><Name>SentTimestamp</Name><Value>1636054288389</Value></Attribute><Attribute><Name>ApproximateReceiveCount</Name><Value>1</Value></Attribute><Attribute><Name>ApproximateFirstReceiveTimestamp</Name><Value>1636054288391</Value></Attribute></Message>"#,
-        message_id, receipt_handle, md5, body
+        r#"<Message><MessageId>{message_id}</MessageId><ReceiptHandle>{receipt_handle}</ReceiptHandle><MD5OfBody>{md5}</MD5OfBody><Body>{body}</Body><Attribute><Name>SenderId</Name><Value>AIDAIT2UOQQY3AUEKVGXU</Value></Attribute><Attribute><Name>SentTimestamp</Name><Value>1636054288389</Value></Attribute><Attribute><Name>ApproximateReceiveCount</Name><Value>1</Value></Attribute><Attribute><Name>ApproximateFirstReceiveTimestamp</Name><Value>1636054288391</Value></Attribute></Message>"#
     )
 }

--- a/src/block.rs
+++ b/src/block.rs
@@ -6,7 +6,7 @@ use std::{
 use metrics::gauge;
 use rand::{prelude::SliceRandom, Rng};
 
-use crate::payload::{self, Serialize};
+use crate::payload::{self, Serialize, TraceAgent};
 
 #[derive(Debug, PartialEq, Eq, Clone, Copy, thiserror::Error)]
 pub enum Error {
@@ -117,6 +117,14 @@ where
     R: Rng,
 {
     match payload {
+        payload::Config::TraceAgent(enc) => {
+            let ta = match enc {
+                payload::Encoding::Json => TraceAgent::json(),
+                payload::Encoding::MsgPack => TraceAgent::msg_pack(),
+            };
+
+            construct_block_cache_inner(&mut rng, &ta, block_chunks, labels)
+        }
         payload::Config::Syslog5424 => construct_block_cache_inner(
             &mut rng,
             &payload::Syslog5424::default(),

--- a/src/codec.rs
+++ b/src/codec.rs
@@ -53,8 +53,7 @@ pub(crate) fn decode(
                     return Err(hyper::Response::builder()
                         .status(StatusCode::UNSUPPORTED_MEDIA_TYPE)
                         .body(hyper::Body::from(format!(
-                            "Unsupported encoding type: {}",
-                            encoding
+                            "Unsupported encoding type: {encoding}"
                         )))
                         .expect("failed to build response"))
                 }
@@ -72,8 +71,7 @@ fn encoding_error_to_response(
     hyper::Response::builder()
         .status(StatusCode::UNSUPPORTED_MEDIA_TYPE)
         .body(hyper::Body::from(format!(
-            "failed to decode input as {}: {}",
-            encoding, error
+            "failed to decode input as {encoding}: {error}"
         )))
         .expect("failed to build response")
 }

--- a/src/payload.rs
+++ b/src/payload.rs
@@ -94,6 +94,7 @@ pub enum Encoding {
     /// Use JSON format
     Json,
     /// Use MsgPack binary format
+    #[serde(alias = "msgpack")]
     MsgPack,
 }
 

--- a/src/payload.rs
+++ b/src/payload.rs
@@ -87,7 +87,7 @@ pub(crate) trait Serialize {
         W: Write;
 }
 
-/// Sub-configuration for TraceAgent format
+/// Sub-configuration for `TraceAgent` format
 #[derive(Debug, Deserialize, Clone, Copy, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum Encoding {

--- a/src/payload.rs
+++ b/src/payload.rs
@@ -19,6 +19,7 @@ pub(crate) use opentelemetry_trace::OpentelemetryTraces;
 pub(crate) use splunk_hec::{Encoding as SplunkHecEncoding, SplunkHec};
 pub(crate) use statik::Static;
 pub(crate) use syslog::Syslog5424;
+pub(crate) use trace_agent::TraceAgent;
 
 mod apache_common;
 mod ascii;
@@ -34,6 +35,7 @@ mod opentelemetry_trace;
 mod splunk_hec;
 mod statik;
 mod syslog;
+mod trace_agent;
 
 /// Errors related to serialization
 #[derive(Debug)]
@@ -85,6 +87,16 @@ pub(crate) trait Serialize {
         W: Write;
 }
 
+/// Sub-configuration for TraceAgent format
+#[derive(Debug, Deserialize, Clone, Copy, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum Encoding {
+    /// Use JSON format
+    Json,
+    /// Use MsgPack binary format
+    MsgPack,
+}
+
 /// Configuration for `Payload`
 #[derive(Debug, Deserialize, Clone, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
@@ -120,6 +132,8 @@ pub enum Config {
     /// Generates DogStatsD
     #[serde(rename = "dogstatsd")]
     DogStatsD,
+    /// Generates TraceAgent payloads in JSON format
+    TraceAgent(Encoding),
 }
 
 #[derive(Debug)]
@@ -142,6 +156,7 @@ pub(crate) enum Payload {
     OtelLogs(OpentelemetryLogs),
     OtelMetrics(OpentelemetryMetrics),
     DogStatsdD(DogStatsD),
+    TraceAgent(TraceAgent),
 }
 
 impl Payload {}
@@ -166,6 +181,7 @@ impl Serialize for Payload {
             Payload::OtelLogs(ser) => ser.to_bytes(rng, max_bytes, writer),
             Payload::OtelMetrics(ser) => ser.to_bytes(rng, max_bytes, writer),
             Payload::DogStatsdD(ser) => ser.to_bytes(rng, max_bytes, writer),
+            Payload::TraceAgent(ser) => ser.to_bytes(rng, max_bytes, writer),
         }
     }
 }

--- a/src/payload/apache_common.rs
+++ b/src/payload/apache_common.rs
@@ -142,8 +142,7 @@ impl fmt::Display for Timestamp {
 
         write!(
             f,
-            "{:02}/{}/{}:{:02}:{:02}:{:02} {:04}",
-            day, month, year, hour, minute, second, timezone
+            "{day:02}/{month}/{year}:{hour:02}:{minute:02}:{second:02} {timezone:04}"
         )
     }
 }

--- a/src/payload/opentelemetry_log.rs
+++ b/src/payload/opentelemetry_log.rs
@@ -101,9 +101,7 @@ impl Serialize for OpentelemetryLogs {
         // a varint-encoded message length field. The worst case for the message
         // length field is the max message size divided by 0x7F.
         let bytes_remaining = max_bytes.checked_sub(5 + super::div_ceil(max_bytes, 0x7F));
-        let mut bytes_remaining = if let Some(val) = bytes_remaining {
-            val
-        } else {
+        let Some(mut bytes_remaining) = bytes_remaining else {
             return Ok(());
         };
 

--- a/src/payload/opentelemetry_metric.rs
+++ b/src/payload/opentelemetry_metric.rs
@@ -190,9 +190,7 @@ impl Serialize for OpentelemetryMetrics {
         // a varint-encoded message length field. The worst case for the message
         // length field is the max message size divided by 0x7F.
         let bytes_remaining = max_bytes.checked_sub(5 + super::div_ceil(max_bytes, 0x7F));
-        let mut bytes_remaining = if let Some(val) = bytes_remaining {
-            val
-        } else {
+        let Some(mut bytes_remaining) = bytes_remaining else {
             return Ok(());
         };
 

--- a/src/payload/opentelemetry_trace.rs
+++ b/src/payload/opentelemetry_trace.rs
@@ -113,9 +113,7 @@ impl Serialize for OpentelemetryTraces {
         // a varint-encoded message length field. The worst case for the message
         // length field is the max message size divided by 0x7F.
         let bytes_remaining = max_bytes.checked_sub(5 + super::div_ceil(max_bytes, 0x7F));
-        let mut bytes_remaining = if let Some(val) = bytes_remaining {
-            val
-        } else {
+        let Some(mut bytes_remaining) = bytes_remaining else {
             return Ok(());
         };
 

--- a/src/payload/trace_agent.rs
+++ b/src/payload/trace_agent.rs
@@ -140,9 +140,10 @@ impl crate::payload::Serialize for TraceAgent {
                     buf
                 }
             };
-            // NOTE because the type of Vec<Vec<Span>> this algorithm isn't
-            // right. We want to shrink the tree present here. This algorithm
-            // _does_ work if the tree is a straight pipe.
+            // NOTE because the type of Vec<Vec<Span>> this shrink isn't as
+            // efficient as it could be. We want to shrink the tree present
+            // here. This algorithm _does_ work perfectly if the tree is a
+            // straight pipe.
             if encoding.len() > max_bytes {
                 high /= 2;
             } else {

--- a/src/payload/trace_agent.rs
+++ b/src/payload/trace_agent.rs
@@ -1,0 +1,197 @@
+use std::{collections::HashMap, io::Write};
+
+use arbitrary::{Arbitrary, Unstructured};
+use rand::Rng;
+use rmp_serde::Serializer;
+
+use crate::payload::Error;
+use serde::Serialize;
+
+// Manual implementation of [this protobuf](https://github.com/DataDog/datadog-agent/blob/main/pkg/trace/pb/span.proto).
+//
+// ```
+// syntax = "proto3";
+//
+// package pb;
+//
+// import "github.com/gogo/protobuf/gogoproto/gogo.proto";
+//
+// message Span {
+//     // service is the name of the service with which this span is associated.
+//     string service = 1 [(gogoproto.jsontag) = "service", (gogoproto.moretags) = "msg:\"service\""];
+//     // name is the operation name of this span.
+//     string name = 2 [(gogoproto.jsontag) = "name", (gogoproto.moretags) = "msg:\"name\""];
+//     // resource is the resource name of this span, also sometimes called the endpoint (for web spans).
+//     string resource = 3 [(gogoproto.jsontag) = "resource", (gogoproto.moretags) = "msg:\"resource\""];
+//     // traceID is the ID of the trace to which this span belongs.
+//     uint64 traceID = 4 [(gogoproto.jsontag) = "trace_id", (gogoproto.moretags) = "msg:\"trace_id\""];
+//     // spanID is the ID of this span.
+//     uint64 spanID = 5 [(gogoproto.jsontag) = "span_id", (gogoproto.moretags) = "msg:\"span_id\""];
+//     // parentID is the ID of this span's parent, or zero if this span has no parent.
+//     uint64 parentID = 6 [(gogoproto.jsontag) = "parent_id", (gogoproto.moretags) = "msg:\"parent_id\""];
+//     // start is the number of nanoseconds between the Unix epoch and the beginning of this span.
+//     int64 start = 7 [(gogoproto.jsontag) = "start", (gogoproto.moretags) = "msg:\"start\""];
+//     // duration is the time length of this span in nanoseconds.
+//     int64 duration = 8 [(gogoproto.jsontag) = "duration", (gogoproto.moretags) = "msg:\"duration\""];
+//     // error is 1 if there is an error associated with this span, or 0 if there is not.
+//     int32 error = 9 [(gogoproto.jsontag) = "error", (gogoproto.moretags) = "msg:\"error\""];
+//     // meta is a mapping from tag name to tag value for string-valued tags.
+//     map<string, string> meta = 10 [(gogoproto.jsontag) = "meta", (gogoproto.moretags) = "msg:\"meta\""];
+//     // metrics is a mapping from tag name to tag value for numeric-valued tags.
+//     map<string, double> metrics = 11 [(gogoproto.jsontag) = "metrics", (gogoproto.moretags) = "msg:\"metrics\""];
+//     // type is the type of the service with which this span is associated.  Example values: web, db, lambda.
+//     string type = 12 [(gogoproto.jsontag) = "type", (gogoproto.moretags) = "msg:\"type\""];
+//     // meta_struct is a registry of structured "other" data used by, e.g., AppSec.
+//     map<string, bytes> meta_struct = 13 [(gogoproto.jsontag) = "meta_struct,omitempty", (gogoproto.moretags) = "msg:\"meta_struct\""];
+// }
+// ```
+//
+// Note that this protobuf carries go-isms in it, documented
+// [here](https://github.com/gogo/protobuf/blob/master/extensions.md#more-serialization-formats),
+// although awkwardly this shunts to a [Google
+// Groups](https://groups.google.com/g/gogoprotobuf/c/xmFnqAS6MIc) thread for
+// further elaboration. I _think_ this is the equivalent of a serde rename to
+// camel_case for all the field names and then `meta_struct`, the `jsontag`. If
+// I understand correctly the `moretags` also implies that the field names are
+// camel_case in msgpack.
+
+/// TraceAgent span
+#[derive(Arbitrary, serde::Serialize)]
+struct Span {
+    /// service is the name of the service with which this span is associated.
+    service: String,
+    /// name is the operation name of this span.
+    name: String,
+    /// resource is the resource name of this span, also sometimes called the endpoint (for web spans).
+    resource: String,
+    /// traceID is the ID of the trace to which this span belongs.
+    trace_id: u64,
+    /// spanID is the ID of this span.
+    span_id: u64,
+    /// parentID is the ID of this span's parent, or zero if this span has no parent.
+    parent_id: u64,
+    /// start is the number of nanoseconds between the Unix epoch and the beginning of this span.
+    start: i64,
+    /// duration is the time length of this span in nanoseconds.
+    duration: i64,
+    /// error is 1 if there is an error associated with this span, or 0 if there is not.
+    error: i32,
+    /// meta is a mapping from tag name to tag value for string-valued tags.
+    meta: HashMap<String, String>,
+    /// metrics is a mapping from tag name to tag value for numeric-valued tags.
+    metrics: HashMap<String, f64>,
+    /// type is the type of the service with which this span is associated.  Example values: web, db, lambda.
+    #[serde(alias = "type")]
+    kind: String,
+    /// meta_struct is a registry of structured "other" data used by, e.g., AppSec.
+    meta_struct: HashMap<String, Vec<u8>>,
+}
+
+#[derive(Debug, Clone, Copy, Default)]
+#[cfg_attr(test, derive(proptest_derive::Arbitrary))]
+pub(crate) enum Encoding {
+    /// Encode TraceAgent payload in JSON format
+    Json,
+    /// Encode TraceAgent payload in MsgPack format
+    #[default]
+    MsgPack,
+}
+
+#[derive(Debug, Default, Clone, Copy)]
+#[allow(clippy::module_name_repetitions)]
+#[cfg_attr(test, derive(proptest_derive::Arbitrary))]
+pub(crate) struct TraceAgent {
+    encoding: Encoding,
+}
+
+impl TraceAgent {
+    pub(crate) fn json() -> Self {
+        Self {
+            encoding: Encoding::Json,
+        }
+    }
+    pub(crate) fn msg_pack() -> Self {
+        Self {
+            encoding: Encoding::MsgPack,
+        }
+    }
+}
+
+impl crate::payload::Serialize for TraceAgent {
+    fn to_bytes<W, R>(&self, mut rng: R, max_bytes: usize, writer: &mut W) -> Result<(), Error>
+    where
+        R: Rng + Sized,
+        W: Write,
+    {
+        let mut entropy: Vec<u8> = vec![0; max_bytes];
+        rng.fill_bytes(&mut entropy);
+        let unstructured = Unstructured::new(&entropy);
+
+        let members = <Vec<Vec<Span>> as arbitrary::Arbitrary>::arbitrary_take_rest(unstructured)?;
+        let low = 0;
+        let mut high = members.len();
+
+        loop {
+            let encoding = match self.encoding {
+                Encoding::Json => serde_json::to_vec(&members[low..high])?,
+                Encoding::MsgPack => {
+                    let mut buf = Vec::with_capacity(max_bytes);
+                    members[low..high].serialize(&mut Serializer::new(&mut buf))?;
+                    buf
+                }
+            };
+            // NOTE because the type of Vec<Vec<Span>> this algorithm isn't
+            // right. We want to shrink the tree present here. This algorithm
+            // _does_ work if the tree is a straight pipe.
+            if encoding.len() > max_bytes {
+                high /= 2;
+            } else {
+                writer.write_all(&encoding)?;
+                break;
+            }
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use proptest::prelude::*;
+    use rand::{rngs::SmallRng, SeedableRng};
+
+    use crate::payload::{Serialize, TraceAgent};
+
+    // We want to be sure that the serialized size of the payload does not
+    // exceed `max_bytes`.
+    proptest! {
+        #[test]
+        fn payload_not_exceed_max_bytes_json(seed: u64, max_bytes: u16) {
+            let max_bytes = max_bytes as usize;
+            let rng = SmallRng::seed_from_u64(seed);
+            let trace_agent = TraceAgent::json();
+
+            let mut bytes = Vec::with_capacity(max_bytes);
+            trace_agent.to_bytes(rng, max_bytes, &mut bytes).unwrap();
+            debug_assert!(
+                bytes.len() <= max_bytes,
+                "{:?}",
+                std::str::from_utf8(&bytes).unwrap()
+            );
+        }
+
+        #[test]
+        fn payload_not_exceed_max_bytes_msg_pack(seed: u64, max_bytes: u16) {
+            let max_bytes = max_bytes as usize;
+            let rng = SmallRng::seed_from_u64(seed);
+            let trace_agent = TraceAgent::msg_pack();
+
+            let mut bytes = Vec::with_capacity(max_bytes);
+            trace_agent.to_bytes(rng, max_bytes, &mut bytes).unwrap();
+            debug_assert!(
+                bytes.len() <= max_bytes,
+                "{:?}",
+                std::str::from_utf8(&bytes).unwrap()
+            );
+        }
+    }
+}

--- a/src/payload/trace_agent.rs
+++ b/src/payload/trace_agent.rs
@@ -55,7 +55,7 @@ use serde::Serialize;
 // I understand correctly the `moretags` also implies that the field names are
 // camel_case in msgpack.
 
-/// TraceAgent span
+/// `TraceAgent` span
 #[derive(Arbitrary, serde::Serialize)]
 struct Span {
     /// service is the name of the service with which this span is associated.


### PR DESCRIPTION
### What does this PR do?

This commit introduces support for the Datadog Agent tracing span, defined [here](https://github.com/DataDog/datadog-agent/blob/main/pkg/trace/pb/span.proto). In practice this will be combined with the HTTP generator to POST payloads toward the Agent.

### Additional Notes

As of this commit -- as noted in the code -- the shrink algorithm in our payload creation isn't quite right, but I'm sure something will come to me tomorrow.

### Related issues

REF SMP-410
