### PR TITLE
All out throttle

### DIFF
--- a/src/throttle.rs
+++ b/src/throttle.rs
@@ -11,8 +11,10 @@ mod predictive;
 /// Configuration of this generator.
 #[serde(rename_all = "snake_case")]
 pub enum Config {
-    /// Create a throttle that predicts target capability
+    /// A throttle that predicts target capability
     Predictive,
+    /// A throttle that allows the user to produce as fast as possible.
+    AllOut,
 }
 
 impl Default for Config {
@@ -74,6 +76,7 @@ impl Clock for RealClock {
 #[derive(Debug)]
 pub(crate) enum Throttle<C = RealClock> {
     Predictive(predictive::Predictive<C>),
+    AllOut,
 }
 
 impl Throttle<RealClock> {
@@ -87,6 +90,7 @@ impl Throttle<RealClock> {
                 maximum_capacity,
                 RealClock::default(),
             )),
+            Config::AllOut => Throttle::AllOut,
         }
     }
 }
@@ -101,6 +105,7 @@ where
     pub(crate) async fn wait(&mut self) -> Result<(), Error> {
         match self {
             Throttle::Predictive(inner) => inner.wait().await?,
+            Throttle::AllOut => (),
         }
 
         Ok(())
@@ -111,6 +116,7 @@ where
     pub(crate) async fn wait_for(&mut self, request: NonZeroU32) -> Result<(), Error> {
         match self {
             Throttle::Predictive(inner) => inner.wait_for(request).await?,
+            Throttle::AllOut => (),
         }
 
         Ok(())

--- a/src/throttle/predictive.rs
+++ b/src/throttle/predictive.rs
@@ -9,7 +9,7 @@ use super::{Clock, RealClock};
 
 const INTERVAL_TICKS: u64 = 1_000_000;
 
-/// Errors produced by [`Throttle`].
+/// Errors produced by [`Predictive`].
 #[derive(thiserror::Error, Debug, Clone, Copy)]
 pub(crate) enum Error {
     /// Requested capacity is greater than maximum allowed capacity.


### PR DESCRIPTION
### What does this PR do?

This PR builds on https://github.com/DataDog/lading/pull/573 and introduces a throttle that allows the caller to go as
fast as possible. There is actually no throttle here, per se, only a
configuration option and a branch.

### Additional Notes

Please review #573 before this one. 

### Related issues

REF [SMP-520](https://datadoghq.atlassian.net/browse/SMP-520)
REF [SMP-521](https://datadoghq.atlassian.net/browse/SMP-521)


[SMP-520]: https://datadoghq.atlassian.net/browse/SMP-520?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SMP-521]: https://datadoghq.atlassian.net/browse/SMP-521?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