### PR TITLE
Release lading 0.14.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.14.0-rc9]
+## [0.14.0]
 ## Added
 - Added the ability to configure details about DogStatsD payload
 ## Changed


### PR DESCRIPTION
### What does this PR do?

This release allows the user to configure details about the DogStatsD payload in addition to carrying non-trivial performance improvements. Please see the CHANGELOG for details.
