### PR TITLE
Convert `Block` to use `Bytes` type not `Vec<u8>`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Added
 - Introduced Proportional Set Size (PSS) memory measurement under the
   `pss_bytes` metric.
+-  Convert `Block` to use `Bytes` type instead of `Vec<u8>`.
 
 ## [0.13.1-rc1]
 ##

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ async-trait = { version = "0.1", default-features = false, features = [] }
 arbitrary = { version = "1", default-features = false, features = ["derive"] }
 byte-unit = { version = "4.0", features = ["serde"] }
 bytecount = "0.6"
-bytes = { version = "1.4.0", default-features = false }
+bytes = { version = "1.4.0", default-features = false, features = ["std"] }
 clap = { version = "3.2", default-features = false, features = ["std", "color", "suggestions", "derive"] }
 flate2 = { version = "1.0.25", default-features = false, features = ["rust_backend"] }
 futures = "0.3.27"


### PR DESCRIPTION
The `Bytes` type is really useful when you need to share the underlying `Vec<u8>` without modification and our `Block` type is basically a fancy holder for `Vec<u8>` with continual clones. The idea for this occurred to me in #506 although I didn't want to include it there.

There might be other locations in our codebase where `Bytes` is more appropriate than `Vec<u8>`.
