### PR TITLE
Prepare release 0.13.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,13 +5,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+
+## [0.13.1]
 ## Added
 - Introduced Proportional Set Size (PSS) memory measurement under the
   `pss_bytes` metric.
--  Convert `Block` to use `Bytes` type instead of `Vec<u8>`.
-
-## [0.13.1-rc1]
-##
+- Convert `Block` to use `Bytes` type instead of `Vec<u8>`.
 - Introduce Datadog trace-agent payload support in JSON and MsgPack serialization.
 
 ## [0.13.0]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -801,7 +801,7 @@ dependencies = [
 
 [[package]]
 name = "lading"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "arbitrary",
  "async-pidfd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 
 [package]
 name = "lading"
-version = "0.13.0"
+version = "0.13.1"
 authors = ["Brian L. Troutwine <brian@troutwine.us>"]
 edition = "2021"
 license = "MIT"


### PR DESCRIPTION
## Release Notes

### Added
- Introduced Proportional Set Size (PSS) memory measurement under the
  `pss_bytes` metric.
- Convert `Block` to use `Bytes` type instead of `Vec<u8>`.
- Introduce Datadog trace-agent payload support in JSON and MsgPack serialization.

## Related issues

SMP-448
