### PR TITLE
Stop running integration tests on Macos

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,18 +81,11 @@ jobs:
 
   integration-test:
     name: Integration Tests
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-latest, macos-latest]
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - uses: actions-rust-lang/setup-rust-toolchain@v1.3.7
       - name: Install protobuf (Apt)
         run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
-        if: matrix.os == 'ubuntu-latest'
-      - name: Install protobuf (Brew)
-        run: brew install protobuf
-        if: matrix.os == 'macos-latest'
       - run: cargo test -p sheepdog
         timeout-minutes: 30


### PR DESCRIPTION
### What does this PR do?

These are flaky and it's annoying. We don't depend on Mac builds, so this can be removed.

### Motivation

Improve CI reliability.
