### PR TITLE
Fix globs & skip label on dependabot PRs

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,4 +1,6 @@
+# Note: the labeler workflow is configured to skip dependabot PRs
+
 # Label code changes with `needs_changelog` label
 needs_changelog:
-- any: ['**.rs', '**.toml']
+- any: ['**/*.rs', '**/*.toml']
   all: ['!CHANGELOG.md']

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -4,6 +4,7 @@ on:
 
 jobs:
   triage:
+    if: ${{ github.actor != 'dependabot[bot]' }}
     permissions:
       contents: read
       pull-requests: write


### PR DESCRIPTION
### What does this PR do?

Fix labeler globs. Skip labeler entirely for dependabot PRs.

### Related issues

#512 
