### PR TITLE
Allow users to set weights for the kinds of DogStatsD

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -8,7 +8,7 @@ use serde::Deserialize;
 use crate::{blackhole, generator, inspector, observer, target, target_metrics};
 
 /// Main configuration struct for this program
-#[derive(Debug, Default, Deserialize, Eq, PartialEq)]
+#[derive(Debug, Default, Deserialize, PartialEq)]
 pub struct Config {
     /// The method by which to express telemetry
     #[serde(default)]

--- a/src/generator.rs
+++ b/src/generator.rs
@@ -52,7 +52,7 @@ pub enum Error {
     ProcessTree(process_tree::Error),
 }
 
-#[derive(Debug, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Deserialize, PartialEq)]
 #[serde(rename_all = "snake_case")]
 /// Configuration for [`Server`]
 pub enum Config {

--- a/src/generator/file_gen.rs
+++ b/src/generator/file_gen.rs
@@ -51,7 +51,7 @@ fn default_rotation() -> bool {
     true
 }
 
-#[derive(Debug, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Deserialize, PartialEq)]
 /// Configuration of [`FileGen`]
 pub struct Config {
     /// The seed for random operations against this target

--- a/src/generator/grpc.rs
+++ b/src/generator/grpc.rs
@@ -40,7 +40,7 @@ pub enum Error {
 }
 
 /// Config for [`Grpc`]
-#[derive(Debug, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Deserialize, PartialEq)]
 pub struct Config {
     /// The gRPC URI. Looks like http://host/service.path/endpoint
     pub target_uri: String,

--- a/src/generator/http.rs
+++ b/src/generator/http.rs
@@ -25,7 +25,7 @@ use crate::{
 static CONNECTION_SEMAPHORE: OnceCell<Semaphore> = OnceCell::new();
 
 /// The HTTP method to be used in requests
-#[derive(Debug, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Deserialize, PartialEq)]
 #[serde(rename_all = "snake_case")]
 pub enum Method {
     /// Make HTTP Post requests
@@ -37,7 +37,7 @@ pub enum Method {
     },
 }
 
-#[derive(Debug, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Deserialize, PartialEq)]
 /// Configuration of this generator.
 pub struct Config {
     /// The seed for random operations against this target

--- a/src/generator/tcp.rs
+++ b/src/generator/tcp.rs
@@ -19,7 +19,7 @@ use crate::{
     throttle::Throttle,
 };
 
-#[derive(Debug, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Deserialize, PartialEq)]
 /// Configuration of this generator.
 pub struct Config {
     /// The seed for random operations against this target

--- a/src/generator/udp.rs
+++ b/src/generator/udp.rs
@@ -20,7 +20,7 @@ use crate::{
     throttle::Throttle,
 };
 
-#[derive(Debug, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Deserialize, PartialEq)]
 /// Configuration of this generator.
 pub struct Config {
     /// The seed for random operations against this target

--- a/src/generator/unix_datagram.rs
+++ b/src/generator/unix_datagram.rs
@@ -25,7 +25,7 @@ fn default_parallel_connections() -> u16 {
     1
 }
 
-#[derive(Debug, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Deserialize, PartialEq)]
 /// Configuration of this generator.
 pub struct Config {
     /// The seed for random operations against this target

--- a/src/generator/unix_stream.rs
+++ b/src/generator/unix_stream.rs
@@ -17,7 +17,7 @@ use std::{
 use tokio::{net, task::JoinError};
 use tracing::{debug, error, info};
 
-#[derive(Debug, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Deserialize, PartialEq)]
 /// Configuration of this generator.
 pub struct Config {
     /// The seed for random operations against this target

--- a/src/payload.rs
+++ b/src/payload.rs
@@ -1,6 +1,5 @@
 use std::{
     io::{self, Write},
-    num::NonZeroUsize,
     path::PathBuf,
 };
 
@@ -25,7 +24,7 @@ mod apache_common;
 mod ascii;
 mod common;
 mod datadog_logs;
-mod dogstatsd;
+pub(crate) mod dogstatsd;
 mod fluent;
 mod json;
 mod opentelemetry_log;
@@ -64,7 +63,7 @@ pub(crate) trait Serialize {
 }
 
 /// Sub-configuration for `TraceAgent` format
-#[derive(Debug, Deserialize, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Deserialize, Clone, Copy, PartialEq)]
 #[serde(rename_all = "snake_case")]
 pub enum Encoding {
     /// Use JSON format
@@ -75,7 +74,7 @@ pub enum Encoding {
 }
 
 /// Configuration for `Payload`
-#[derive(Debug, Deserialize, Clone, PartialEq, Eq)]
+#[derive(Debug, Deserialize, Clone, PartialEq)]
 #[serde(rename_all = "snake_case")]
 pub enum Config {
     /// Generates Fluent messages
@@ -106,18 +105,7 @@ pub enum Config {
     OpentelemetryMetrics,
     /// Generates DogStatsD
     #[serde(rename = "dogstatsd")]
-    DogStatsD {
-        /// Defines the minimum number of metric names allowed in a payload.
-        metric_names_minimum: Option<NonZeroUsize>,
-        /// Defines the maximum number of metric names allowed in a
-        /// payload. Must be greater or equal to minimum.
-        metric_names_maximum: Option<NonZeroUsize>,
-        /// Defines the minimum number of metric names allowed in a payload.
-        tag_keys_minimum: Option<usize>,
-        /// Defines the maximum number of metric names allowed in a
-        /// payload. Must be greater or equal to minimum.
-        tag_keys_maximum: Option<usize>,
-    },
+    DogStatsD(crate::payload::dogstatsd::Config),
     /// Generates TraceAgent payloads in JSON format
     TraceAgent(Encoding),
 }

--- a/src/payload/dogstatsd.rs
+++ b/src/payload/dogstatsd.rs
@@ -251,7 +251,7 @@ mod test {
     use proptest::prelude::*;
     use rand::{rngs::SmallRng, SeedableRng};
 
-    use crate::payload::{DogStatsD, Serialize};
+    use crate::payload::{dogstatsd::KindWeights, DogStatsD, Serialize};
 
     // We want to be sure that the serialized size of the payload does not
     // exceed `max_bytes`.
@@ -262,7 +262,8 @@ mod test {
             let mut rng = SmallRng::seed_from_u64(seed);
             let metric_names_range =  NonZeroUsize::new(1).unwrap()..NonZeroUsize::new(64).unwrap();
             let tag_keys_range =  0..32;
-            let dogstatsd = DogStatsD::new(metric_names_range, tag_keys_range, &mut rng);
+            let kind_weights = KindWeights { metric: 2, event: 1, service_check: 1};
+            let dogstatsd = DogStatsD::new(metric_names_range, tag_keys_range, kind_weights, &mut rng);
 
             let mut bytes = Vec::with_capacity(max_bytes);
             dogstatsd.to_bytes(rng, max_bytes, &mut bytes).unwrap();


### PR DESCRIPTION
### What does this PR do?

This commit allows a user to set the probability of, say, a DogStatsD metric being created in a payload compared to a service-check. The ambition here is to allow for experiments that produce only metrics, or mostly service-checks etc. We preserve the existing behavior by weighting all kinds equally.

### Additional Notes

I have adjusted how we parse the dogstatsd payload config, making more field optional, preserving backward compatibility overall.

### Related issues

REF SMP-513
