### PR TITLE
Fix hang in no-target mode & wait for startup in `unix_datagram` generator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+
+## [0.16.1]
 ### Changed
 - Unix datagram connect errors are now logged at the `error` level.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - No-target mode no longer hangs at startup
 - The `unix_datagram` generator doesn't start generating data until the target is running.
+- Panic fixed in `unix_datagram` generator
 
 ## [0.16.0]
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Unix datagram connect errors are now logged at the `error` level.
 
+### Fixed
+- No-target mode no longer hangs at startup
+- The `unix_datagram` generator doesn't start generating data until the target is running.
+
 ## [0.16.0]
 ### Added
 - `Generators` and `Blackholes` now support an `id` configuration field. This

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -826,7 +826,7 @@ dependencies = [
 
 [[package]]
 name = "lading"
-version = "0.16.0"
+version = "0.16.1"
 dependencies = [
  "async-pidfd",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,13 +1,9 @@
 [workspace]
-members = [
-    "./",
-    "integration/sheepdog",
-    "integration/ducks",
-]
+members = ["./", "integration/sheepdog", "integration/ducks"]
 
 [package]
 name = "lading"
-version = "0.16.0"
+version = "0.16.1"
 authors = ["Brian L. Troutwine <brian@troutwine.us>"]
 edition = "2021"
 license = "MIT"
@@ -20,22 +16,40 @@ description = "A tool for load testing daemons."
 async-trait = { version = "0.1", default-features = false, features = [] }
 byte-unit = { version = "4.0", features = ["serde"] }
 bytes = { version = "1.4.0", default-features = false, features = ["std"] }
-clap = { version = "3.2", default-features = false, features = ["std", "color", "suggestions", "derive"] }
-flate2 = { version = "1.0.26", default-features = false, features = ["rust_backend"] }
+clap = { version = "3.2", default-features = false, features = [
+    "std",
+    "color",
+    "suggestions",
+    "derive",
+] }
+flate2 = { version = "1.0.26", default-features = false, features = [
+    "rust_backend",
+] }
 futures = "0.3.28"
 http = "0.2"
 http-serde = "1.1"
 hyper = { version = "0.14", features = ["client"] }
 is_executable = "1.0.1"
 metrics = { version = "0.21", default-features = false }
-metrics-exporter-prometheus = { version = "0.12.1", default-features = false, features = ["http-listener"] }
+metrics-exporter-prometheus = { version = "0.12.1", default-features = false, features = [
+    "http-listener",
+] }
 metrics-util = { version = "0.15" }
 nix = { version = "0.26" }
 once_cell = "1.18"
-opentelemetry-proto = { git = "https://github.com/open-telemetry/opentelemetry-rust/", rev = "6078e32", features = ["traces", "metrics", "logs", "gen-tonic"] }
+opentelemetry-proto = { git = "https://github.com/open-telemetry/opentelemetry-rust/", rev = "6078e32", features = [
+    "traces",
+    "metrics",
+    "logs",
+    "gen-tonic",
+] }
 prost = "0.11"
-rand = { version = "0.8", default-features = false, features = ["small_rng", "std", "std_rng"] }
-reqwest = {version = "0.11", default-features = false, features = ["json"]}
+rand = { version = "0.8", default-features = false, features = [
+    "small_rng",
+    "std",
+    "std_rng",
+] }
+reqwest = { version = "0.11", default-features = false, features = ["json"] }
 rmp-serde = { version = "1.1", default-features = false }
 serde = { version = "1.0", features = ["std", "derive"] }
 serde_json = { version = "1.0", features = ["std"] }
@@ -44,13 +58,27 @@ serde_tuple = { version = "0.5", default-features = false }
 serde_yaml = "0.9"
 thiserror = { version = "1.0" }
 time = { version = "0.3", features = ["formatting"] }
-tokio = { version = "1.28", features = ["rt", "rt-multi-thread", "macros", "fs", "io-util", "process", "signal", "time", "net"] }
+tokio = { version = "1.28", features = [
+    "rt",
+    "rt-multi-thread",
+    "macros",
+    "fs",
+    "io-util",
+    "process",
+    "signal",
+    "time",
+    "net",
+] }
 tokio-util = { version = "0.7", features = ["io"] }
 tonic = { version = "0.9" }
-tower = { version = "0.4", default-features = false, features = ["timeout", "limit", "load-shed"] }
+tower = { version = "0.4", default-features = false, features = [
+    "timeout",
+    "limit",
+    "load-shed",
+] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["std", "env-filter"] }
-uuid =  { version = "1.3", features = ["serde", "v4"] }
+uuid = { version = "1.3", features = ["serde", "v4"] }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 procfs = { version = "0.15", default-features = false, features = [] }

--- a/src/bin/lading.rs
+++ b/src/bin/lading.rs
@@ -286,7 +286,7 @@ async fn inner_main(
     // * the "observer" which reads procfs on Linux and reports relevant process
     //   detail to the capture log
 
-    let (tgt_snd, _) = broadcast::channel(1);
+    let (tgt_snd, _tgt_rcv) = broadcast::channel(1);
 
     //
     // GENERATOR

--- a/src/bin/lading.rs
+++ b/src/bin/lading.rs
@@ -355,6 +355,10 @@ async fn inner_main(
         let tsrv = tokio::spawn(target_server.run(tgt_snd));
         futures::future::Either::Left(tsrv)
     } else {
+        // Many lading servers synchronize on target startup.
+        tgt_snd
+            .send(None)
+            .expect("unable to transmit startup sync signal, catastrophic failure");
         futures::future::Either::Right(futures::future::pending())
     };
 

--- a/src/generator.rs
+++ b/src/generator.rs
@@ -11,10 +11,9 @@
 //! experimental control.
 
 use serde::Deserialize;
-use tokio::sync::broadcast::Receiver;
 use tracing::error;
 
-use crate::signals::Shutdown;
+use crate::{signals::Shutdown, target::TargetPidReceiver};
 
 pub mod file_gen;
 pub mod file_tree;
@@ -186,7 +185,7 @@ impl Server {
     ///
     /// Function will return an error if the underlying sub-server signals
     /// error.
-    pub async fn run(self, mut pid_snd: Receiver<u32>) -> Result<(), Error> {
+    pub async fn run(self, mut pid_snd: TargetPidReceiver) -> Result<(), Error> {
         // Pause until the target process is running.
         let _ = pid_snd.recv().await;
         drop(pid_snd);

--- a/src/generator/unix_stream.rs
+++ b/src/generator/unix_stream.rs
@@ -174,6 +174,7 @@ impl UnixStream {
                     // buffer.
                     let blk_max: usize = total_bytes.get() as usize;
                     let mut blk_offset = 0;
+                    let blk = blocks.next().unwrap(); // advance to the block that was previously peeked
                     while blk_offset < blk_max {
                         let stream = unix_stream.unwrap();
                         unix_stream = None;
@@ -184,7 +185,6 @@ impl UnixStream {
                             .map_err(Error::Io)
                             .unwrap(); // Cannot ? in a spawned task :<. Mimics UDP generator.
                         if ready.is_writable() {
-                            let blk = blocks.next().unwrap(); // actually advance through the blocks
                             // Try to write data, this may still fail with `WouldBlock`
                             // if the readiness event is a false positive.
                             match stream.try_write(&blk.bytes[blk_offset..]) {


### PR DESCRIPTION
### What does this PR do?

Running `lading` in no-target mode would previously cause a hang if any lading `Servers` were waiting on the PID sender broadcast channel. This is the main point of synchronization in lading startup. This is modified to send an `Option::None` in no-target mode.

This PR also adds a synchronization step to the `unix_datagram` generator. Its behavior now matches other generators and will wait for `fn spin` to be called before running. It previously started running as soon as it was created.
