### PR TITLE
Support for collecting Go Expvar target metrics

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -2,5 +2,5 @@
 
 # Label code changes with `needs_changelog` label
 needs_changelog:
-- any: ['**/*.rs', '**/*.toml']
-  all: ['!CHANGELOG.md']
+- any: ['!CHANGELOG.md']
+  all: ['**/*.rs', '**/*.toml']

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## Added
+- Added target metrics support for Go expvars
 
 ## [0.14.0]
 ## Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -376,6 +376,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90e5c1c8368803113bf0c9584fc495a58b86dc8a29edbf8fe877d21d9507e797"
 
 [[package]]
+name = "encoding_rs"
+version = "0.8.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071a31f4ee85403370b58aca746f01041ede6f0da2730960ad001edc2b71b394"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "endian-type"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -467,6 +476,15 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "form_urlencoded"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9c384f161156f5260c24a097c56119f9be8c798586aecc13afbcbe7b7e26bf8"
+dependencies = [
+ "percent-encoding",
+]
 
 [[package]]
 name = "futures"
@@ -722,6 +740,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "idna"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e14ddfc70884202db2244c223200c204c2bda1bc6e0998d11b5e024d657209e6"
+dependencies = [
+ "unicode-bidi",
+ "unicode-normalization",
+]
+
+[[package]]
 name = "indexmap"
 version = "1.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -816,6 +844,7 @@ dependencies = [
  "proptest-derive",
  "prost",
  "rand",
+ "reqwest",
  "rmp-serde",
  "serde",
  "serde_json",
@@ -1558,6 +1587,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "456c603be3e8d448b072f410900c09faf164fbce2d480456f50eea6e25f9c848"
 
 [[package]]
