### PR TITLE
Enforce forward/backward compatibility with buf

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,10 +100,7 @@ jobs:
         uses: bufbuild/buf-setup-action@v1.15.0
       - name: buf-lint
         uses: bufbuild/buf-lint-action@v1.0.3
-      # NOTE we will need to actually have protos in main before this has the
-      # potential of working.
-      #
-      # - name: buf-breaking
-      #   uses: bufbuild/buf-breaking-action@v1.1.2
-      #   with:
-      #     against: 'https://github.com/datadog/lading.git#branch=main'
+      - name: buf-breaking
+        uses: bufbuild/buf-breaking-action@v1.1.2
+        with:
+          against: 'https://github.com/datadog/lading.git#branch=main'


### PR DESCRIPTION
### What does this PR do?

This commit adjusts our CI workflow to ensure that any change we make to project protobufs are perfectly forward and backward compatible.

REF SMP-631