### PR TITLE
Adjust Datadog Log payload to use `Generator` trait

### DIFF
--- a/src/block.rs
+++ b/src/block.rs
@@ -156,12 +156,10 @@ where
         payload::Config::Ascii => {
             construct_block_cache_inner(&mut rng, &payload::Ascii::default(), block_chunks, labels)
         }
-        payload::Config::DatadogLog => construct_block_cache_inner(
-            &mut rng,
-            &payload::DatadogLog::default(),
-            block_chunks,
-            labels,
-        ),
+        payload::Config::DatadogLog => {
+            let serializer = payload::DatadogLog::new(&mut rng);
+            construct_block_cache_inner(&mut rng, &serializer, block_chunks, labels)
+        }
         payload::Config::Json => {
             construct_block_cache_inner(&mut rng, &payload::Json::default(), block_chunks, labels)
         }

--- a/src/payload.rs
+++ b/src/payload.rs
@@ -111,7 +111,6 @@ pub enum Config {
 }
 
 #[derive(Debug)]
-#[cfg_attr(test, derive(proptest_derive::Arbitrary))]
 #[allow(dead_code)]
 pub(crate) enum Payload {
     ApacheCommon(ApacheCommon),
@@ -120,9 +119,6 @@ pub(crate) enum Payload {
     Fluent(Fluent),
     Json(Json),
     SplunkHec(SplunkHec),
-    #[cfg_attr(test, proptest(skip))]
-    // No way to generate the files necessary to back Static, so avoid
-    // generating this variant entirely.
     Static(Static),
     Syslog(Syslog5424),
     OtelTraces(OpentelemetryTraces),

--- a/src/payload/datadog_logs.rs
+++ b/src/payload/datadog_logs.rs
@@ -128,7 +128,7 @@ impl Distribution<Structured> for Standard {
     }
 }
 
-#[derive(Debug, serde::Serialize, serde::Deserialize)]
+#[derive(Debug, serde::Serialize, serde::Deserialize, Clone)]
 #[serde(untagged)]
 enum Message {
     Unstructured(String),
@@ -184,9 +184,54 @@ impl Distribution<Member> for Standard {
     }
 }
 
-#[derive(Debug, Default, Clone, Copy)]
-#[cfg_attr(test, derive(proptest_derive::Arbitrary))]
-pub(crate) struct DatadogLog {}
+#[derive(Debug)]
+struct MemberGenerator {
+    messages: Vec<Message>,
+}
+
+impl MemberGenerator {
+    fn new<R>(mut rng: &mut R) -> Self
+    where
+        R: Rng + ?Sized,
+    {
+        Self {
+            messages: Standard.sample_iter(&mut rng).take(1_000).collect(),
+        }
+    }
+}
+
+impl Generator<Member> for MemberGenerator {
+    fn generate<R>(&self, rng: &mut R) -> Member
+    where
+        R: rand::Rng + ?Sized,
+    {
+        Member {
+            message: (*self.messages.choose(rng).unwrap()).clone(),
+            status: rng.gen(),
+            timestamp: rng.gen(),
+            hostname: rng.gen(),
+            service: rng.gen(),
+            ddsource: rng.gen(),
+            ddtags: (*TAG_OPTIONS.choose(rng).unwrap()).to_string(),
+        }
+    }
+}
+
+#[derive(Debug)]
+pub(crate) struct DatadogLog {
+    member_generator: MemberGenerator,
+}
+
+impl DatadogLog {
+    pub(crate) fn new<R>(rng: &mut R) -> Self
+    where
+        R: rand::Rng + ?Sized,
+    {
+        let member_generator = MemberGenerator::new(rng);
+
+        Self { member_generator }
+    }
+}
 
 impl Serialize for DatadogLog {
     fn to_bytes<W, R>(&self, mut rng: R, max_bytes: usize, writer: &mut W) -> Result<(), Error>
@@ -194,30 +239,26 @@ impl Serialize for DatadogLog {
         W: Write,
         R: Rng + Sized,
     {
-        if max_bytes < 2 {
+        let approx_member_encoded_size = 220; // bytes, determined experimentally
+
+        if max_bytes < approx_member_encoded_size {
             // 'empty' payload  is []
             return Ok(());
         }
 
-        // We will arbitrarily generate 1_000 Member instances and then
-        // serialize. If this is below `max_bytes` we'll add more until we're
-        // over. Once we are we'll start removing instances until we're back
-        // below the limit.
+        // We will arbitrarily generate Member instances and then serialize. If
+        // this is below `max_bytes` we'll add more until we're over. Once we
+        // are we'll start removing instances until we're back below the limit.
 
-        let mut members: Vec<Member> = Standard.sample_iter(&mut rng).take(1_000).collect();
-
-        // Search for too many Member instances.
-        loop {
-            let encoding = serde_json::to_string(&members)?;
-            if encoding.len() > max_bytes {
-                break;
-            }
-            members.extend(Standard.sample_iter(&mut rng).take(100));
+        let cap = (max_bytes / approx_member_encoded_size) + 100;
+        let mut members: Vec<Member> = Vec::with_capacity(cap);
+        for _ in 0..cap {
+            members.push(self.member_generator.generate(&mut rng));
         }
 
         // Search for an encoding that's just right.
         let mut high = members.len();
-        loop {
+        while high != 0 {
             let encoding = serde_json::to_string(&members[0..high])?;
             if encoding.len() > max_bytes {
                 high /= 2;
@@ -244,8 +285,8 @@ mod test {
         #[test]
         fn payload_not_exceed_max_bytes(seed: u64, max_bytes: u16) {
             let max_bytes = max_bytes as usize;
-            let rng = SmallRng::seed_from_u64(seed);
-            let ddlogs = DatadogLog::default();
+            let mut rng = SmallRng::seed_from_u64(seed);
+            let ddlogs = DatadogLog::new(&mut rng);
 
             let mut bytes = Vec::with_capacity(max_bytes);
             ddlogs.to_bytes(rng, max_bytes, &mut bytes).unwrap();
@@ -263,8 +304,8 @@ mod test {
         #[test]
         fn every_payload_deserializes(seed: u64, max_bytes: u16)  {
             let max_bytes = max_bytes as usize;
-            let rng = SmallRng::seed_from_u64(seed);
-            let ddlogs = DatadogLog::default();
+            let mut rng = SmallRng::seed_from_u64(seed);
+            let ddlogs = DatadogLog::new(&mut rng);
 
             let mut bytes: Vec<u8> = Vec::with_capacity(max_bytes);
             ddlogs.to_bytes(rng, max_bytes, &mut bytes).unwrap();


### PR DESCRIPTION
### What does this PR do?

It turns out that we call `Serializer::to_bytes` an awful lot at startup. Prior to #532 when we made new instantiated types we were doing little more than transmuting from bytes. Now, however, we perform some allocations and this process is much, much slower. A pure `Distribution` based approach for allocated types is too slow for some payloads, Datadog logs being one.

This commit adjusts the payload to use the `Generator` trait and allocate in one shot. This makes our startup time tolerable for this payload. Note also the search for serialized payload sizes includes an experimental constant but does not rely on this constant being especially accurate.

### Related issues

Extracted from #539
REF SMP-463