+name = "reqwest"
+version = "0.11.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27b71749df584b7f4cac2c426c127a7c785a5106cc98f7a8feb044115f0fa254"
+dependencies = [
+ "base64 0.21.0",
+ "bytes",
+ "encoding_rs",
+ "futures-core",
+ "futures-util",
+ "h2",
+ "http",
+ "http-body",
+ "hyper",
+ "ipnet",
+ "js-sys",
+ "log",
+ "mime",
+ "once_cell",
+ "percent-encoding",
+ "pin-project-lite",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "tokio",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "winreg",
+]
+
+[[package]]
 name = "rmp"
 version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1698,6 +1761,18 @@ dependencies = [
  "proc-macro2 1.0.52",
  "quote 1.0.26",
  "syn 1.0.107",
+]
+
+[[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
+ "serde",
 ]
 
 [[package]]
@@ -1923,6 +1998,21 @@ checksum = "fd80a657e71da814b8e5d60d3374fc6d35045062245d80224748ae522dd76f36"
 dependencies = [
  "time-core",
 ]
+
+[[package]]
+name = "tinyvec"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87cc5ceb3875bb20c2890005a4e226a4651264a5c75edb2421b52861a0a0cb50"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
@@ -2178,10 +2268,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
 
 [[package]]
+name = "unicode-bidi"
+version = "0.3.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92888ba5573ff080736b3648696b70cafad7d250551175acbaa4e0385b3e1460"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "84a22b9f218b40614adcb3f4ff08b703773ad44fa9423e4e0d346d5db86e4ebc"
+
+[[package]]
+name = "unicode-normalization"
+version = "0.1.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c5713f0fc4b5db668a2ac63cdb7bb4469d8c9fed047b1d0292cc7b0ce2ba921"
+dependencies = [
+ "tinyvec",
+]
 
 [[package]]
 name = "unicode-xid"
@@ -2194,6 +2299,17 @@ name = "unsafe-libyaml"
 version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ad2024452afd3874bf539695e04af6732ba06517424dbf958fdb16a01f3bef6c"
+
+[[package]]
+name = "url"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d68c799ae75762b8c3fe375feb6600ef5602c883c5d21eb51c09f22b83c4643"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+]
 
 [[package]]
 name = "utf8-width"
@@ -2283,6 +2399,18 @@ dependencies = [
  "quote 1.0.26",
  "syn 1.0.107",
  "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23639446165ca5a5de86ae1d8896b737ae80319560fbaa4c2887b7da6e7ebd7d"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "wasm-bindgen",
+ "web-sys",
 ]
 
 [[package]]
@@ -2455,3 +2583,12 @@ name = "windows_x86_64_msvc"
 version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "447660ad36a13288b1db4d4248e857b510e8c3a225c822ba4fb748c0aafecffd"
+
+[[package]]
+name = "winreg"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80d0f4e272c85def139476380b12f9ac60926689dd2e01d4923222f40580869d"
+dependencies = [
+ "winapi",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,7 @@ once_cell = "1.17"
 opentelemetry-proto = { git = "https://github.com/open-telemetry/opentelemetry-rust/", rev = "6078e32", features = ["traces", "metrics", "logs", "gen-tonic"] }
 prost = "0.11"
 rand = { version = "0.8", default-features = false, features = ["small_rng", "std", "std_rng"] }
+reqwest = {version = "0.11", default-features = false, features = ["json"]}
 rmp-serde = { version = "1.1", default-features = false }
 serde = { version = "1.0", features = ["std", "derive"] }
 serde_json = { version = "1.0", features = ["std"] }

--- a/src/bin/lading.rs
+++ b/src/bin/lading.rs
@@ -19,6 +19,7 @@ use lading::{
     inspector, observer,
     signals::Shutdown,
     target::{self, Behavior, Output},
+    target_metrics,
 };
 use metrics_exporter_prometheus::PrometheusBuilder;
 use rand::{rngs::StdRng, SeedableRng};
@@ -318,6 +319,21 @@ async fn inner_main(
                 match blackhole_server.run().await {
                     Ok(()) => debug!("blackhole shut down successfully"),
                     Err(err) => warn!("blackhole failed with {:?}", err),
+                }
+            });
+        }
+    }
+
+    //
+    // TARGET METRICS
+    //
+    if let Some(cfgs) = config.target_metrics {
+        for cfg in cfgs {
+            let metrics_server = target_metrics::Server::new(cfg, shutdown.clone());
+            tokio::spawn(async {
+                match metrics_server.run().await {
+                    Ok(()) => debug!("target_metrics shut down successfully"),
+                    Err(err) => warn!("target_metrics failed with {:?}", err),
                 }
             });
         }

--- a/src/config.rs
+++ b/src/config.rs
@@ -5,7 +5,7 @@ use std::{collections::HashMap, net::SocketAddr, path::PathBuf};
 
 use serde::Deserialize;
 
-use crate::{blackhole, generator, inspector, observer, target};
+use crate::{blackhole, generator, inspector, observer, target, target_metrics};
 
 /// Main configuration struct for this program
 #[derive(Debug, Default, Deserialize, Eq, PartialEq)]
@@ -27,6 +27,10 @@ pub struct Config {
     #[serde(default)]
     #[serde(with = "serde_yaml::with::singleton_map_recursive")]
     pub blackhole: Option<Vec<blackhole::Config>>,
+    /// The target_metrics to scrape from the target
+    #[serde(default)]
+    #[serde(with = "serde_yaml::with::singleton_map_recursive")]
+    pub target_metrics: Option<Vec<target_metrics::Config>>,
     /// The target inspector sub-program
     pub inspector: Option<inspector::Config>,
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -128,6 +128,7 @@ blackhole:
                 telemetry: crate::config::Telemetry::default(),
                 observer: observer::Config::default(),
                 inspector: Option::default(),
+                target_metrics: Option::default(),
             },
         );
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,4 +31,5 @@ pub mod observer;
 pub(crate) mod payload;
 pub mod signals;
 pub mod target;
+pub mod target_metrics;
 pub(crate) mod throttle;

--- a/src/target_metrics.rs
+++ b/src/target_metrics.rs
@@ -46,7 +46,8 @@ impl Server {
 
     /// Run this [`Server`] to completion
     ///
-    /// todo[gh]
+    /// The `target_metrics` server is responsible for fetching metrics directly
+    /// from the target software.
     ///
     /// # Errors
     ///

--- a/src/target_metrics.rs
+++ b/src/target_metrics.rs
@@ -25,7 +25,7 @@ pub enum Config {
     Expvar(expvar::Config),
 }
 
-/// The target_metrics server.
+/// The `target_metrics` server.
 #[derive(Debug)]
 pub enum Server {
     /// See [`crate::target_metrics::expvar::Expvar`] for details.
@@ -35,9 +35,10 @@ pub enum Server {
 impl Server {
     /// Create a new [`Server`] instance
     ///
-    /// The target_metrics `Server` is responsible for scraping metrics from
+    /// The `target_metrics::Server` is responsible for scraping metrics from
     /// the target process.
     ///
+    #[must_use]
     pub fn new(config: Config, shutdown: Shutdown) -> Self {
         match config {
             Config::Expvar(conf) => Self::Expvar(expvar::Expvar::new(conf, shutdown)),

--- a/src/target_metrics.rs
+++ b/src/target_metrics.rs
@@ -1,0 +1,64 @@
+//! Fetch metrics from the target process
+//!
+//! This module allows lading to fetch metrics from the target process and
+//! include them in the captures file.
+//!
+
+use serde::Deserialize;
+
+use crate::signals::Shutdown;
+
+pub mod expvar;
+
+#[derive(Debug, Clone, Copy)]
+/// Errors produced by [`Server`]
+pub enum Error {
+    /// See [`crate::target_metrics::expvar::Expvar`] for details.
+    Expvar(expvar::Error),
+}
+
+#[derive(Debug, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+/// Configuration for [`Server`]
+pub enum Config {
+    /// See [`crate::target_metrics::expvar::Config`] for details.
+    Expvar(expvar::Config),
+}
+
+/// The target_metrics server.
+#[derive(Debug)]
+pub enum Server {
+    /// See [`crate::target_metrics::expvar::Expvar`] for details.
+    Expvar(expvar::Expvar),
+}
+
+impl Server {
+    /// Create a new [`Server`] instance
+    ///
+    /// The target_metrics `Server` is responsible for scraping metrics from
+    /// the target process.
+    ///
+    pub fn new(config: Config, shutdown: Shutdown) -> Self {
+        match config {
+            Config::Expvar(conf) => Self::Expvar(expvar::Expvar::new(conf, shutdown)),
+        }
+    }
+
+    /// Run this [`Server`] to completion
+    ///
+    /// todo[gh]
+    ///
+    /// # Errors
+    ///
+    /// Function will return an error if the underlying metrics collector
+    /// returns an error.
+    ///
+    /// # Panics
+    ///
+    /// None are known.
+    pub async fn run(self) -> Result<(), Error> {
+        match self {
+            Server::Expvar(inner) => inner.run().await.map_err(Error::Expvar),
+        }
+    }
+}

--- a/src/target_metrics/expvar.rs
+++ b/src/target_metrics/expvar.rs
@@ -1,17 +1,24 @@
-//! Word. (todo[gh])
+//! Expvar target metrics fetcher
+//!
+//! This module scrapes Go expvar formatted metrics from the target software.
+//! The metrics are formatted as a JSON tree that is fetched over HTTP.
 
 use std::time::Duration;
 
 use metrics::gauge;
 use serde::Deserialize;
 use serde_json::Value;
-use tracing::{info, trace};
+use tracing::{error, info, trace};
 
 use crate::signals::Shutdown;
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, thiserror::Error)]
 /// Errors produced by [`Expvar`]
-pub enum Error {}
+pub enum Error {
+    /// Expvar scraper shut down unexpectedly
+    #[error("Unexpected shutdown")]
+    EarlyShutdown,
+}
 
 #[derive(Debug, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
@@ -23,7 +30,7 @@ pub struct Config {
     vars: Vec<String>,
 }
 
-/// todo[gh]
+/// The `Expvar` target metrics implementation.
 #[derive(Debug)]
 pub struct Expvar {
     config: Config,
@@ -43,43 +50,55 @@ impl Expvar {
 
     /// Run this [`Server`] to completion
     ///
-    /// todo[gh]
+    /// Scrape expvars from the target at 1Hz.
     ///
     /// # Errors
     ///
+    /// None are known.
     ///
     /// # Panics
     ///
     /// None are known.
-    pub(crate) async fn run(self) -> Result<(), Error> {
-        info!("expvar running");
+    pub(crate) async fn run(mut self) -> Result<(), Error> {
+        info!("Expvar target metrics scraper running");
         let client = reqwest::Client::new();
-        loop {
-            // todo!("handle shutdown");
 
-            tokio::time::sleep(Duration::from_secs(1)).await;
-            info!("expvar loop");
+        let server = async move {
+            loop {
+                tokio::time::sleep(Duration::from_secs(1)).await;
 
-            let resp = if let Ok(resp) = client.get(&self.config.uri).send().await {
-                resp
-            } else {
-                info!("failed to get expvar uri");
-                continue;
-            };
+                let resp = if let Ok(resp) = client.get(&self.config.uri).send().await {
+                    resp
+                } else {
+                    info!("failed to get expvar uri");
+                    continue;
+                };
 
-            let json = if let Ok(json) = resp.json::<Value>().await {
-                json
-            } else {
-                info!("failed to parse expvar json");
-                continue;
-            };
+                let json = if let Ok(json) = resp.json::<Value>().await {
+                    json
+                } else {
+                    info!("failed to parse expvar json");
+                    continue;
+                };
 
-            for var_name in self.config.vars.iter().cloned() {
-                let val = json.pointer(&var_name).and_then(|v| v.as_f64());
-                if let Some(val) = val {
-                    trace!("expvar: {} = {}", var_name, val);
-                    gauge!(var_name, val, "source" => "target_metrics/expvar");
+                for var_name in self.config.vars.iter().cloned() {
+                    let val = json.pointer(&var_name).and_then(|v| v.as_f64());
+                    if let Some(val) = val {
+                        trace!("expvar: {} = {}", var_name, val);
+                        gauge!(format!("target/{name}", name = var_name.trim_start_matches('/')), val, "source" => "target_metrics/expvar");
+                    }
                 }
+            }
+        };
+
+        tokio::select! {
+            _res = server => {
+                error!("server shutdown unexpectedly");
+                return Err(Error::EarlyShutdown);
+            }
+            _ = self.shutdown.recv() => {
+                info!("shutdown signal received");
+                return Ok(())
             }
         }
     }

--- a/src/target_metrics/expvar.rs
+++ b/src/target_metrics/expvar.rs
@@ -1,0 +1,86 @@
+//! Word. (todo[gh])
+
+use std::time::Duration;
+
+use metrics::gauge;
+use serde::Deserialize;
+use serde_json::Value;
+use tracing::{info, trace};
+
+use crate::signals::Shutdown;
+
+#[derive(Debug, Clone, Copy)]
+/// Errors produced by [`Expvar`]
+pub enum Error {}
+
+#[derive(Debug, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+/// Configuration for collecting Go Expvar based target metrics
+pub struct Config {
+    /// URI to read expvars from
+    uri: String,
+    /// Variable names to scrape
+    vars: Vec<String>,
+}
+
+/// todo[gh]
+#[derive(Debug)]
+pub struct Expvar {
+    config: Config,
+    shutdown: Shutdown,
+}
+
+impl Expvar {
+    /// Create a new [`ExpVar`] instance
+    ///
+    /// This is responsible for scraping metrics from the target process
+    /// using Go's expvar format.
+    ///
+    pub(crate) fn new(config: Config, shutdown: Shutdown) -> Self {
+        info!("expvar created");
+        Self { config, shutdown }
+    }
+
+    /// Run this [`Server`] to completion
+    ///
+    /// todo[gh]
+    ///
+    /// # Errors
+    ///
+    ///
+    /// # Panics
+    ///
+    /// None are known.
+    pub(crate) async fn run(self) -> Result<(), Error> {
+        info!("expvar running");
+        let client = reqwest::Client::new();
+        loop {
+            // todo!("handle shutdown");
+
+            tokio::time::sleep(Duration::from_secs(1)).await;
+            info!("expvar loop");
+
+            let resp = if let Ok(resp) = client.get(&self.config.uri).send().await {
+                resp
+            } else {
+                info!("failed to get expvar uri");
+                continue;
+            };
+
+            let json = if let Ok(json) = resp.json::<Value>().await {
+                json
+            } else {
+                info!("failed to parse expvar json");
+                continue;
+            };
+
+            for var_name in self.config.vars.iter().cloned() {
+                let val = json.pointer(&var_name).and_then(|v| v.as_f64());
+                if let Some(val) = val {
+                    trace!("expvar: {} = {}", var_name, val);
+                    gauge!(var_name, val, "source" => "target_metrics/expvar");
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
### What does this PR do?

Collect Go expvars from the target at runtime.

### Motivation

This allows for analysis that involves introspection into the target application.

### Related issues

SMP-461
