### PR TITLE
Allow users to configure DogStatsD value ranges

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## [0.17.3-rc2]
+### Changed
+- We now allow users to set the range of values for DogStatsD metrics.
+
 ## [0.17.3-rc1]
 ### Fixed
 - We no longer incorrectly send multiple values on a SET metric in DogStatsD.

--- a/lading/src/block.rs
+++ b/lading/src/block.rs
@@ -131,6 +131,7 @@ where
             kind_weights,
             metric_weights,
             metric_multivalue,
+            metric_value_range,
         }) => {
             let mn_range = *metric_names_minimum..*metric_names_maximum;
             let tg_range = *tag_keys_minimum..*tag_keys_maximum;
@@ -141,6 +142,7 @@ where
                 *kind_weights,
                 *metric_weights,
                 metric_multivalue,
+                *metric_value_range,
                 &mut rng,
             );
 

--- a/lading/src/payload/dogstatsd.rs
+++ b/lading/src/payload/dogstatsd.rs
@@ -373,7 +373,7 @@ mod test {
     use rand::{rngs::SmallRng, SeedableRng};
 
     use crate::payload::{
-        dogstatsd::{default_metric_multivalue, KindWeights, MetricWeights},
+        dogstatsd::{default_metric_multivalue, KindWeights, MetricValueRange, MetricWeights},
         DogStatsD, Serialize,
     };
 
@@ -389,8 +389,11 @@ mod test {
             let kind_weights = KindWeights::default();
             let metric_weights = MetricWeights::default();
             let metric_multivalue_weights = default_metric_multivalue();
+            let metric_value_range = MetricValueRange::default();
             let dogstatsd = DogStatsD::new(metric_names_range, tag_keys_range, kind_weights,
-                                           metric_weights, &metric_multivalue_weights, &mut rng);
+                                           metric_weights, &metric_multivalue_weights,
+                                           metric_value_range,
+                                           &mut rng);
 
             let mut bytes = Vec::with_capacity(max_bytes);
             dogstatsd.to_bytes(rng, max_bytes, &mut bytes).unwrap();

--- a/lading/src/payload/dogstatsd/common.rs
+++ b/lading/src/payload/dogstatsd/common.rs
@@ -7,7 +7,7 @@ use crate::payload::Generator;
 pub(crate) mod tags;
 
 pub(crate) struct NumValueGenerator {
-    pub(crate) value_range: Range<f32>,
+    pub(crate) value_range: Range<f64>,
 }
 
 #[allow(clippy::cast_possible_truncation, clippy::cast_lossless)]
@@ -17,7 +17,7 @@ impl Generator<NumValue> for NumValueGenerator {
         R: rand::Rng + ?Sized,
     {
         match rng.gen_range(0..=1) {
-            0 => NumValue::Float(rng.gen_range(self.value_range.clone()) as f64),
+            0 => NumValue::Float(rng.gen_range(self.value_range.clone())),
             1 => NumValue::Int(rng.gen_range(self.value_range.clone()) as i64),
             _ => unreachable!(),
         }

--- a/lading/src/payload/dogstatsd/common.rs
+++ b/lading/src/payload/dogstatsd/common.rs
@@ -1,25 +1,32 @@
-use std::fmt;
+use std::{fmt, ops::Range};
 
 use rand::{distributions::Standard, prelude::Distribution, Rng};
 
+use crate::payload::Generator;
+
 pub(crate) mod tags;
+
+pub(crate) struct NumValueGenerator {
+    pub(crate) value_range: Range<f32>,
+}
+
+#[allow(clippy::cast_possible_truncation, clippy::cast_lossless)]
+impl Generator<NumValue> for NumValueGenerator {
+    fn generate<R>(&self, rng: &mut R) -> NumValue
+    where
+        R: rand::Rng + ?Sized,
+    {
+        match rng.gen_range(0..=1) {
+            0 => NumValue::Float(rng.gen_range(self.value_range.clone()) as f64),
+            1 => NumValue::Int(rng.gen_range(self.value_range.clone()) as i64),
+            _ => unreachable!(),
+        }
+    }
+}
 
 pub(crate) enum NumValue {
     Float(f64),
     Int(i64),
-}
-
-impl Distribution<NumValue> for Standard {
-    fn sample<R>(&self, rng: &mut R) -> NumValue
-    where
-        R: Rng + ?Sized,
-    {
-        match rng.gen_range(0..=1) {
-            0 => NumValue::Float(rng.gen()),
-            1 => NumValue::Int(rng.gen()),
-            _ => unreachable!(),
-        }
-    }
 }
 
 impl fmt::Display for NumValue {

--- a/lading/src/payload/dogstatsd/metric.rs
+++ b/lading/src/payload/dogstatsd/metric.rs
@@ -34,7 +34,8 @@ impl Generator<Metric> for MetricGenerator {
         let total_values = self.metric_multivalue_choices[metric_multivalue_choice_idx] as usize;
 
         let value_gen = NumValueGenerator {
-            value_range: self.metric_value_range.min..self.metric_value_range.max,
+            value_range: f64::from(self.metric_value_range.min)
+                ..f64::from(self.metric_value_range.max),
         };
         let mut values = Vec::with_capacity(total_values);
         for _ in 0..total_values {


### PR DESCRIPTION
### What does this PR do?

While investigating Datadog Agent behavior we've thought it might be useful to limit the range of metric values. This commit allows users to configure that, defaulting to [f32::min,f32::max).

### Related issues

REF SMP-664
