### PR TITLE
Allow lading config to be specified via env var

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Changed
+- Config can now be specified using an env var `LADING_CONFIG`. If set, the env var takes precedence over the on-disk config file.
 
 ## [0.17.2-rc1]
 ### Changed

--- a/lading/src/bin/lading.rs
+++ b/lading/src/bin/lading.rs
@@ -1,5 +1,6 @@
 use std::{
     collections::HashMap,
+    env,
     fmt::{self, Display},
     io::Read,
     num::NonZeroU32,
@@ -166,12 +167,22 @@ fn get_config(ops: &Opts) -> Config {
         "Attempting to open configuration file at: {}",
         ops.config_path
     );
-    let mut file: std::fs::File = std::fs::OpenOptions::new()
-        .read(true)
-        .open(&ops.config_path)
-        .unwrap_or_else(|_| panic!("Could not open configuration file at: {}", &ops.config_path));
-    let mut contents = String::new();
-    file.read_to_string(&mut contents).unwrap();
+
+    let contents = if let Ok(env_var_value) = env::var("LADING_CONFIG") {
+        env_var_value
+    } else {
+        let mut file: std::fs::File = std::fs::OpenOptions::new()
+            .read(true)
+            .open(&ops.config_path)
+            .unwrap_or_else(|_| {
+                panic!("Could not open configuration file at: {}", &ops.config_path)
+            });
+        let mut contents = String::new();
+        file.read_to_string(&mut contents).unwrap();
+
+        contents
+    };
+
     let mut config: Config = serde_yaml::from_str(&contents).unwrap();
 
     if let Some(rss_bytes_limit) = ops.target_rss_bytes_limit {

--- a/lading/src/bin/lading.rs
+++ b/lading/src/bin/lading.rs
@@ -163,14 +163,14 @@ struct ProcessTreeGen {
 }
 
 fn get_config(ops: &Opts) -> Config {
-    debug!(
-        "Attempting to open configuration file at: {}",
-        ops.config_path
-    );
-
     let contents = if let Ok(env_var_value) = env::var("LADING_CONFIG") {
+        debug!("Using config from env var 'LADING_CONFIG'");
         env_var_value
     } else {
+        debug!(
+            "Attempting to open configuration file at: {}",
+            ops.config_path
+        );
         let mut file: std::fs::File = std::fs::OpenOptions::new()
             .read(true)
             .open(&ops.config_path)


### PR DESCRIPTION
### What does this PR do?
Supports an environment variable `LADING_CONFIG` that can contain the exact same yaml as the current config. The environment variable takes precedence over the on-disk config.

### Motivation
This is useful in a kubernetes deployment file to avoid the need for a config-map to put a file on disk. It keeps all config tightly coupled to the `lading` pod.

### Related issues
none.

### Additional Notes

This is useful to me, but I have no strong opinions if its a good fit for lading upstream. I defer to your vision for lading whether or not you want to merge this.