### PR TITLE
Add a VSCode remote container setup

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,5 @@
+FROM mcr.microsoft.com/devcontainers/base:1-bookworm
+RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
+    && apt-get -y install git build-essential protobuf-compiler \
+    # Remove imagemagick due to https://security-tracker.debian.org/tracker/CVE-2019-10131
+    && apt-get purge -y imagemagick imagemagick-6-common

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,34 @@
+{
+	"build": {
+		"dockerfile": "Dockerfile"
+	},
+	"features": {
+		"ghcr.io/devcontainers/features/common-utils:2": {
+			"installZsh": "true",
+			"username": "vscode",
+			"userUid": "1000",
+			"userGid": "1000",
+			"upgradePackages": "true",
+			"nonFreePackage": "true"
+		},
+		"ghcr.io/devcontainers/features/docker-outside-of-docker:1": {
+			"installDockerBuildx": "true"
+		},
+		"ghcr.io/devcontainers/features/rust:1": {
+			"version": "1.70",
+			"profile": "complete"
+		},
+		"ghcr.io/devcontainers/features/git:1": {
+			"version": "os-provided",
+			"ppa": "false"
+		}
+	},
+	"customizations": {
+		"vscode": {
+			"extensions": [
+				"rust-lang.rust-analyzer"
+			]
+		}
+	},
+	"postCreateCommand": "cargo clean --quiet && cargo check"
+}


### PR DESCRIPTION
### What does this PR do?

This introduces a dev container that allows for lading's Linux flagged features to be worked from an OS X laptop without the use of a VM. This should not intrude on dev setups that already use a VM, but this would be good to verify.
