### PR TITLE
Delete debug println

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Fixed
+- Removed a leftover debug print in the Json payload implementation.
 
 ## [0.17.0]
 ### Changed
@@ -12,7 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - On Linux calculate CPU utilization in terms of logical, not physical, cores when possible.
 - CPU percentage calculated in the same manner as Agent's
 - Throttle metrics are now labeled with the respective generator's labels.
-- Observer now calculates CPU utilization with respect to target cgroup hard, soft limits. 
+- Observer now calculates CPU utilization with respect to target cgroup hard, soft limits.
 
 ## [0.16.1]
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+
+## [0.17.1]
 ### Fixed
 - Removed a leftover debug print in the Json payload implementation.
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -847,7 +847,7 @@ dependencies = [
 
 [[package]]
 name = "lading"
-version = "0.17.0"
+version = "0.17.1"
 dependencies = [
  "async-pidfd",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["./", "integration/sheepdog", "integration/ducks"]
 
 [package]
 name = "lading"
-version = "0.17.0"
+version = "0.17.1"
 authors = ["Brian L. Troutwine <brian@troutwine.us>"]
 edition = "2021"
 license = "MIT"

--- a/src/payload/json.rs
+++ b/src/payload/json.rs
@@ -63,7 +63,6 @@ impl Serialize for Json {
             let encoding = serde_json::to_string(&member)?;
             let line_length = encoding.len() + 1; // add one for the newline
 
-            println!("[{max_bytes}] {line_length} {bytes_remaining}");
             match bytes_remaining.checked_sub(line_length) {
                 Some(remainder) => {
                     writeln!(writer, "{encoding}")?;


### PR DESCRIPTION
### What does this PR do?

Delete a debug println in the json payload generator

### Motivation

This is spamming logs and likely has significant performance impact.
