### PR TITLE
Release 0.15.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,14 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.15.1-rc2]
+## [0.15.1]
 ### Added
 - Add 'stable' throttle
 - Add 'all-out' throttle
 - Allow users to configure generators to use the various throttles
-
-## [0.15.1-rc1]
-### Added
 - Added the ability for users to configure DogStatsD payload kind ratios
 - Added the ability for users to configure DogStatsd metric kind ratios
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -825,7 +825,7 @@ dependencies = [
 
 [[package]]
 name = "lading"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "async-pidfd",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 
 [package]
 name = "lading"
-version = "0.15.0"
+version = "0.15.1"
 authors = ["Brian L. Troutwine <brian@troutwine.us>"]
 edition = "2021"
 license = "MIT"


### PR DESCRIPTION
### What does this PR do?

This commit introduces changes to the throttle mechanism and expands on the configuration possibilities open to users in the DogStatsD payload.