### PR TITLE
Set lading experiment duration

### DIFF
--- a/.github/workflows/regression_trusted.yml
+++ b/.github/workflows/regression_trusted.yml
@@ -312,7 +312,7 @@ jobs:
             --comparison-sha ${{ needs.compute-metadata.outputs.comparison-sha }} \
             --target-config-dir ${{ github.workspace }}/regression/ \
             --target-name lading-target \
-            --target-command "/usr/local/bin/lading --no-target --config-path /etc/lading-target/lading.yaml" \
+            --target-command "/usr/local/bin/lading --no-target --config-path /etc/lading-target/lading.yaml --experiment-duration-seconds 1200" \
             --submission-metadata ${{ runner.temp }}/submission-metadata
 
       - uses: actions/upload-artifact@v3


### PR DESCRIPTION
### What does this PR do?

The experiment duration is currently 600 seconds, but the target lading was exiting after the default of 120 seconds. This change makes it run to the end of the experiment.
