### PR TITLE
Run regression detector with the release candidate

### DIFF
--- a/.github/workflows/regression_trusted.yml
+++ b/.github/workflows/regression_trusted.yml
@@ -43,7 +43,7 @@ jobs:
           export P_VALUE="0.1"
           export SMP_CRATE_VERSION="0.7.2"
           export SMP_WAIT_TIMEOUT="55"
-          export LADING_VERSION="0.13.1"
+          export LADING_VERSION="0.13.2-rc1"
 
 
           echo "warmup seconds: ${WARMUP_SECONDS}"


### PR DESCRIPTION
### What does this PR do?

Update 'outer' lading with support for experiments that don't have a generator.

### Motivation

This allows `apache_common_http_to_blackhole` to function.

### Related issues

#514 

