### PR TITLE
Prepare release to crates.io

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -104,3 +104,14 @@ jobs:
       - name: Upload binary to S3
         run: |
           aws s3 cp target/${{ matrix.target }}/release/lading s3://lading-releases/${{  github.ref_name }}/${{ matrix.target }}/lading
+
+      - name: Publish to crates.io
+        run: |
+          cargo publish \
+            --token ${{ secrets.CARGO_REGISTRY_TOKEN }} \
+            --locked \
+            --package lading-capture
+          cargo publish \
+            --token ${{ secrets.CARGO_REGISTRY_TOKEN }} \
+            --locked \
+            --package lading

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -105,6 +105,11 @@ jobs:
         run: |
           aws s3 cp target/${{ matrix.target }}/release/lading s3://lading-releases/${{  github.ref_name }}/${{ matrix.target }}/lading
 
+  crates-io-publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
       - name: Publish to crates.io
         run: |
           cargo publish \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## [0.17.4]
+### Added
+- `lading` and `lading-capture` releases are now published on crates.io.
+
 ## [0.17.3]
 ### Fixed
 - We no longer incorrectly send multiple values on a SET metric in DogStatsD.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -870,7 +870,7 @@ dependencies = [
 
 [[package]]
 name = "lading"
-version = "0.17.3"
+version = "0.17.4"
 dependencies = [
  "async-pidfd",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -870,7 +870,7 @@ dependencies = [
 
 [[package]]
 name = "lading"
-version = "0.17.3"
+version = "0.17.4"
 dependencies = [
  "async-pidfd",
  "async-trait",
@@ -917,7 +917,7 @@ dependencies = [
 
 [[package]]
 name = "lading-capture"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "prost",
  "prost-build",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1187,7 +1187,8 @@ checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
 [[package]]
 name = "opentelemetry"
 version = "0.18.0"
-source = "git+https://github.com/open-telemetry/opentelemetry-rust/?rev=6078e32#6078e32ab4d19d5978e97025fdd2e7c75264d36d"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69d6c3d7288a106c0a363e4b0e8d308058d56902adefb16f4936f417ffef086e"
 dependencies = [
  "opentelemetry_api",
  "opentelemetry_sdk",
@@ -1196,19 +1197,22 @@ dependencies = [
 [[package]]
 name = "opentelemetry-proto"
 version = "0.1.0"
-source = "git+https://github.com/open-telemetry/opentelemetry-rust/?rev=6078e32#6078e32ab4d19d5978e97025fdd2e7c75264d36d"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d61a2f56df5574508dd86aaca016c917489e589ece4141df1b5e349af8d66c28"
 dependencies = [
  "futures",
  "futures-util",
  "opentelemetry",
  "prost",
  "tonic 0.8.3",
+ "tonic-build 0.8.4",
 ]
 
 [[package]]
 name = "opentelemetry_api"
 version = "0.18.0"
-source = "git+https://github.com/open-telemetry/opentelemetry-rust/?rev=6078e32#6078e32ab4d19d5978e97025fdd2e7c75264d36d"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c24f96e21e7acc813c7a8394ee94978929db2bcc46cf6b5014fc612bf7760c22"
 dependencies = [
  "fnv",
  "futures-channel",
@@ -1223,7 +1227,8 @@ dependencies = [
 [[package]]
 name = "opentelemetry_sdk"
 version = "0.18.0"
-source = "git+https://github.com/open-telemetry/opentelemetry-rust/?rev=6078e32#6078e32ab4d19d5978e97025fdd2e7c75264d36d"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ca41c4933371b61c2a2f214bf16931499af4ec90543604ec828f7a625c09113"
 dependencies = [
  "async-trait",
  "crossbeam-channel",
@@ -1906,7 +1911,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tonic 0.9.2",
- "tonic-build",
+ "tonic-build 0.9.2",
 ]
 
 [[package]]
@@ -2239,6 +2244,19 @@ dependencies = [
  "tower-layer",
  "tower-service",
  "tracing",
+]
+
+[[package]]
+name = "tonic-build"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5bf5e9b9c0f7e0a7c027dcfaba7b2c60816c7049171f679d99ee2ff65d0de8c4"
+dependencies = [
+ "prettyplease",
+ "proc-macro2 1.0.66",
+ "prost-build",
+ "quote 1.0.31",
+ "syn 1.0.109",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -870,7 +870,7 @@ dependencies = [
 
 [[package]]
 name = "lading"
-version = "0.17.4"
+version = "0.17.3"
 dependencies = [
  "async-pidfd",
  "async-trait",
@@ -917,7 +917,7 @@ dependencies = [
 
 [[package]]
 name = "lading-capture"
-version = "0.1.1"
+version = "0.1.0"
 dependencies = [
  "prost",
  "prost-build",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -917,7 +917,7 @@ dependencies = [
 
 [[package]]
 name = "lading-capture"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "prost",
  "prost-build",

--- a/lading/Cargo.toml
+++ b/lading/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lading"
-version = "0.17.3"
+version = "0.17.4"
 authors = ["Brian L. Troutwine <brian.troutwine@datadoghq.com>", "George Hahn <george.hahn@datadoghq.com"]
 edition = "2021"
 license = "MIT"

--- a/lading/Cargo.toml
+++ b/lading/Cargo.toml
@@ -28,8 +28,7 @@ metrics-util = { version = "0.15" }
 nix = { version = "0.26" }
 num_cpus = { version = "1.16" }
 once_cell = "1.18"
-opentelemetry-proto = { git = "https://github.com/open-telemetry/opentelemetry-rust/", rev = "6078e32", features = ["traces", "metrics", "logs", "gen-tonic",
-] }
+opentelemetry-proto = { version = "0.1.0", features = ["traces", "metrics", "logs", "gen-tonic" ] }
 prost = "0.11"
 rand = { version = "0.8", default-features = false, features = ["small_rng", "std", "std_rng" ]}
 reqwest = { version = "0.11", default-features = false, features = ["json"] }

--- a/lading/Cargo.toml
+++ b/lading/Cargo.toml
@@ -10,7 +10,7 @@ categories = ["development-tools::profiling"]
 description = "A tool for load testing daemons."
 
 [dependencies]
-lading-capture = { path = "../lading_capture" }
+lading-capture = { version = "0.1", path = "../lading_capture" }
 
 async-trait = { version = "0.1", default-features = false, features = [] }
 byte-unit = { version = "4.0", features = ["serde"] }

--- a/lading/Cargo.toml
+++ b/lading/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lading"
-version = "0.17.4"
+version = "0.17.3"
 authors = ["Brian L. Troutwine <brian.troutwine@datadoghq.com>", "George Hahn <george.hahn@datadoghq.com"]
 edition = "2021"
 license = "MIT"

--- a/lading_capture/Cargo.toml
+++ b/lading_capture/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lading-capture"
-version = "0.1.1"
+version = "0.1.0"
 authors = ["Brian L. Troutwine <brian.troutwine@datadoghq.com>", "George Hahn <george.hahn@datadoghq.com"]
 edition = "2021"
 license = "MIT"

--- a/lading_capture/Cargo.toml
+++ b/lading_capture/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lading-capture"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["Brian L. Troutwine <brian.troutwine@datadoghq.com>", "George Hahn <george.hahn@datadoghq.com"]
 edition = "2021"
 license = "MIT"


### PR DESCRIPTION
### What does this PR do?

Prepare lading crates for publishing to crates.io.

### Motivation

This will get lading docs on docs.rs and will let us take a versioned dependency on `lading-capture`.

### Steps before merging

- [x] Set `lading-capture` and `lading` versions to `0.1.0` and `0.17.3` respectively.
- [x] Release `lading-capture` and `lading` crates manually to create them on crates.io. The CI token intentionally lacks permission to publish new crates.
- [x] Add SMP team to lading owners: `﻿cargo owner --add github:DataDog:single-machine-performance`.
- [x] Undo the manual version changes.
- [x] Tag `0.17.4` and verify that it is released correctly.