### PR TITLE
Add labels to throttle metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Changed
+- Throttle metrics are now labeled with the respective generator's labels.
 
 ## [0.16.1]
 ### Changed

--- a/src/generator/file_gen.rs
+++ b/src/generator/file_gen.rs
@@ -159,13 +159,19 @@ impl FileGen {
             &block_sizes,
         )?;
 
+        let labels = vec![
+            ("component".to_string(), "generator".to_string()),
+            ("component_name".to_string(), "file_gen".to_string()),
+        ];
+
         let mut handles = Vec::new();
         let file_index = Arc::new(AtomicU32::new(0));
         let block_cache = construct_block_cache(&mut rng, &config.variant, &block_chunks, &labels);
         let block_cache = Arc::new(block_cache);
 
         for _ in 0..config.duplicates {
-            let throttle = Throttle::new_with_config(config.throttle, bytes_per_second);
+            let throttle =
+                Throttle::new_with_config(config.throttle, bytes_per_second, labels.clone());
 
             let child = Child {
                 path_template: config.path_template.clone(),

--- a/src/generator/file_tree.rs
+++ b/src/generator/file_tree.rs
@@ -130,8 +130,15 @@ impl FileTree {
         let mut rng = StdRng::from_seed(config.seed);
         let (nodes, _total_files, total_folder) = generate_tree(&mut rng, config);
 
-        let open_throttle = Throttle::new_with_config(config.throttle, config.open_per_second);
-        let rename_throttle = Throttle::new_with_config(config.throttle, config.rename_per_second);
+        let labels = vec![
+            ("component".to_string(), "generator".to_string()),
+            ("component_name".to_string(), "file_tree".to_string()),
+        ];
+
+        let open_throttle =
+            Throttle::new_with_config(config.throttle, config.open_per_second, labels.clone());
+        let rename_throttle =
+            Throttle::new_with_config(config.throttle, config.rename_per_second, labels);
         Ok(Self {
             name_len: config.name_len,
             open_throttle,

--- a/src/generator/grpc.rs
+++ b/src/generator/grpc.rs
@@ -190,7 +190,7 @@ impl Grpc {
             .cloned()
             .expect("target_uri should have an RPC path");
 
-        let throttle = Throttle::new_with_config(config.throttle, bytes_per_second);
+        let throttle = Throttle::new_with_config(config.throttle, bytes_per_second, labels.clone());
         Ok(Self {
             target_uri,
             rpc_path,

--- a/src/generator/http.rs
+++ b/src/generator/http.rs
@@ -163,7 +163,11 @@ impl Http {
                     method: hyper::Method::POST,
                     headers: config.headers,
                     block_cache,
-                    throttle: Throttle::new_with_config(config.throttle, bytes_per_second),
+                    throttle: Throttle::new_with_config(
+                        config.throttle,
+                        bytes_per_second,
+                        labels.clone(),
+                    ),
                     metric_labels: labels,
                     shutdown,
                 })

--- a/src/generator/process_tree.rs
+++ b/src/generator/process_tree.rs
@@ -262,7 +262,13 @@ impl ProcessTree {
             Err(e) => return Err(Error::from(e)),
         };
 
-        let throttle = Throttle::new_with_config(config.throttle, config.max_tree_per_second);
+        let labels = vec![
+            ("component".to_string(), "generator".to_string()),
+            ("component_name".to_string(), "process_tree".to_string()),
+        ];
+
+        let throttle =
+            Throttle::new_with_config(config.throttle, config.max_tree_per_second, labels);
         match serde_yaml::to_string(config) {
             Ok(serialized) => Ok(Self {
                 lading_path,

--- a/src/generator/splunk_hec.rs
+++ b/src/generator/splunk_hec.rs
@@ -200,7 +200,7 @@ impl SplunkHec {
             uri,
             token: config.token,
             block_cache,
-            throttle: Throttle::new_with_config(config.throttle, bytes_per_second),
+            throttle: Throttle::new_with_config(config.throttle, bytes_per_second, labels.clone()),
             metric_labels: labels,
             shutdown,
         })

--- a/src/generator/tcp.rs
+++ b/src/generator/tcp.rs
@@ -131,7 +131,7 @@ impl Tcp {
         Ok(Self {
             addr,
             block_cache,
-            throttle: Throttle::new_with_config(config.throttle, bytes_per_second),
+            throttle: Throttle::new_with_config(config.throttle, bytes_per_second, labels.clone()),
             metric_labels: labels,
             shutdown,
         })

--- a/src/generator/udp.rs
+++ b/src/generator/udp.rs
@@ -130,7 +130,7 @@ impl Udp {
         Ok(Self {
             addr,
             block_cache,
-            throttle: Throttle::new_with_config(config.throttle, bytes_per_second),
+            throttle: Throttle::new_with_config(config.throttle, bytes_per_second, labels.clone()),
             metric_labels: labels,
             shutdown,
         })

--- a/src/generator/unix_datagram.rs
+++ b/src/generator/unix_datagram.rs
@@ -149,7 +149,11 @@ impl UnixDatagram {
             let child = Child {
                 path: config.path.clone(),
                 block_cache,
-                throttle: Throttle::new_with_config(config.throttle, bytes_per_second),
+                throttle: Throttle::new_with_config(
+                    config.throttle,
+                    bytes_per_second,
+                    labels.clone(),
+                ),
                 metric_labels: labels.clone(),
                 shutdown: shutdown.clone(),
             };

--- a/src/generator/unix_stream.rs
+++ b/src/generator/unix_stream.rs
@@ -124,7 +124,7 @@ impl UnixStream {
         Ok(Self {
             path: config.path,
             block_cache,
-            throttle: Throttle::new_with_config(config.throttle, bytes_per_second),
+            throttle: Throttle::new_with_config(config.throttle, bytes_per_second, labels.clone()),
             metric_labels: labels,
             shutdown,
         })

--- a/src/throttle.rs
+++ b/src/throttle.rs
@@ -86,15 +86,21 @@ pub(crate) enum Throttle<C = RealClock> {
 }
 
 impl Throttle<RealClock> {
-    pub(crate) fn new_with_config(config: Config, maximum_capacity: NonZeroU32) -> Self {
+    pub(crate) fn new_with_config(
+        config: Config,
+        maximum_capacity: NonZeroU32,
+        labels: Vec<(String, String)>,
+    ) -> Self {
         match config {
             Config::Predictive => Throttle::Predictive(predictive::Predictive::with_clock(
                 maximum_capacity,
                 RealClock::default(),
+                labels,
             )),
             Config::Stable => Throttle::Stable(stable::Stable::with_clock(
                 maximum_capacity,
                 RealClock::default(),
+                labels,
             )),
             Config::AllOut => Throttle::AllOut,
         }

--- a/src/throttle/stable.rs
+++ b/src/throttle/stable.rs
@@ -29,6 +29,8 @@ pub(crate) struct Stable<C = RealClock> {
     refill_per_tick: u64,
     /// The clock that `Stable` will use.
     clock: C,
+    /// Metrics labels
+    labels: Vec<(String, String)>,
 }
 
 impl<C> Stable<C>
@@ -49,7 +51,11 @@ where
         // they draw down more than is available in the bucket they're made to
         // wait.
 
-        gauge!("throttle_refills_per_tick", self.refill_per_tick as f64);
+        gauge!(
+            "throttle_refills_per_tick",
+            self.refill_per_tick as f64,
+            &self.labels
+        );
 
         // Fast bail-out. There's no way for this to ever be satisfied and is a
         // bug on the part of the caller, arguably.
@@ -88,7 +94,11 @@ where
         Ok(())
     }
 
-    pub(crate) fn with_clock(maximum_capacity: NonZeroU32, clock: C) -> Self {
+    pub(crate) fn with_clock(
+        maximum_capacity: NonZeroU32,
+        clock: C,
+        labels: Vec<(String, String)>,
+    ) -> Self {
         // We set the maximum capacity of the bucket, X. We say that an
         // 'interval' happens once every second. If we allow for the tick of
         // Throttle to be one per microsecond that's 1x10^6 ticks per interval.
@@ -103,6 +113,7 @@ where
             refill_per_tick,
             spare_capacity: 0,
             clock,
+            labels,
         }
     }
 }


### PR DESCRIPTION
### What does this PR do?

This PR labels each throttle's metrics with its parent generator's labels. This will separate the metrics for different throttles to give visibility into each generator's throttles when multiple are in use.

### Motivation

Debugging multi-generator setups.
