### PR TITLE
Prepare release 0.13.2

### DIFF
--- a/.github/workflows/regression_trusted.yml
+++ b/.github/workflows/regression_trusted.yml
@@ -43,7 +43,7 @@ jobs:
           export P_VALUE="0.1"
           export SMP_CRATE_VERSION="0.7.2"
           export SMP_WAIT_TIMEOUT="55"
-          export LADING_VERSION="0.13.2-rc1"
+          export LADING_VERSION="0.13.2"
 
 
           echo "warmup seconds: ${WARMUP_SECONDS}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 
-## [0.13.2-rc1]
+## [0.13.2]
 ## Added
 - Added a CLI flag to disable the target module
 - Allow lading to run without any generators active

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+
+## [0.13.2-rc1]
 ## Added
 - Added a CLI flag to disable the target module
+- Allow lading to run without any generators active
 
 ## [0.13.1]
 ## Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -812,7 +812,7 @@ dependencies = [
 
 [[package]]
 name = "lading"
-version = "0.13.1"
+version = "0.13.2"
 dependencies = [
  "arbitrary",
  "async-pidfd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 
 [package]
 name = "lading"
-version = "0.13.1"
+version = "0.13.2"
 authors = ["Brian L. Troutwine <brian@troutwine.us>"]
 edition = "2021"
 license = "MIT"


### PR DESCRIPTION
### What does this PR do?

Release 0.13.2 that was tested in #527 

---

## [0.13.2]
## Added
- Added a CLI flag to disable the target module
- Allow lading to run without any generators active