### PR TITLE
Allow users to configure metric multivalue weights

### DIFF
--- a/lading/src/block.rs
+++ b/lading/src/block.rs
@@ -140,7 +140,7 @@ where
                 tg_range,
                 *kind_weights,
                 *metric_weights,
-                metric_multivalue.clone(),
+                metric_multivalue,
                 &mut rng,
             );
 

--- a/lading/src/block.rs
+++ b/lading/src/block.rs
@@ -130,6 +130,7 @@ where
             tag_keys_maximum,
             kind_weights,
             metric_weights,
+            metric_multivalue,
         }) => {
             let mn_range = *metric_names_minimum..*metric_names_maximum;
             let tg_range = *tag_keys_minimum..*tag_keys_maximum;
@@ -139,6 +140,7 @@ where
                 tg_range,
                 *kind_weights,
                 *metric_weights,
+                metric_multivalue.clone(),
                 &mut rng,
             );
 

--- a/lading/src/payload/dogstatsd.rs
+++ b/lading/src/payload/dogstatsd.rs
@@ -127,7 +127,7 @@ pub struct Config {
     /// Defines the relative probability of each kind of DogStatsD metric.
     #[serde(default)]
     pub metric_weights: MetricWeights,
-    /// Defines the relative probability of a metric having multiple values.
+    /// Defines the relative probability of a dogstatsd message having multiple values.
     /// Choices are weighted according to the specified weight.
     #[serde(default = "default_metric_multivalue")]
     pub metric_multivalue: Vec<MetricValueWeight>,

--- a/lading/src/payload/dogstatsd.rs
+++ b/lading/src/payload/dogstatsd.rs
@@ -46,7 +46,7 @@ fn default_metric_multivalue() -> Vec<MetricValueWeight> {
     weights
 }
 
-/// Weight for a `DogStatsD` multivalue line.
+/// Weight for a `DogStatsD` multivalue message.
 ///
 /// Defines the relative weight of a certain number of 'values' packed into a
 /// single metric message.

--- a/lading/src/payload/dogstatsd.rs
+++ b/lading/src/payload/dogstatsd.rs
@@ -49,7 +49,7 @@ fn default_metric_multivalue() -> Vec<MetricValueWeight> {
 /// Weight for a `DogStatsD` multivalue line.
 ///
 /// Defines the relative weight of a certain number of 'values' packed into a
-/// single metric line.
+/// single metric message.
 #[derive(Debug, Deserialize, Clone, Copy, PartialEq)]
 #[serde(rename_all = "snake_case")]
 pub struct MetricValueWeight {

--- a/lading/src/payload/dogstatsd.rs
+++ b/lading/src/payload/dogstatsd.rs
@@ -113,6 +113,7 @@ pub struct Config {
     #[serde(default)]
     pub metric_weights: MetricWeights,
     /// Defines the relative probability of a metric having multiple values.
+    /// Choices are evenly weighted among those listed.
     #[serde(default = "default_metric_multivalue")]
     pub metric_multivalue: Vec<u8>,
 }
@@ -330,7 +331,7 @@ mod test {
             let tag_keys_range =  0..32;
             let kind_weights = KindWeights::default();
             let metric_weights = MetricWeights::default();
-            let metric_multivalue_weights: default_metric_multivalue_weights();
+            let metric_multivalue_weights: default_metric_multivalue();
             let dogstatsd = DogStatsD::new(metric_names_range, tag_keys_range, kind_weights, metric_weights, metric_multivalue_weights, &mut rng);
 
             let mut bytes = Vec::with_capacity(max_bytes);

--- a/lading/src/payload/dogstatsd.rs
+++ b/lading/src/payload/dogstatsd.rs
@@ -46,7 +46,7 @@ fn default_metric_multivalue() -> Vec<MetricValueWeight> {
     weights
 }
 
-// Weight for a `DogStatsD` multivalue line.
+/// Weight for a `DogStatsD` multivalue line.
 ///
 /// Defines the relative weight of a certain number of 'values' packed into a
 /// single metric line.

--- a/lading/src/payload/dogstatsd.rs
+++ b/lading/src/payload/dogstatsd.rs
@@ -124,7 +124,7 @@ pub struct Config {
     /// payload.
     #[serde(default)]
     pub kind_weights: KindWeights,
-    /// Defines the relative probability of each kind of DogStatsD metic.
+    /// Defines the relative probability of each kind of DogStatsD metric.
     #[serde(default)]
     pub metric_weights: MetricWeights,
     /// Defines the relative probability of a metric having multiple values.

--- a/lading/src/payload/dogstatsd.rs
+++ b/lading/src/payload/dogstatsd.rs
@@ -128,7 +128,7 @@ pub struct Config {
     #[serde(default)]
     pub metric_weights: MetricWeights,
     /// Defines the relative probability of a metric having multiple values.
-    /// Choices are evenly weighted among those listed.
+    /// Choices are weighted according to the specified weight.
     #[serde(default = "default_metric_multivalue")]
     pub metric_multivalue: Vec<MetricValueWeight>,
 }

--- a/lading/src/payload/dogstatsd/metric.rs
+++ b/lading/src/payload/dogstatsd/metric.rs
@@ -13,6 +13,7 @@ use super::{choose_or_not, common};
 #[derive(Debug, Clone)]
 pub(crate) struct MetricGenerator {
     pub(crate) metric_weights: WeightedIndex<u8>,
+    pub(crate) metric_multivalue: Vec<u8>,
     pub(crate) names: Vec<String>,
     pub(crate) container_ids: Vec<String>,
     pub(crate) tags: Vec<common::tags::Tags>,
@@ -27,7 +28,7 @@ impl Generator<Metric> for MetricGenerator {
         let name = self.names.choose(&mut rng).unwrap().clone();
         let tags = choose_or_not(&mut rng, &self.tags);
         let sample_rate = rng.gen();
-        let total_values = rng.gen_range(1..32);
+        let total_values = *self.metric_multivalue.choose(&mut rng).unwrap() as usize;
         let value: Vec<common::NumValue> =
             Standard.sample_iter(&mut rng).take(total_values).collect();
 

--- a/lading/src/payload/dogstatsd/metric.rs
+++ b/lading/src/payload/dogstatsd/metric.rs
@@ -13,7 +13,8 @@ use super::{choose_or_not, common};
 #[derive(Debug, Clone)]
 pub(crate) struct MetricGenerator {
     pub(crate) metric_weights: WeightedIndex<u8>,
-    pub(crate) metric_multivalue: Vec<u8>,
+    pub(crate) metric_multivalue_weights: WeightedIndex<u8>,
+    pub(crate) metric_multivalue_choices: Vec<u8>,
     pub(crate) names: Vec<String>,
     pub(crate) container_ids: Vec<String>,
     pub(crate) tags: Vec<common::tags::Tags>,
@@ -28,7 +29,8 @@ impl Generator<Metric> for MetricGenerator {
         let name = self.names.choose(&mut rng).unwrap().clone();
         let tags = choose_or_not(&mut rng, &self.tags);
         let sample_rate = rng.gen();
-        let total_values = *self.metric_multivalue.choose(&mut rng).unwrap() as usize;
+        let metric_multivalue_choice_idx = self.metric_multivalue_weights.sample(rng);
+        let total_values = self.metric_multivalue_choices[metric_multivalue_choice_idx] as usize;
         let value: Vec<common::NumValue> =
             Standard.sample_iter(&mut rng).take(total_values).collect();
 


### PR DESCRIPTION
### What does this PR do?

In DogStatsD it is allowable for a metric line to have multiple values. In practice, this is rare. Our previous 1/32 odds of producing only a single-valued line makes lading's output unusual. This is not a bad thing but it is behavior that we want users to be able to configure.

For the purposes of backward compatibility we maintain the same 1/32 odds.

### Related issues

REF SMP-663