### PR TITLE
Slightly adjust AsciiString alphabet

### DIFF
--- a/src/payload/common.rs
+++ b/src/payload/common.rs
@@ -2,7 +2,7 @@ use rand::seq::SliceRandom;
 
 use super::Generator;
 
-const CHARSET: &[u8] = b"abcdefghijklmnopqrstuvwxyz ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789().,";
+const CHARSET: &[u8] = b"abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
 
 #[derive(Debug, PartialEq)]
 pub(crate) struct AsciiString {


### PR DESCRIPTION
### What does this PR do?

This commit removes non-letter, non-number characters from the AsciiString pool. This is intended to correct a situation where we would sometimes generate invalid DogStatsD metric names. We might consider intentionally constructing metric names et al from a more explicit grammar but this is an acceptable and relatively easy fix.

### Related issues

REF SMP-514
