### PR TITLE
Introduce metric weighting in dogstatsd payload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [0.15.1-rc1]
+### Added
 - Added the ability for users to configure DogStatsD payload kind ratios
 - Added the ability for users to configure DogStatsd metric kind ratios
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- Added the ability for users to configure DogStatsD payload kind ratios
+- Added the ability for users to configure DogStatsd metric kind ratios
 
 ## [0.15.0]
 ### Added

--- a/src/block.rs
+++ b/src/block.rs
@@ -135,11 +135,18 @@ where
             tag_keys_minimum,
             tag_keys_maximum,
             kind_weights,
+            metric_weights,
         }) => {
             let mn_range = *metric_names_minimum..*metric_names_maximum;
             let tg_range = *tag_keys_minimum..*tag_keys_maximum;
 
-            let serializer = payload::DogStatsD::new(mn_range, tg_range, *kind_weights, &mut rng);
+            let serializer = payload::DogStatsD::new(
+                mn_range,
+                tg_range,
+                *kind_weights,
+                *metric_weights,
+                &mut rng,
+            );
 
             construct_block_cache_inner(&mut rng, &serializer, block_chunks, labels)
         }

--- a/src/payload/dogstatsd.rs
+++ b/src/payload/dogstatsd.rs
@@ -297,7 +297,10 @@ mod test {
     use proptest::prelude::*;
     use rand::{rngs::SmallRng, SeedableRng};
 
-    use crate::payload::{dogstatsd::KindWeights, DogStatsD, Serialize};
+    use crate::payload::{
+        dogstatsd::{KindWeights, MetricWeights},
+        DogStatsD, Serialize,
+    };
 
     // We want to be sure that the serialized size of the payload does not
     // exceed `max_bytes`.
@@ -308,8 +311,9 @@ mod test {
             let mut rng = SmallRng::seed_from_u64(seed);
             let metric_names_range =  NonZeroUsize::new(1).unwrap()..NonZeroUsize::new(64).unwrap();
             let tag_keys_range =  0..32;
-            let kind_weights = KindWeights { metric: 2, event: 1, service_check: 1};
-            let dogstatsd = DogStatsD::new(metric_names_range, tag_keys_range, kind_weights, &mut rng);
+            let kind_weights = KindWeights::default();
+            let metric_weights = MetricWeights::default();
+            let dogstatsd = DogStatsD::new(metric_names_range, tag_keys_range, kind_weights, metric_weights,  &mut rng);
 
             let mut bytes = Vec::with_capacity(max_bytes);
             dogstatsd.to_bytes(rng, max_bytes, &mut bytes).unwrap();

--- a/src/payload/dogstatsd/metric.rs
+++ b/src/payload/dogstatsd/metric.rs
@@ -1,6 +1,10 @@
 use std::fmt;
 
-use rand::{distributions::Standard, prelude::Distribution, seq::SliceRandom};
+use rand::{
+    distributions::{Standard, WeightedIndex},
+    prelude::Distribution,
+    seq::SliceRandom,
+};
 
 use crate::payload::Generator;
 
@@ -8,6 +12,7 @@ use super::{choose_or_not, common};
 
 #[derive(Debug, Clone)]
 pub(crate) struct MetricGenerator {
+    pub(crate) metric_weights: WeightedIndex<u8>,
     pub(crate) names: Vec<String>,
     pub(crate) container_ids: Vec<String>,
     pub(crate) tags: Vec<common::tags::Tags>,
@@ -26,7 +31,7 @@ impl Generator<Metric> for MetricGenerator {
         let value: Vec<common::NumValue> =
             Standard.sample_iter(&mut rng).take(total_values).collect();
 
-        match rng.gen_range(0..6) {
+        match self.metric_weights.sample(rng) {
             0 => Metric::Count(Count {
                 name,
                 value,


### PR DESCRIPTION
### What does this PR do?

This commit allows the user to specify the relative ratios of the metric variants in dogstatsd payload. This is a follow-up from #569.

### Related issues

REF SMP-515
