### PR TITLE
Release lading 0.15.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.15.2-rc1]
+## [0.15.2]
 ### Fixed
 - Disallow the creation of DogStatsD metrics with no values
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -825,7 +825,7 @@ dependencies = [
 
 [[package]]
 name = "lading"
-version = "0.15.1"
+version = "0.15.2"
 dependencies = [
  "async-pidfd",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 
 [package]
 name = "lading"
-version = "0.15.1"
+version = "0.15.2"
 authors = ["Brian L. Troutwine <brian@troutwine.us>"]
 edition = "2021"
 license = "MIT"


### PR DESCRIPTION
### What does this PR do?

This commit fixes a bug where we may create DogStatsD metrics with no values, release 0.15.2.
