### PR TITLE
Adjust the default throttle to 'stable'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,17 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
-
-## [0.17.0-rc3]
+## [0.17.0]
 ### Changed
- - On Linux calculate CPU utilization in terms of logical, not physical, cores when possible.
-
-## [0.17.0-rc2]
-### Changed
- - CPU percentage calculated in the same manner as Agent's
-
-## [0.17.0-rc1]
-### Changed
+- Adjusted the default throttle to stable from predictive
+- On Linux calculate CPU utilization in terms of logical, not physical, cores when possible.
+- CPU percentage calculated in the same manner as Agent's
 - Throttle metrics are now labeled with the respective generator's labels.
 - Observer now calculates CPU utilization with respect to target cgroup hard, soft limits. 
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -817,7 +817,7 @@ dependencies = [
 
 [[package]]
 name = "lading"
-version = "0.17.0-rc3"
+version = "0.17.0"
 dependencies = [
  "async-pidfd",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["./", "integration/sheepdog", "integration/ducks"]
 
 [package]
 name = "lading"
-version = "0.17.0-rc3"
+version = "0.17.0"
 authors = ["Brian L. Troutwine <brian@troutwine.us>"]
 edition = "2021"
 license = "MIT"

--- a/src/throttle.rs
+++ b/src/throttle.rs
@@ -22,7 +22,7 @@ pub enum Config {
 
 impl Default for Config {
     fn default() -> Self {
-        Self::Predictive
+        Self::Stable
     }
 }
 


### PR DESCRIPTION
### What does this PR do?

We have found in practice that many of our users set their throttle to 'stable'. While predictive throttle is valuable and we wish to retain it this being the default is often confusing.

### Related issues

This change is technically breaking. Should be merged behind PR #616 to appear in the changelog.
