### PR TITLE
Log datagram connect errors as errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+### Changed
+- Unix datagram connect errors are now logged at the `error` level.
+
 ## [0.16.0]
 ### Added
 - `Generators` and `Blackholes` now support an `id` configuration field. This

--- a/src/generator/unix_datagram.rs
+++ b/src/generator/unix_datagram.rs
@@ -19,7 +19,7 @@ use tokio::{
     net,
     task::{JoinError, JoinHandle},
 };
-use tracing::{debug, error, info, trace};
+use tracing::{debug, error, info};
 
 use super::General;
 
@@ -193,7 +193,7 @@ impl Child {
                     break;
                 }
                 Err(err) => {
-                    trace!(
+                    error!(
                         "Unable to connect to socket {path}: {err}",
                         path = &self.path.display()
                     );


### PR DESCRIPTION
### What does this PR do?

Datagram connect errors were previously hidden at `trace` level. This PR bumps that up to `error` level to surface them.
