### PR TITLE
Update to rust 1.71.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,23 +30,6 @@ jobs:
         if: matrix.os == 'macos-latest'
       - run: cargo check
 
-  test:
-    name: Test Suite
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-latest, macos-latest]
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rust-lang/setup-rust-toolchain@v1.3.7
-      - name: Install protobuf (Apt)
-        run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
-        if: matrix.os == 'ubuntu-latest'
-      - name: Install protobuf (Brew)
-        run: brew install protobuf
-        if: matrix.os == 'macos-latest'
-      - run: cargo test
-
   fmt:
     name: Rustfmt
     runs-on: ${{ matrix.os }}
@@ -78,6 +61,16 @@ jobs:
         run: brew install protobuf
         if: matrix.os == 'macos-latest'
       - run: cargo clippy --all-features
+
+  test:
+    name: Test Suite
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rust-lang/setup-rust-toolchain@v1.3.7
+      - name: Install protobuf (Apt)
+        run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
+      - run: cargo test
 
   integration-test:
     name: Integration Tests

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Changed
+- Rust compiler updated to 1.71.0
 
 ## [0.17.3-rc1]
 ### Fixed

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/rust:1.63.0-bullseye@sha256:d7e3f69edcdcd03b145d8d9361765b816656755e49c1c1fe28224a4505f91b0a as builder
+FROM docker.io/rust:1.71.0-bullseye@sha256:31e5ca2912dd2313ff4841a168224312a066df278cb873f546e0fd625758ff40 as builder
 
 RUN apt-get update && apt-get install -y \
     protobuf-compiler \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/rust:1.71.0-bullseye@sha256:31e5ca2912dd2313ff4841a168224312a066df278cb873f546e0fd625758ff40 as builder
+FROM docker.io/rust:1.71.0-bullseye@sha256:bef59af02f103760cd57e8d6ccadf364954b0ae5e74ea7c7203d26744aeec051 as builder
 
 RUN apt-get update && apt-get install -y \
     protobuf-compiler \

--- a/lading/Cargo.toml
+++ b/lading/Cargo.toml
@@ -61,5 +61,8 @@ proptest-derive = "0.3.0"
 [features]
 default = []
 
+[lib]
+doctest = false
+
 [[bin]]
 name = "lading"

--- a/lading/src/block.rs
+++ b/lading/src/block.rs
@@ -169,7 +169,7 @@ where
             construct_block_cache_inner(&mut rng, &serializer, block_chunks, labels)
         }
         payload::Config::Json => {
-            construct_block_cache_inner(&mut rng, &payload::Json::default(), block_chunks, labels)
+            construct_block_cache_inner(&mut rng, &payload::Json, block_chunks, labels)
         }
         payload::Config::Static { ref static_path } => construct_block_cache_inner(
             &mut rng,
@@ -177,24 +177,15 @@ where
             block_chunks,
             labels,
         ),
-        payload::Config::OpentelemetryTraces => construct_block_cache_inner(
-            rng,
-            &payload::OpentelemetryTraces::default(),
-            block_chunks,
-            labels,
-        ),
-        payload::Config::OpentelemetryLogs => construct_block_cache_inner(
-            rng,
-            &payload::OpentelemetryLogs::default(),
-            block_chunks,
-            labels,
-        ),
-        payload::Config::OpentelemetryMetrics => construct_block_cache_inner(
-            rng,
-            &payload::OpentelemetryMetrics::default(),
-            block_chunks,
-            labels,
-        ),
+        payload::Config::OpentelemetryTraces => {
+            construct_block_cache_inner(rng, &payload::OpentelemetryTraces, block_chunks, labels)
+        }
+        payload::Config::OpentelemetryLogs => {
+            construct_block_cache_inner(rng, &payload::OpentelemetryLogs, block_chunks, labels)
+        }
+        payload::Config::OpentelemetryMetrics => {
+            construct_block_cache_inner(rng, &payload::OpentelemetryMetrics, block_chunks, labels)
+        }
     }
 }
 

--- a/lading/src/captures.rs
+++ b/lading/src/captures.rs
@@ -37,7 +37,8 @@ struct Inner {
 /// Wrangles internal metrics into capture files
 ///
 /// This struct is responsible for capturing all internal metrics sent through
-/// [`metrics`] and periodically writing them to disk with format [`Line`].
+/// [`metrics`] and periodically writing them to disk with format
+/// [`json::Line`].
 pub struct CaptureManager {
     fetch_index: u64,
     run_id: Uuid,

--- a/lading/src/generator/grpc.rs
+++ b/lading/src/generator/grpc.rs
@@ -241,7 +241,7 @@ impl Grpc {
             tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {e}"))
         })?;
         let res = client
-            .unary(Request::new(request), rpc_path, NoopCodec::default())
+            .unary(Request::new(request), rpc_path, NoopCodec)
             .await?;
 
         Ok(res)

--- a/lading_capture/Cargo.toml
+++ b/lading_capture/Cargo.toml
@@ -17,3 +17,6 @@ uuid = { workspace = true, features = ["serde", "v4"] }
 
 [build-dependencies]
 prost-build = { version = "0.11" }
+
+[lib]
+doctest = false

--- a/regression/Dockerfile
+++ b/regression/Dockerfile
@@ -1,7 +1,7 @@
 #
 # LADING BUILDER
 #
-FROM docker.io/rust:1.68.1-bullseye@sha256:ce1f9cc5f88955a7384a957a64793012945a7c130883edab0af44168723c7b77 as builder
+FROM docker.io/rust:1.71.0-bullseye@sha256:bef59af02f103760cd57e8d6ccadf364954b0ae5e74ea7c7203d26744aeec051 as builder
 WORKDIR /work
 COPY . .
 RUN apt-get update && apt-get install -y protobuf-compiler && rm -rf /var/lib/apt/lists/*

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.70.0"
+channel = "1.71.0"
 profile = "default"


### PR DESCRIPTION
### What does this PR do?

Update Rust compiler to version 1.71.0.

### Motivation

I noticed that the container toolchain was out of sync with the rest of the repo.
