### PR TITLE
Point target lading caps to `/dev/null` & use http blackhole

### DIFF
--- a/.github/workflows/regression_trusted.yml
+++ b/.github/workflows/regression_trusted.yml
@@ -312,7 +312,7 @@ jobs:
             --comparison-sha ${{ needs.compute-metadata.outputs.comparison-sha }} \
             --target-config-dir ${{ github.workspace }}/regression/ \
             --target-name lading-target \
-            --target-command "/usr/local/bin/lading --no-target --config-path /etc/lading-target/lading.yaml --experiment-duration-seconds 1200" \
+            --target-command "/usr/local/bin/lading --no-target --config-path /etc/lading-target/lading.yaml --capture-path /dev/null --experiment-duration-seconds 1200" \
             --submission-metadata ${{ runner.temp }}/submission-metadata
 
       - uses: actions/upload-artifact@v3

--- a/regression/cases/apache_common_http_both_directions_this_doesnt_make_sense/lading-target/lading.yaml
+++ b/regression/cases/apache_common_http_both_directions_this_doesnt_make_sense/lading-target/lading.yaml
@@ -5,7 +5,7 @@ generator:
       seed: [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53,
              59, 61, 67, 71, 73, 79, 83, 89, 97, 101, 103, 107, 109, 113, 127, 131]
       headers: {}
-      target_uri: "http://localhost:8080/"
+      target_uri: "http://127.0.0.1:8383/"
       bytes_per_second: "1 Gb"
       parallel_connections: 1000
       method:
@@ -14,5 +14,7 @@ generator:
           variant: "apache_common"
 
 blackhole:
-  - tcp:
-      binding_addr: "0.0.0.0:8282"
+  - http:
+      concurrent_requests_max: 1000
+      binding_addr: "127.0.0.1:8282"
+      body_variant: nothing

--- a/regression/cases/apache_common_http_both_directions_this_doesnt_make_sense/lading/lading.yaml
+++ b/regression/cases/apache_common_http_both_directions_this_doesnt_make_sense/lading/lading.yaml
@@ -7,7 +7,7 @@ generator:
       seed: [131, 2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53,
              59, 61, 67, 71, 73, 79, 83, 89, 97, 101, 103, 107, 109, 113, 127]
       headers: {}
-      target_uri: "http://localhost:8282/"
+      target_uri: "http://127.0.0.1:8282/"
       bytes_per_second: "1 Gb"
       parallel_connections: 1000
       method:
@@ -16,5 +16,7 @@ generator:
           variant: "apache_common"
 
 blackhole:
-  - tcp:
-      binding_addr: "0.0.0.0:8080"
+  - http:
+      concurrent_requests_max: 1000
+      binding_addr: "127.0.0.1:8383"
+      body_variant: nothing

--- a/regression/cases/blackhole_from_apache_common_http/lading-target/lading.yaml
+++ b/regression/cases/blackhole_from_apache_common_http/lading-target/lading.yaml
@@ -1,5 +1,7 @@
 # Configure the lading under test
 
 blackhole:
-  - tcp:
-      binding_addr: "0.0.0.0:8282"
+  - http:
+      concurrent_requests_max: 1000
+      binding_addr: "127.0.0.1:8282"
+      body_variant: nothing


### PR DESCRIPTION
### What does this PR do?

Fix both existing experiments.