### PR TITLE
Extend integration test timeout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,5 +94,5 @@ jobs:
       - name: Install protobuf (Brew)
         run: brew install protobuf
         if: matrix.os == 'macos-latest'
-      - run: cargo test -p
+      - run: cargo test -p sheepdog
         timeout-minutes: 30

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,4 +94,5 @@ jobs:
       - name: Install protobuf (Brew)
         run: brew install protobuf
         if: matrix.os == 'macos-latest'
-      - run: cargo test -p sheepdog
+      - run: cargo test -p
+        timeout-minutes: 30

--- a/integration/sheepdog/src/lib.rs
+++ b/integration/sheepdog/src/lib.rs
@@ -192,7 +192,7 @@ impl IntegrationTest {
     pub async fn run(self) -> Result<Metrics, anyhow::Error> {
         tokio::select! {
             res = self.run_inner() => { res }
-            _ = tokio::time::sleep(Duration::from_secs(600)) => { panic!("test timed out") }
+            _ = tokio::time::sleep(Duration::from_secs(30 * 60)) => { panic!("test timed out") }
         }
     }
 }


### PR DESCRIPTION
### What does this PR do?

The hardcoded timeout was being hit periodically in CI. This extends the timeout to 30 minutes and adds a timeout to the CI workflow.

### Motivation

Eliminate the CI flakiness that this showed up as.
