### PR TITLE
Add no-target option to lading

### DIFF
--- a/.github/workflows/regression_trusted.yml
+++ b/.github/workflows/regression_trusted.yml
@@ -312,7 +312,7 @@ jobs:
             --comparison-sha ${{ needs.compute-metadata.outputs.comparison-sha }} \
             --target-config-dir ${{ github.workspace }}/regression/ \
             --target-name lading-target \
-            --target-command /usr/local/bin/lading \
+            --target-command /usr/local/bin/lading --no-target --config-path /etc/lading-target/lading.yml \
             --submission-metadata ${{ runner.temp }}/submission-metadata
 
       - uses: actions/upload-artifact@v3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-
+## Added
+- Added a CLI flag to disable the target module
 
 ## [0.13.1]
 ## Added

--- a/src/bin/lading.rs
+++ b/src/bin/lading.rs
@@ -76,7 +76,7 @@ impl FromStr for CliKeyValues {
 #[clap(group(
     ArgGroup::new("target")
         .required(true)
-        .args(&["target-path", "target-pid"]),
+        .args(&["target-path", "target-pid", "no-target"]),
 ))]
 struct Opts {
     /// path on disk to the configuration file
@@ -88,6 +88,9 @@ struct Opts {
     /// measure an externally-launched process by PID
     #[clap(long)]
     target_pid: Option<NonZeroU32>,
+    /// disable target measurement
+    #[clap(long)]
+    no_target: bool,
     /// the path of the target executable
     #[clap(long, group = "binary-target")]
     target_path: Option<PathBuf>,
@@ -173,7 +176,9 @@ fn get_config(ops: &Opts) -> Config {
     if let Some(rss_bytes_limit) = ops.target_rss_bytes_limit {
         target::Meta::set_rss_bytes_limit(rss_bytes_limit).unwrap();
     }
-    let target = if let Some(pid) = ops.target_pid {
+    let target = if ops.no_target {
+        target::Config::None
+    } else if let Some(pid) = ops.target_pid {
         target::Config::Pid(target::PidConfig { pid })
     } else if let Some(path) = &ops.target_path {
         target::Config::Binary(target::BinaryConfig {

--- a/src/bin/lading.rs
+++ b/src/bin/lading.rs
@@ -290,10 +290,6 @@ async fn inner_main(
     //
     // GENERATOR
     //
-    assert!(
-        !config.generator.is_empty(),
-        "lading requires at least one generator in order to run"
-    );
     for cfg in config.generator {
         let tgt_rcv = tgt_snd.subscribe();
         let generator_server = generator::Server::new(cfg, shutdown.clone()).unwrap();

--- a/src/config.rs
+++ b/src/config.rs
@@ -14,6 +14,7 @@ pub struct Config {
     #[serde(default)]
     pub telemetry: Telemetry,
     /// The generator to apply to the target in-rig
+    #[serde(default)]
     #[serde(with = "serde_yaml::with::singleton_map_recursive")]
     pub generator: Vec<generator::Config>,
     /// The observer that watches the target

--- a/src/generator.rs
+++ b/src/generator.rs
@@ -156,10 +156,7 @@ impl Server {
     /// Function will return an error if the underlying sub-server signals
     /// error.
     pub async fn run(self, mut pid_snd: Receiver<u32>) -> Result<(), Error> {
-        let _ = pid_snd
-            .recv()
-            .await
-            .expect("target failed to transmit PID, catastrophic failure");
+        let _ = pid_snd.recv().await;
         drop(pid_snd);
 
         let res = match self {

--- a/src/generator.rs
+++ b/src/generator.rs
@@ -156,6 +156,7 @@ impl Server {
     /// Function will return an error if the underlying sub-server signals
     /// error.
     pub async fn run(self, mut pid_snd: Receiver<u32>) -> Result<(), Error> {
+        // Pause until the target process is running.
         let _ = pid_snd.recv().await;
         drop(pid_snd);
 

--- a/src/target.rs
+++ b/src/target.rs
@@ -138,6 +138,8 @@ pub struct BinaryConfig {
 /// Configuration for [`Server`]
 #[derive(Debug, PartialEq, Eq)]
 pub enum Config {
+    /// Disable target measurement
+    None,
     /// An existing process that is managed externally
     Pid(PidConfig),
     /// A binary that will be launched and managed directly
@@ -203,6 +205,7 @@ impl Server {
         // a critical error. Binary mode expects the target to run until
         // signalled to exit.
         match config {
+            Config::None => {}
             Config::Pid(config) => {
                 Self::watch(config, pid_snd, self.shutdown).await?;
             }

--- a/src/target.rs
+++ b/src/target.rs
@@ -138,8 +138,6 @@ pub struct BinaryConfig {
 /// Configuration for [`Server`]
 #[derive(Debug, PartialEq, Eq)]
 pub enum Config {
-    /// Disable target measurement
-    None,
     /// An existing process that is managed externally
     Pid(PidConfig),
     /// A binary that will be launched and managed directly
@@ -205,7 +203,6 @@ impl Server {
         // a critical error. Binary mode expects the target to run until
         // signalled to exit.
         match config {
-            Config::None => {}
             Config::Pid(config) => {
                 Self::watch(config, pid_snd, self.shutdown).await?;
             }


### PR DESCRIPTION
### What does this PR do?

The lading-under-test in regression detector workflows needs a target config. Options are either the measurement lading, a dummy target, or no target.

This PR chooses to add a no-target option with the intention to follow up with an 'unlimited' throttling option.

### Motivation

Regression detector bringup

### Related issues

#514 
