### PR TITLE
Always include at least one value in a DogStastD metric

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Disallow the creation of DogStatsD metrics with no values
 
 ## [0.15.1]
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [0.15.2-rc1]
 ### Fixed
 - Disallow the creation of DogStatsD metrics with no values
 

--- a/src/payload/dogstatsd/metric.rs
+++ b/src/payload/dogstatsd/metric.rs
@@ -27,7 +27,7 @@ impl Generator<Metric> for MetricGenerator {
         let name = self.names.choose(&mut rng).unwrap().clone();
         let tags = choose_or_not(&mut rng, &self.tags);
         let sample_rate = rng.gen();
-        let total_values = rng.gen_range(0..32);
+        let total_values = rng.gen_range(1..32);
         let value: Vec<common::NumValue> =
             Standard.sample_iter(&mut rng).take(total_values).collect();
 


### PR DESCRIPTION
### What does this PR do?

This commit fixes a bug in the last release. We allowed for the creation of DogStatsD metrics that have no values associated with them with probability 1/33. We now require at least one value and do not adjust the maximum of 32.

### Related issues

REF SMP-527
