### PR TITLE
Fixup: delete invalid experiment

### DIFF
--- a/regression/cases/apache_common_http_to_blackhole/experiment.yaml
+++ b/regression/cases/apache_common_http_to_blackhole/experiment.yaml
@@ -1,2 +1,0 @@
-optimization_goal: egress_throughput
-erratic: false


### PR DESCRIPTION
### What does this PR do?

Fixup for #530. Delete invalid Regression Detector experiment.
