### PR TITLE
Update observer to collect CPU utilization data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,12 +6,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+
+## [0.17.0-rc3]
+### Changed
+ - On Linux calculate CPU utilization in terms of logical, not physical, cores when possible.
+
 ## [0.17.0-rc2]
 ### Changed
  - CPU percentage calculated in the same manner as Agent's
 
 ## [0.17.0-rc1]
-
 ### Changed
 - Throttle metrics are now labeled with the respective generator's labels.
 - Observer now calculates CPU utilization with respect to target cgroup hard, soft limits. 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+
+## [0.16.2-rc1]
+
 ### Changed
 - Throttle metrics are now labeled with the respective generator's labels.
+- Observer now calculates CPU utilization with respect to target cgroup hard, soft limits. 
 
 ## [0.16.1]
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## [0.17.0-rc2]
+### Changed
+ - CPU percentage calculated in the same manner as Agent's
+
 ## [0.17.0-rc1]
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
-## [0.16.2-rc1]
+## [0.17.0-rc1]
 
 ### Changed
 - Throttle metrics are now labeled with the respective generator's labels.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -817,7 +817,7 @@ dependencies = [
 
 [[package]]
 name = "lading"
-version = "0.17.0-rc2"
+version = "0.17.0-rc3"
 dependencies = [
  "async-pidfd",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -646,15 +646,6 @@ dependencies = [
 
 [[package]]
 name = "hermit-abi"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee512640fe35acbfb4bb779db6f0d80704c2cacfa2e39b601ef3e3f47d1ae4c7"
-dependencies = [
- "libc",
-]
-
-[[package]]
-name = "hermit-abi"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fed44880c466736ef9a5c5b5facefb5ed0785676d0c02d612db14e54f0d84286"
@@ -826,7 +817,7 @@ dependencies = [
 
 [[package]]
 name = "lading"
-version = "0.16.2-rc1"
+version = "0.17.0-rc1"
 dependencies = [
  "async-pidfd",
  "async-trait",
@@ -843,6 +834,7 @@ dependencies = [
  "metrics-exporter-prometheus",
  "metrics-util",
  "nix",
+ "num_cpus",
  "once_cell",
  "opentelemetry-proto",
  "procfs",
@@ -1092,11 +1084,11 @@ dependencies = [
 
 [[package]]
 name = "num_cpus"
-version = "1.15.0"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fac9e2da13b5eb447a6ce3d392f23a29d8694bff781bf03a16cd9ac8697593b"
+checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
 dependencies = [
- "hermit-abi 0.2.6",
+ "hermit-abi 0.3.1",
  "libc",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -817,7 +817,7 @@ dependencies = [
 
 [[package]]
 name = "lading"
-version = "0.17.0-rc1"
+version = "0.17.0-rc2"
 dependencies = [
  "async-pidfd",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -826,7 +826,7 @@ dependencies = [
 
 [[package]]
 name = "lading"
-version = "0.16.1"
+version = "0.16.2-rc1"
 dependencies = [
  "async-pidfd",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["./", "integration/sheepdog", "integration/ducks"]
 
 [package]
 name = "lading"
-version = "0.16.2-rc1"
+version = "0.17.0-rc1"
 authors = ["Brian L. Troutwine <brian@troutwine.us>"]
 edition = "2021"
 license = "MIT"
@@ -36,6 +36,7 @@ metrics-exporter-prometheus = { version = "0.12.1", default-features = false, fe
 ] }
 metrics-util = { version = "0.15" }
 nix = { version = "0.26" }
+num_cpus = { version = "1.16" }
 once_cell = "1.18"
 opentelemetry-proto = { git = "https://github.com/open-telemetry/opentelemetry-rust/", rev = "6078e32", features = [
     "traces",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["./", "integration/sheepdog", "integration/ducks"]
 
 [package]
 name = "lading"
-version = "0.17.0-rc1"
+version = "0.17.0-rc2"
 authors = ["Brian L. Troutwine <brian@troutwine.us>"]
 edition = "2021"
 license = "MIT"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["./", "integration/sheepdog", "integration/ducks"]
 
 [package]
 name = "lading"
-version = "0.16.1"
+version = "0.16.2-rc1"
 authors = ["Brian L. Troutwine <brian@troutwine.us>"]
 edition = "2021"
 license = "MIT"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["./", "integration/sheepdog", "integration/ducks"]
 
 [package]
 name = "lading"
-version = "0.17.0-rc2"
+version = "0.17.0-rc3"
 authors = ["Brian L. Troutwine <brian@troutwine.us>"]
 edition = "2021"
 license = "MIT"

--- a/src/observer.rs
+++ b/src/observer.rs
@@ -145,7 +145,7 @@ impl Server {
             .map_err(Error::ProcError)?;
 
         let limits = process.limits().map_err(Error::ProcError)?;
-        // NOTE units on the CPU limits are 'CPU / second'
+        // NOTE units on the CPU limits are 'CPU-seconds / second'
         let max_cpu_time: Limit = limits.max_cpu_time;
         let soft_cpu_limit: f64 = match max_cpu_time.soft_limit {
             LimitValue::Unlimited => f64::MAX,
@@ -188,18 +188,18 @@ impl Server {
                         let stime: u64 = all_stats.iter().map(|stat| stat.0.stime).sum();
 
                         let kernel_time_ticks: u64 = cstime.unsigned_abs() + stime; // CPU-ticks
-                        let kernel_time_seconds: f64 = kernel_time_ticks as f64 / ticks_per_second as f64; // CPU
+                        let kernel_time_seconds: f64 = kernel_time_ticks as f64 / ticks_per_second as f64; // CPU-seconds
                         let user_time_ticks: u64 = cutime.unsigned_abs() + utime; // CPU-ticks
-                        let user_time_seconds: f64 = user_time_ticks as f64 / ticks_per_second as f64; // CPU
+                        let user_time_seconds: f64 = user_time_ticks as f64 / ticks_per_second as f64; // CPU-seconds
 
                         let process_uptime_seconds_diff: f64 = process_uptime_seconds - prev_process_uptime_seconds; // second
                         let kernel_time_ticks_diff = (kernel_time_ticks - prev_kernel_time_ticks) as f64; // CPU-ticks
                         let user_time_ticks_diff = (user_time_ticks - prev_user_time_ticks) as f64; // CPU-ticks
                         let time_ticks_diff = (kernel_time_ticks + user_time_ticks) - (prev_kernel_time_ticks + prev_user_time_ticks); // CPU-ticks
 
-                        let kernel_time_seconds_diff: f64 = kernel_time_ticks_diff / ticks_per_second as f64; // CPU / second
-                        let user_time_seconds_diff: f64 = user_time_ticks_diff / ticks_per_second as f64; // CPU / second
-                        let time_seconds_diff: f64 = time_ticks_diff as f64 / ticks_per_second as f64; // CPU / second
+                        let kernel_time_seconds_diff: f64 = kernel_time_ticks_diff / ticks_per_second as f64; // CPU-seconds
+                        let user_time_seconds_diff: f64 = user_time_ticks_diff / ticks_per_second as f64; // CPU-seconds
+                        let time_seconds_diff: f64 = time_ticks_diff as f64 / ticks_per_second as f64; // CPU-seconds
 
                         let kernel_utilization_soft = (kernel_time_seconds_diff / process_uptime_seconds_diff) / soft_cpu_limit;
                         let kernel_utilization_hard = (kernel_time_seconds_diff / process_uptime_seconds_diff) / hard_cpu_limit;

--- a/src/observer.rs
+++ b/src/observer.rs
@@ -133,10 +133,7 @@ impl Server {
         use std::{sync::atomic::Ordering, time::Duration};
 
         use metrics::{gauge, register_counter, register_gauge};
-        use procfs::{
-            process::{Limit, LimitValue},
-            Uptime,
-        };
+        use procfs::Uptime;
 
         let target_pid = pid_snd
             .recv()

--- a/src/observer.rs
+++ b/src/observer.rs
@@ -167,9 +167,7 @@ impl Server {
         let process = Process::new(target_pid.try_into().expect("PID coercion failed"))
             .map_err(Error::ProcError)?;
 
-        let num_cores = procfs::CpuInfo::new()
-            .map_err(Error::ProcError)?
-            .num_cores() as u64; // Cores
+        let num_cores = num_cpus::get(); // Cores, logical on Linux, obeying cgroup limits if present
 
         let ticks_per_second: u64 = procfs::ticks_per_second(); // CPU-ticks / second
         let page_size = procfs::page_size();


### PR DESCRIPTION
### What does this PR do?

This commit updates the observer with the aim of calculating CPU utilization. We maintain output of user and kernel space CPU seconds but add utilization with the understanding that this is useful to users that need to consider utilization and not ticks.

### Additional Notes

Note, if there is CPU use in the system that is not in a parent, child relationship but should still be counted this change will not address that.

### Related issues

REF SMP-613
#613 

