### PR TITLE
Collect procfs data per-process

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,10 +1,10 @@
 {
-    "[rust]" : {
+    "[rust]": {
         "editor.defaultFormatter": "rust-lang.rust-analyzer",
         "editor.formatOnSave": true
     },
-    "[toml]" : {
+    "[toml]": {
         "editor.defaultFormatter": "tamasfe.even-better-toml",
-        "editor.formatOnSave": true
+        "editor.formatOnSave": false
     }
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## [0.17.2-rc4]
+### Changed
+ - We now elide sampling threads that are not also processes in the observer.
+
 ## [0.17.2-rc3]
 ### Changed
  - Correct `rss` to be reported in terms of bytes, not pages, as before.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## [0.17.2-rc6]
+### Changed
+ - We now avoid scaling utilization and clamp it directly to the appropriate
+   range.
+
 ## [0.17.2-rc5]
 ### Changed
  - We now clamp CPU utilization to number of cores, not scaled to.
@@ -20,7 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.17.2-rc2]
 ### Removed
-- Observer no longer emits tick data for kernel and user-space time. 
+- Observer no longer emits tick data for kernel and user-space time.
 ### Changed
 - Observer now distinguishes between parent and children processes.
 - Config can now be specified using an env var `LADING_CONFIG`. If set, the env var takes precedence over the on-disk config file.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+
+## [0.17.2-rc2]
+### Removed
+- Observer no longer emits tick data for kernel and user-space time. 
 ### Changed
+- Observer now distinguishes between parent and children processes.
 - Config can now be specified using an env var `LADING_CONFIG`. If set, the env var takes precedence over the on-disk config file.
 
 ## [0.17.2-rc1]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## [0.17.2-rc5]
+### Changed
+ - We now clamp CPU utilization to number of cores, not scaled to.
+
 ## [0.17.2-rc4]
 ### Changed
  - We now elide sampling threads that are not also processes in the observer.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## [0.17.2-rc3]
+### Changed
+ - Correct `rss` to be reported in terms of bytes, not pages, as before.
+
 ## [0.17.2-rc2]
 ### Removed
 - Observer no longer emits tick data for kernel and user-space time. 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -886,6 +886,7 @@ dependencies = [
  "rand",
  "reqwest",
  "rmp-serde",
+ "rustc-hash",
  "serde",
  "serde_json",
  "serde_qs",
@@ -1704,6 +1705,12 @@ name = "rustc-demangle"
 version = "0.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d626bb9dae77e28219937af045c257c28bfd3f69333c512553507f5f9798cb76"
+
+[[package]]
+name = "rustc-hash"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustix"

--- a/lading/Cargo.toml
+++ b/lading/Cargo.toml
@@ -15,42 +15,26 @@ lading-capture = { path = "../lading_capture" }
 async-trait = { version = "0.1", default-features = false, features = [] }
 byte-unit = { version = "4.0", features = ["serde"] }
 bytes = { version = "1.4.0", default-features = false, features = ["std"] }
-clap = { version = "3.2", default-features = false, features = [
-    "std",
-    "color",
-    "suggestions",
-    "derive",
-] }
-flate2 = { version = "1.0.26", default-features = false, features = [
-    "rust_backend",
-] }
+clap = { version = "3.2", default-features = false, features = ["std", "color", "suggestions", "derive"] }
+flate2 = { version = "1.0.26", default-features = false, features = ["rust_backend" ] }
 futures = "0.3.28"
 http = "0.2"
 http-serde = "1.1"
 hyper = { version = "0.14", features = ["client"] }
 is_executable = "1.0.1"
 metrics = { version = "0.21", default-features = false }
-metrics-exporter-prometheus = { version = "0.12.1", default-features = false, features = [
-    "http-listener",
-] }
+metrics-exporter-prometheus = { version = "0.12.1", default-features = false, features = ["http-listener"]}
 metrics-util = { version = "0.15" }
 nix = { version = "0.26" }
 num_cpus = { version = "1.16" }
 once_cell = "1.18"
-opentelemetry-proto = { git = "https://github.com/open-telemetry/opentelemetry-rust/", rev = "6078e32", features = [
-    "traces",
-    "metrics",
-    "logs",
-    "gen-tonic",
+opentelemetry-proto = { git = "https://github.com/open-telemetry/opentelemetry-rust/", rev = "6078e32", features = ["traces", "metrics", "logs", "gen-tonic",
 ] }
 prost = "0.11"
-rand = { version = "0.8", default-features = false, features = [
-    "small_rng",
-    "std",
-    "std_rng",
-] }
+rand = { version = "0.8", default-features = false, features = ["small_rng", "std", "std_rng" ]}
 reqwest = { version = "0.11", default-features = false, features = ["json"] }
 rmp-serde = { version = "1.1", default-features = false }
+rustc-hash = { version = "1.1.0" }
 serde = { workspace = true }
 serde_json = {workspace = true }
 serde_qs = "0.12"
@@ -58,24 +42,10 @@ serde_tuple = { version = "0.5", default-features = false }
 serde_yaml = "0.9"
 thiserror = { version = "1.0" }
 time = { version = "0.3", features = ["formatting"] }
-tokio = { version = "1.29", features = [
-    "rt",
-    "rt-multi-thread",
-    "macros",
-    "fs",
-    "io-util",
-    "process",
-    "signal",
-    "time",
-    "net",
-] }
+tokio = { version = "1.29", features = ["rt", "rt-multi-thread", "macros", "fs", "io-util", "process", "signal", "time", "net"] }
 tokio-util = { version = "0.7", features = ["io"] }
 tonic = { version = "0.9" }
-tower = { version = "0.4", default-features = false, features = [
-    "timeout",
-    "limit",
-    "load-shed",
-] }
+tower = { version = "0.4", default-features = false, features = ["timeout", "limit", "load-shed"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["std", "env-filter"] }
 uuid = { workspace = true }

--- a/lading/src/observer.rs
+++ b/lading/src/observer.rs
@@ -11,28 +11,30 @@
 use std::{io, sync::atomic::AtomicU64};
 
 use crate::target::TargetPidReceiver;
-use nix::errno::Errno;
 use serde::Deserialize;
 
 use crate::signals::Shutdown;
 
 #[cfg(target_os = "linux")]
-use procfs::process::Process;
+mod linux;
 
 /// Expose the process' current RSS consumption, allowing abstractions to be
 /// built on top in the Target implementation.
 pub(crate) static RSS_BYTES: AtomicU64 = AtomicU64::new(0);
 
-#[derive(Debug)]
+#[derive(thiserror::Error, Debug)]
 /// Errors produced by [`Server`]
 pub enum Error {
     /// Wrapper for [`nix::errno::Errno`]
-    Errno(Errno),
+    #[error("erno: {0}")]
+    Errno(#[from] nix::errno::Errno),
     /// Wrapper for [`std::io::Error`]
-    Io(io::Error),
+    #[error("IO error: {0}")]
+    Io(#[from] io::Error),
     #[cfg(target_os = "linux")]
-    /// Wrapper for [`procfs::ProcError`]
-    ProcError(procfs::ProcError),
+    /// Wrapper for [`linux::Error`]
+    #[error("Linux error: {0}")]
+    Linux(#[from] linux::Error),
 }
 
 #[derive(Debug, Deserialize, Clone, Copy, Default, PartialEq, Eq)]
@@ -55,27 +57,6 @@ pub struct Server {
     shutdown: Shutdown,
 }
 
-#[inline]
-#[cfg(target_os = "linux")]
-fn percentage(delta_ticks: f64, delta_time: f64, num_cores: f64) -> f64 {
-    // Takes (heavy) inspiration from Datadog Agent, see https://github.com/DataDog/datadog-agent/blob/8914a281cf6f9cfa867e0d72899c39afa51abce7/pkg/process/checks/process_nix.go
-    if delta_time == 0.0 {
-        return 0.0;
-    }
-
-    let mut overall_percentage = (delta_ticks / delta_time) * 100.0;
-    if overall_percentage > 100.0 {
-        overall_percentage = 100.0;
-    }
-
-    let mut percent = overall_percentage * num_cores;
-    if percent < 0.0 {
-        percent = 0.0;
-    }
-
-    percent
-}
-
 impl Server {
     /// Create a new [`Server`] instance
     ///
@@ -88,42 +69,6 @@ impl Server {
     /// the path is valid but is not to file executable by this program.
     pub fn new(config: Config, shutdown: Shutdown) -> Result<Self, Error> {
         Ok(Self { config, shutdown })
-    }
-
-    /// Get all children of the specified process.
-    ///
-    /// This ignores most errors in favor of creating a best-effort list of
-    /// children.
-    #[cfg(target_os = "linux")]
-    fn get_all_children(process: Process) -> Result<Vec<Process>, Error> {
-        let tree = process
-            .tasks()
-            .map_err(Error::ProcError)?
-            .flatten()
-            .flat_map(|t| t.children())
-            .flatten()
-            .flat_map(TryInto::try_into)
-            .flat_map(Process::new)
-            .flat_map(Self::get_all_children)
-            .flatten()
-            .chain(std::iter::once(process))
-            .collect();
-        Ok(tree)
-    }
-
-    /// Get process stats for the given process and all of its children.
-    #[cfg(target_os = "linux")]
-    fn get_proc_stats(
-        process: &Process,
-    ) -> Result<Vec<(procfs::process::Stat, procfs::process::MemoryMaps)>, Error> {
-        let target_process = Process::new(process.pid()).map_err(Error::ProcError)?;
-        let target_and_children = Self::get_all_children(target_process)?;
-        let stats = target_and_children
-            .into_iter()
-            .map(|p| Ok((p.stat()?, p.smaps()?)))
-            .collect::<Result<Vec<_>, _>>()
-            .map_err(Error::ProcError)?;
-        Ok(stats)
     }
 
     /// Run this [`Server`] to completion
@@ -151,10 +96,9 @@ impl Server {
     )]
     #[cfg(target_os = "linux")]
     pub async fn run(mut self, mut pid_snd: TargetPidReceiver) -> Result<(), Error> {
-        use std::{sync::atomic::Ordering, time::Duration};
+        use std::time::Duration;
 
-        use metrics::{gauge, register_counter, register_gauge};
-        use procfs::Uptime;
+        use crate::observer::linux::Sampler;
 
         let target_pid = pid_snd
             .recv()
@@ -164,108 +108,13 @@ impl Server {
 
         let target_pid = target_pid.expect("observer cannot be used in no-target mode");
 
-        let process = Process::new(target_pid.try_into().expect("PID coercion failed"))
-            .map_err(Error::ProcError)?;
-
-        let num_cores = num_cpus::get(); // Cores, logical on Linux, obeying cgroup limits if present
-
-        let ticks_per_second: u64 = procfs::ticks_per_second(); // CPU-ticks / second
-        let page_size = procfs::page_size();
-
-        gauge!("core_total", num_cores as f64);
-        gauge!("ticks_per_second", ticks_per_second as f64);
-
-        let mut procfs_delay = tokio::time::interval(Duration::from_secs(1));
-
-        let mut prev_kernel_time_ticks = 0;
-        let mut prev_user_time_ticks = 0;
-        let mut prev_process_uptime_ticks = 0;
-
-        let kernel_ticks_counter = register_counter!("kernel_ticks");
-        let user_ticks_counter = register_counter!("user_ticks");
-        let target_uptime_ticks_counter = register_counter!("target_uptime_ticks");
-        let cpu_percentage_gauge = register_gauge!("cpu_percentage");
-        let kernel_cpu_percentage_gauge = register_gauge!("kernel_cpu_percentage");
-        let user_cpu_percentage_gauge = register_gauge!("user_cpu_percentage");
+        let mut sample_delay = tokio::time::interval(Duration::from_secs(1));
+        let mut sampler = Sampler::new(target_pid)?;
 
         loop {
             tokio::select! {
-                _ = procfs_delay.tick() => {
-                    if let (Ok(parent_stat), Ok(all_stats)) = (process.stat(), Self::get_proc_stats(&process)) {
-                        // Calculate process uptime. We have two pieces of
-                        // information from the kernel: computer uptime and
-                        // process starttime relative to power-on of the
-                        // computer.
-                        let process_starttime_ticks: u64 = parent_stat.starttime; // ticks after system boot
-                        let uptime_seconds: f64 = Uptime::new().expect("could not query uptime").uptime; // seconds since boot
-                        let uptime_ticks: u64 = uptime_seconds.round() as u64 * ticks_per_second; // CPU-ticks since boot
-                        let process_uptime_ticks: u64 = uptime_ticks - process_starttime_ticks;
-
-                        // Child process wait time
-                        let cutime: i64 = all_stats.iter().map(|stat| stat.0.cutime).sum();
-                        let cstime: i64 = all_stats.iter().map(|stat| stat.0.cstime).sum();
-                        // Parent process wait time
-                        let utime: u64 = all_stats.iter().map(|stat| stat.0.utime).sum();
-                        let stime: u64 = all_stats.iter().map(|stat| stat.0.stime).sum();
-
-                        let kernel_time_ticks: u64 = cstime.unsigned_abs() + stime; // CPU-ticks
-                        let user_time_ticks: u64 = cutime.unsigned_abs() + utime; // CPU-ticks
-
-                        let process_uptime_ticks_diff = process_uptime_ticks - prev_process_uptime_ticks; // CPU-ticks
-                        let kernel_time_ticks_diff = kernel_time_ticks - prev_kernel_time_ticks; // CPU-ticks
-                        let user_time_ticks_diff = user_time_ticks - prev_user_time_ticks; // CPU-ticks
-                        let time_ticks_diff = (kernel_time_ticks + user_time_ticks) - (prev_kernel_time_ticks + prev_user_time_ticks); // CPU-ticks
-
-                        let user_percentage = percentage(user_time_ticks_diff as f64, process_uptime_ticks_diff as f64, num_cores as f64);
-                        let kernel_percentage = percentage(kernel_time_ticks_diff as f64, process_uptime_ticks_diff as f64, num_cores as f64);
-                        let cpu_percentage = percentage(time_ticks_diff as f64, process_uptime_ticks_diff as f64, num_cores as f64);
-
-                        // The time spent in kernel-space in ticks.
-                        kernel_ticks_counter.absolute(kernel_time_ticks);
-                        // The time spent in user-space in ticks.
-                        user_ticks_counter.absolute(user_time_ticks);
-                        // The uptime of the process in CPU ticks.
-                        target_uptime_ticks_counter.absolute(process_uptime_ticks);
-                        // The percentage of CPU cores used in user and kernel space.
-                        cpu_percentage_gauge.set(cpu_percentage);
-                        // The percentage of CPU cores used in user space.
-                        user_cpu_percentage_gauge.set(user_percentage);
-                        // The percentage of CPU cores used in kernel space.
-                        kernel_cpu_percentage_gauge.set(kernel_percentage);
-
-                        prev_kernel_time_ticks = kernel_time_ticks;
-                        prev_user_time_ticks = user_time_ticks;
-                        prev_process_uptime_ticks = process_uptime_ticks;
-
-                        let rss: u64 = all_stats.iter().fold(0, |val, stat| val.saturating_add(stat.0.rss));
-                        let pss: u64 = all_stats.iter().fold(0, |val, stat| {
-                            let one_proc = stat.1.iter().fold(0u64, |one_map, stat| {
-                                one_map.saturating_add(stat.extension.map.get("Pss").copied().unwrap_or_default())
-                            });
-                            val.saturating_add(one_proc)
-                        });
-
-                        let rsslim: u64 = all_stats.iter().fold(0, |val, stat| val.saturating_add(stat.0.rsslim));
-                        let vsize: u64 = all_stats.iter().fold(0, |val, stat| val.saturating_add(stat.0.vsize));
-                        let num_threads: u64 = all_stats.iter().map(|stat| stat.0.num_threads).sum::<i64>().unsigned_abs();
-
-                        let rss_bytes: u64 = rss*page_size;
-                        RSS_BYTES.store(rss_bytes, Ordering::Relaxed); // stored for the purposes of throttling
-
-                        // Number of pages that the process has in real memory.
-                        gauge!("rss_bytes", rss_bytes as f64);
-                        // Proportional share of bytes owned by this process and its children.
-                        gauge!("pss_bytes", pss as f64);
-                        // Soft limit on RSS bytes, see RLIMIT_RSS in getrlimit(2).
-                        gauge!("rsslim_bytes", rsslim as f64);
-                        // The size in bytes of the process in virtual memory.
-                        gauge!("vsize_bytes", vsize as f64);
-                        // Number of threads this process has active.
-                        gauge!("num_threads", num_threads as f64);
-
-                        // Number of processes this target has active
-                        gauge!("num_processes", all_stats.len() as f64);
-                    }
+                _ = sample_delay.tick() => {
+                    sampler.sample()?;
                 }
                 _ = self.shutdown.recv() => {
                     tracing::info!("shutdown signal received");

--- a/lading/src/observer.rs
+++ b/lading/src/observer.rs
@@ -143,32 +143,3 @@ impl Server {
         Ok(())
     }
 }
-
-#[cfg(test)]
-mod tests {
-    #[test]
-    #[cfg(target_os = "linux")]
-    fn observer_observes_process_hierarchy() {
-        use super::*;
-        use std::{process::Command, time::Duration};
-
-        let mut test_proc = Command::new("/bin/sh")
-            .args(["-c", "sleep 1"])
-            .spawn()
-            .expect("launch child process");
-
-        // wait for `sh` to launch `sleep`
-        std::thread::sleep(Duration::from_millis(250));
-
-        let proc =
-            Process::new(test_proc.id().try_into().unwrap()).expect("create Process from PID");
-        let stats = Server::get_proc_stats(&proc).expect("get proc stat hierarchy");
-
-        test_proc.kill().unwrap();
-
-        let mut bins = stats.iter().map(|s| s.0.comm.clone()).collect::<Vec<_>>();
-        bins.sort();
-
-        assert_eq!(&bins, &[String::from("sh"), String::from("sleep")]);
-    }
-}

--- a/lading/src/observer/linux.rs
+++ b/lading/src/observer/linux.rs
@@ -252,14 +252,12 @@ fn percentage(delta_ticks: f64, delta_time: f64, num_cores: f64) -> f64 {
     }
 
     let mut overall_percentage = (delta_ticks / delta_time) * 100.0;
-    if overall_percentage > 100.0 {
-        overall_percentage = 100.0;
+    let percent = overall_percentage / num_cores;
+    if percent > 100.0 {
+        100.0
+    } else if percent < 0.0 {
+        0.0
+    } else {
+        percent
     }
-
-    let mut percent = overall_percentage * num_cores;
-    if percent < 0.0 {
-        percent = 0.0;
-    }
-
-    percent
 }

--- a/lading/src/observer/linux.rs
+++ b/lading/src/observer/linux.rs
@@ -1,0 +1,245 @@
+use std::{collections::VecDeque, io, sync::atomic::Ordering};
+
+use metrics::gauge;
+use nix::errno::Errno;
+use procfs::process::Process;
+use rustc_hash::FxHashMap;
+
+use super::RSS_BYTES;
+
+#[derive(thiserror::Error, Debug)]
+/// Errors produced by functions in this module
+pub enum Error {
+    /// Wrapper for [`nix::errno::Errno`]
+    #[error("erno: {0}")]
+    Errno(#[from] Errno),
+    /// Wrapper for [`std::io::Error`]
+    #[error("IO error: {0}")]
+    Io(#[from] io::Error),
+    #[cfg(target_os = "linux")]
+    /// Wrapper for [`procfs::ProcError`]
+    #[error("Unable to read procfs: {0}")]
+    ProcError(#[from] procfs::ProcError),
+}
+
+#[derive(Debug, Default)]
+struct Sample {
+    utime: u64,
+    stime: u64,
+    uptime: u64,
+}
+
+#[derive(Debug)]
+pub(crate) struct Sampler {
+    parent: Process,
+    num_cores: usize,
+    ticks_per_second: u64,
+    previous_samples: FxHashMap<(i32, String), Sample>,
+}
+
+impl Sampler {
+    pub(crate) fn new(parent_pid: u32) -> Result<Self, Error> {
+        let parent = Process::new(parent_pid.try_into().expect("PID coercion failed"))?;
+
+        Ok(Self {
+            parent,
+            num_cores: num_cpus::get(), // Cores, logical on Linux, obeying cgroup limits if present
+            ticks_per_second: procfs::ticks_per_second(),
+            previous_samples: FxHashMap::default(),
+        })
+    }
+
+    #[allow(
+        clippy::similar_names,
+        clippy::too_many_lines,
+        clippy::cast_possible_truncation,
+        clippy::cast_sign_loss,
+        clippy::cast_possible_wrap
+    )]
+    pub(crate) fn sample(&mut self) -> Result<(), Error> {
+        let mut samples: FxHashMap<(i32, String), Sample> = FxHashMap::default();
+
+        let mut total_processes: u64 = 0;
+        // We maintain a tally of the total RSS consumed by the parent process
+        // and its children for cooperation -- through RSS_BYTES -- with the
+        // throttle.
+        let mut total_rss: u64 = 0;
+
+        // Calculate the ticks since machine uptime. This will be important
+        // later for calculating per-process uptime. Because we capture this one
+        // we will be slightly out of date with each subsequent iteration of the
+        // loop. We do not believe this to be an issue.
+        let uptime_seconds: f64 = procfs::Uptime::new()
+            .expect("could not query machine uptime")
+            .uptime; // seconds since boot
+        let uptime_ticks: u64 = uptime_seconds.round() as u64 * self.ticks_per_second; // CPU-ticks since boot
+
+        // Every sample run we collect all the child processes rooted at the
+        // parent. As noted by the procfs documentation is this done by
+        // dereferencing the `/proc/<pid>/root` symlink.
+        //
+        // TODO this is not correct. We need to build a stack of processes.
+        // all_processes_with_root is for systems that have proc somewhere other
+        // than /proc
+        let mut processes: VecDeque<Process> = VecDeque::with_capacity(16); // an arbitrary smallish number
+        processes.push_back(Process::new(self.parent.pid())?);
+        while let Some(process) = processes.pop_back() {
+            // Search for child processes. This is done by querying for every
+            // thread of `process` and inspecting each child of the thread.
+            if let Ok(tasks) = process.tasks() {
+                for task in tasks.filter(std::result::Result::is_ok) {
+                    let task = task.unwrap(); // SAFETY: filter on iterator
+                    if let Ok(mut children) = task.children() {
+                        for child in children
+                            .drain(..)
+                            .map(|c| Process::new(c as i32))
+                            .filter(std::result::Result::is_ok)
+                        {
+                            processes.push_back(child.unwrap()); // SAFETY: filter on iterator
+                        }
+                    }
+                }
+            }
+
+            let pid = process.pid();
+
+            // Collect the 'name' of the process. This is pulled from
+            // /proc/<pid>/exe and we take the last part of that, like posix
+            // `top` does. This will require us to label all data with both pid
+            // and name, again like `top`.
+            let basename: String = if let Ok(exe) = process.exe() {
+                if let Some(basename) = exe.file_name() {
+                    String::from(basename.to_str().unwrap())
+                } else {
+                    // It's possible to have a process with no named exe. On
+                    // Linux systems with functional security setups it's not
+                    // clear _when_ this would be the case but, hey.
+                    String::new()
+                }
+            } else {
+                continue;
+            };
+
+            let stats = process.stat();
+            if stats.is_err() {
+                // We don't want to bail out entirely if we can't read stats
+                // which will happen if we don't have permissions or, more
+                // likely, the process has exited.
+                continue;
+            }
+            let stats = stats.unwrap(); // SAFETY: is_err check above
+
+            // Calculate process uptime. We have two pieces of information from
+            // the kernel: computer uptime and process starttime relative to
+            // power-on of the computer.
+            let uptime: u64 = uptime_ticks - stats.starttime; // ticks
+
+            // The times that the process and the processes' waited for children
+            // have been scheduled in kernel and user space. We exclude cstime,
+            // cutime because while the parent has waited it has not spent CPU
+            // time, it's children have.
+            let utime: u64 = stats.utime; // CPU-ticks
+            let stime: u64 = stats.stime; // CPU-ticks
+
+            let sample = Sample {
+                utime,
+                stime,
+                uptime,
+            };
+            samples.insert((pid, basename.clone()), sample);
+
+            // Answering the question "How much memory is my program consuming?"
+            // is not as straightforward as one might hope. Reside set size
+            // (RSS) is the amount of memory held in memory measured in bytes,
+            // Proportional Set Size (PSS) is the amount of memory held by the
+            // program but unshared between processes (think data mmapped
+            // multiple times), Virtual Size (vsize) is the amount of memory
+            // held in pages, which may or may not be reflected in real memory.
+            // VSize is often much, much larger than RSS.
+            //
+            // We currently do not pull PSS as it requires trawling the smaps
+            // but we don't have call to do that, avoiding an allocation.
+            //
+            // Consider that Linux allocation is done in pages. If I allocate 1
+            // byte, say, from the OS I will receive a page of memory back --
+            // see `page_size` for the size of a page -- and the RSS and VSize
+            // of my program is then a page worth of bytes. If I deallocate that
+            // byte my RSS is 0 but _as an optimization_ Linux may not free the
+            // page. My VSize remains one page. Allocators muddy this even
+            // further by trying to account for the behavior of the operating
+            // system. Anyway, good luck out there. You'll be fine.
+            let rss: u64 = stats.rss;
+            let rsslim: u64 = stats.rsslim;
+            let vsize: u64 = stats.vsize;
+
+            let labels = [("pid", format!("{pid}")), ("exe", basename)];
+
+            // Number of pages that the process has in real memory.
+            gauge!("rss_bytes", rss as f64, &labels);
+            // Soft limit on RSS bytes, see RLIMIT_RSS in getrlimit(2).
+            gauge!("rsslim_bytes", rsslim as f64, &labels);
+            // The size in bytes of the process in virtual memory.
+            gauge!("vsize_bytes", vsize as f64, &labels);
+            // Number of threads this process has active.
+            gauge!("num_threads", stats.num_threads as f64, &labels);
+
+            total_rss += rss;
+            total_processes += 1;
+        }
+
+        gauge!("num_processes", total_processes as f64);
+        RSS_BYTES.store(total_rss, Ordering::Relaxed); // stored for the purposes of throttling
+
+        // Now we loop through our just collected samples and calculate CPU
+        // utilization. This require memory and we will now reference -- and
+        // update, when done -- the previous samples.
+        for (key, sample) in &samples {
+            let prev = self.previous_samples.remove(key).unwrap_or_default();
+
+            let uptime_diff = sample.uptime - prev.uptime; // CPU-ticks
+            let stime_diff: u64 = sample.stime - prev.stime; // CPU-ticks
+            let utime_diff: u64 = sample.utime - prev.utime; // CPU-ticks
+            let time_diff: u64 = (sample.stime + sample.utime) - (prev.stime + prev.utime); // CPU-ticks
+
+            let user_percentage =
+                percentage(utime_diff as f64, uptime_diff as f64, self.num_cores as f64);
+            let kernel_percentage =
+                percentage(stime_diff as f64, uptime_diff as f64, self.num_cores as f64);
+            let cpu_percentage =
+                percentage(time_diff as f64, uptime_diff as f64, self.num_cores as f64);
+
+            let labels = [
+                ("pid", format!("{pid}", pid = key.0)),
+                ("exe", key.1.clone()),
+            ];
+
+            gauge!("cpu_percentage", cpu_percentage, &labels);
+            gauge!("kernel_cpu_percentage", kernel_percentage, &labels);
+            gauge!("user_cpu_percentage", user_percentage, &labels);
+        }
+        self.previous_samples = samples;
+
+        Ok(())
+    }
+}
+
+#[inline]
+fn percentage(delta_ticks: f64, delta_time: f64, num_cores: f64) -> f64 {
+    // Takes (heavy) inspiration from Datadog Agent, see
+    // https://github.com/DataDog/datadog-agent/blob/8914a281cf6f9cfa867e0d72899c39afa51abce7/pkg/process/checks/process_nix.go
+    if delta_time == 0.0 {
+        return 0.0;
+    }
+
+    let mut overall_percentage = (delta_ticks / delta_time) * 100.0;
+    if overall_percentage > 100.0 {
+        overall_percentage = 100.0;
+    }
+
+    let mut percent = overall_percentage * num_cores;
+    if percent < 0.0 {
+        percent = 0.0;
+    }
+
+    percent
+}

--- a/lading/src/observer/linux.rs
+++ b/lading/src/observer/linux.rs
@@ -34,6 +34,7 @@ pub(crate) struct Sampler {
     parent: Process,
     num_cores: usize,
     ticks_per_second: u64,
+    page_size: u64,
     previous_samples: FxHashMap<(i32, String), Sample>,
 }
 
@@ -45,6 +46,7 @@ impl Sampler {
             parent,
             num_cores: num_cpus::get(), // Cores, logical on Linux, obeying cgroup limits if present
             ticks_per_second: procfs::ticks_per_second(),
+            page_size: procfs::page_size(),
             previous_samples: FxHashMap::default(),
         })
     }
@@ -164,7 +166,7 @@ impl Sampler {
             // page. My VSize remains one page. Allocators muddy this even
             // further by trying to account for the behavior of the operating
             // system. Anyway, good luck out there. You'll be fine.
-            let rss: u64 = stats.rss;
+            let rss: u64 = stats.rss * self.page_size;
             let rsslim: u64 = stats.rsslim;
             let vsize: u64 = stats.vsize;
 

--- a/lading/src/observer/linux.rs
+++ b/lading/src/observer/linux.rs
@@ -77,10 +77,6 @@ impl Sampler {
         // Every sample run we collect all the child processes rooted at the
         // parent. As noted by the procfs documentation is this done by
         // dereferencing the `/proc/<pid>/root` symlink.
-        //
-        // TODO this is not correct. We need to build a stack of processes.
-        // all_processes_with_root is for systems that have proc somewhere other
-        // than /proc
         let mut processes: VecDeque<Process> = VecDeque::with_capacity(16); // an arbitrary smallish number
         processes.push_back(Process::new(self.parent.pid())?);
         while let Some(process) = processes.pop_back() {

--- a/lading/src/observer/linux.rs
+++ b/lading/src/observer/linux.rs
@@ -101,7 +101,7 @@ impl Sampler {
                             if !pids.contains(&pid) {
                                 // We have not seen this process and do need to
                                 // record it for child scanning and sampling if
-                                // it proves to be a process. 
+                                // it proves to be a process.
                                 processes.push_back(child);
                                 pids.insert(pid);
                             }

--- a/lading/src/observer/linux.rs
+++ b/lading/src/observer/linux.rs
@@ -251,13 +251,10 @@ fn percentage(delta_ticks: f64, delta_time: f64, num_cores: f64) -> f64 {
         return 0.0;
     }
 
-    let mut overall_percentage = (delta_ticks / delta_time) * 100.0;
-    let percent = overall_percentage / num_cores;
-    if percent > 100.0 {
-        100.0
-    } else if percent < 0.0 {
-        0.0
-    } else {
-        percent
-    }
+    // `delta_time` is the number of scheduler ticks elapsed during this slice
+    // of time. `delta_ticks` is the number of ticks spent across all cores
+    // during this time.
+    let overall_percentage = (delta_ticks / delta_time) * 100.0;
+
+    overall_percentage.clamp(0.0, 100.0 * num_cores)
 }


### PR DESCRIPTION
### What does this PR do?

This commit modifies how we collect procfs data: we now distinguish children from their parent. Previous versions of lading rolled this information up into one time series but were now distinguish them with labels. This allows users interested only in the roll-up to continue sum over names if they wish.

### Additional Notes

We have dropped tick series. It saves some room in the capture file and tick information was not found to be useful in practice.

### Related issues

REF SMP-631
