### PR TITLE
Automatically label PRs missing a changelog entry

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,4 @@
+# Label code changes with `needs_changelog` label
+needs_changelog:
+- any: ['**.rs', '**.toml']
+  all: ['!CHANGELOG.md']

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,12 @@
+name: "Pull Request Labeler"
+on:
+- pull_request_target
+
+jobs:
+  triage:
+    permissions:
+      contents: read
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/labeler@v4


### PR DESCRIPTION
### What does this PR do?

Automatically apply the `needs_changelog` label to PRs that need a changelog entry.

### Motivation

Help keep the changelog filled in.
