### PR TITLE
Share pre-computed block between file write children

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,13 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.15.3-rc2]
+## [0.15.3]
 ### Changed
 - Reduced the CPU time that `file_gen` consumes at the expense of slightly
   longer flush-to-disk times.
-
-## [0.15.3-rc1]
-### Changed
 - `file_gen` now shares its pre-computed block between write children, reducing
   memory consumption.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.15.3-rc1]
+### Changed
+- `file_gen` now shares its pre-computed block between write children, reducing
+  memory consumption.
+
 ## [0.15.2]
 ### Fixed
 - Disallow the creation of DogStatsD metrics with no values

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.15.3-rc2]
+### Changed
+- Reduced the CPU time that `file_gen` consumes at the expense of slightly
+  longer flush-to-disk times.
+
 ## [0.15.3-rc1]
 ### Changed
 - `file_gen` now shares its pre-computed block between write children, reducing

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -819,7 +819,7 @@ dependencies = [
 
 [[package]]
 name = "lading"
-version = "0.15.2"
+version = "0.15.3"
 dependencies = [
  "async-pidfd",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -218,12 +218,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "bytecount"
-version = "0.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c676a478f63e9fa2dd5368a42f28bba0d6c560b775f38583c8bbaa7fcd67c9c"
-
-[[package]]
 name = "byteorder"
 version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -830,7 +824,6 @@ dependencies = [
  "async-pidfd",
  "async-trait",
  "byte-unit",
- "bytecount",
  "bytes",
  "clap",
  "flate2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,6 @@ description = "A tool for load testing daemons."
 [dependencies]
 async-trait = { version = "0.1", default-features = false, features = [] }
 byte-unit = { version = "4.0", features = ["serde"] }
-bytecount = "0.6"
 bytes = { version = "1.4.0", default-features = false, features = ["std"] }
 clap = { version = "3.2", default-features = false, features = ["std", "color", "suggestions", "derive"] }
 flate2 = { version = "1.0.26", default-features = false, features = ["rust_backend"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 
 [package]
 name = "lading"
-version = "0.15.2"
+version = "0.15.3"
 authors = ["Brian L. Troutwine <brian@troutwine.us>"]
 edition = "2021"
 license = "MIT"

--- a/src/block.rs
+++ b/src/block.rs
@@ -21,13 +21,7 @@ impl From<ChunkError> for Error {
 #[derive(Debug)]
 pub(crate) struct Block {
     pub(crate) total_bytes: NonZeroU32,
-    pub(crate) lines: u64,
     pub(crate) bytes: Bytes,
-}
-
-#[inline]
-fn total_newlines(input: &[u8]) -> u64 {
-    bytecount::count(input, b'\n') as u64
 }
 
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
@@ -245,12 +239,7 @@ where
             continue;
         }
         let total_bytes = NonZeroU32::new(bytes.len().try_into().unwrap()).unwrap();
-        let newlines = total_newlines(&bytes);
-        block_cache.push(Block {
-            total_bytes,
-            lines: newlines,
-            bytes,
-        });
+        block_cache.push(Block { total_bytes, bytes });
     }
     assert!(!block_cache.is_empty());
     gauge!("block_construction_complete", 1.0, labels);

--- a/src/generator/file_gen.rs
+++ b/src/generator/file_gen.rs
@@ -156,18 +156,18 @@ impl FileGen {
 
         let mut handles = Vec::new();
         let file_index = Arc::new(AtomicU32::new(0));
+        let block_cache = construct_block_cache(&mut rng, &config.variant, &block_chunks, &labels);
+        let block_cache = Arc::new(block_cache);
+
         for _ in 0..config.duplicates {
             let throttle = Throttle::new_with_config(config.throttle, bytes_per_second);
-
-            let block_cache =
-                construct_block_cache(&mut rng, &config.variant, &block_chunks, &labels);
 
             let child = Child {
                 path_template: config.path_template.clone(),
                 maximum_bytes_per_file,
                 bytes_per_second,
                 throttle,
-                block_cache,
+                block_cache: Arc::clone(&block_cache),
                 file_index: Arc::clone(&file_index),
                 rotate: config.rotate,
                 shutdown: shutdown.clone(),
@@ -210,7 +210,7 @@ struct Child {
     maximum_bytes_per_file: NonZeroU32,
     bytes_per_second: NonZeroU32,
     throttle: Throttle,
-    block_cache: Vec<Block>,
+    block_cache: Arc<Vec<Block>>,
     rotate: bool,
     file_index: Arc<AtomicU32>,
     shutdown: Shutdown,


### PR DESCRIPTION
### What does this PR do?

Previously we constructed a separate block cache for each write child in `file_gen`. This meant as we got more duplicate file writes we increased the memory by the prebuild cache size. This lead to situations where lading would OOM if the number of write children were high enough.

### Related issues

REF SMP-558
