### PR TITLE
Introduce a pool mechanism for producing small strings

### DIFF
--- a/lading/src/block.rs
+++ b/lading/src/block.rs
@@ -178,7 +178,8 @@ where
             labels,
         ),
         payload::Config::Ascii => {
-            construct_block_cache_inner(&mut rng, &payload::Ascii, block_chunks, labels)
+            let pyld = payload::Ascii::new(&mut rng);
+            construct_block_cache_inner(&mut rng, &pyld, block_chunks, labels)
         }
         payload::Config::DatadogLog => {
             let serializer = payload::DatadogLog::new(&mut rng);

--- a/lading_payload/benches/ascii.rs
+++ b/lading_payload/benches/ascii.rs
@@ -1,0 +1,39 @@
+use criterion::{criterion_group, BenchmarkId, Criterion, Throughput};
+
+use lading_payload::{ascii, Serialize};
+use rand::{rngs::SmallRng, SeedableRng};
+use std::time::Duration;
+
+fn ascii_setup(c: &mut Criterion) {
+    c.bench_function("ascii_setup", |b| {
+        b.iter(|| {
+            let mut rng = SmallRng::seed_from_u64(19690716);
+            let _dd = ascii::Ascii::new(&mut rng);
+        })
+    });
+}
+
+fn ascii_all(c: &mut Criterion) {
+    let mb = 1_000_000; // 1 MiB
+
+    let mut group = c.benchmark_group("ascii_all");
+    for size in &[mb, 10 * mb, 100 * mb, 1_000 * mb] {
+        group.throughput(Throughput::Bytes(*size as u64));
+        group.bench_with_input(BenchmarkId::from_parameter(size), size, |b, &size| {
+            b.iter(|| {
+                let mut rng = SmallRng::seed_from_u64(19690716);
+                let asc = ascii::Ascii::new(&mut rng);
+                let mut writer = Vec::with_capacity(size);
+
+                asc.to_bytes(rng, size, &mut writer).unwrap();
+            });
+        });
+    }
+    group.finish();
+}
+
+criterion_group!(
+    name = benches;
+    config = Criterion::default().measurement_time(Duration::from_secs(90));
+    targets = ascii_setup, ascii_all
+);

--- a/lading_payload/benches/default.rs
+++ b/lading_payload/benches/default.rs
@@ -1,4 +1,6 @@
 use criterion::criterion_main;
 
+mod ascii;
 mod dogstatsd;
-criterion_main!(dogstatsd::benches,);
+
+criterion_main!(ascii::benches, dogstatsd::benches,);

--- a/lading_payload/proptest-regressions/common/strings.txt
+++ b/lading_payload/proptest-regressions/common/strings.txt
@@ -1,0 +1,9 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+cc af61ca38851fafeed4d96b45d1d1aca38e2ab8a1489b51ccae6e0e178640e569 # shrinks to seed = 0, max_bytes = 2, of_size_bytes = 0, alphabet = "￼a🈐aAaA0𐦀A𐠊A\u{e0100}"
+cc e4740adac235cc14baefdb17ab4e7b825a9100e1e140031f72c0eb66783a6bdc # shrinks to seed = 49880598398515969, max_bytes = 3977, of_size_bytes = 0, alphabet = "ힰA\u{11c92}® "
+cc 7d00cd4ac860c10fd2a903761b1540638fb95f92bfd352cbf952ec53760bedb4 # shrinks to seed = 170628173656970550, max_bytes = 7313, of_size_bytes = 0, alphabet = " 𒒀"

--- a/lading_payload/src/ascii.rs
+++ b/lading_payload/src/ascii.rs
@@ -4,18 +4,31 @@ use std::io::Write;
 
 use rand::Rng;
 
-use crate::{Error, Serialize};
-
-use super::{common::AsciiString, Generator};
+use crate::{common::strings, Error};
 
 const MAX_LENGTH: u16 = 6_144; // 6 KiB
 
-#[derive(Debug, Default, Clone, Copy)]
-#[cfg_attr(test, derive(proptest_derive::Arbitrary))]
-/// Ascii text payload
-pub struct Ascii;
+#[derive(Debug, Clone)]
+/// ASCII text payload
+pub struct Ascii {
+    pool: strings::Pool,
+}
 
-impl Serialize for Ascii {
+impl Ascii {
+    /// Construct a new instance of `Ascii`
+    pub fn new<R>(rng: &mut R) -> Self
+    where
+        R: rand::Rng + ?Sized,
+    {
+        Self {
+            // SAFETY: Do not adjust this downward below MAX_LENGTH without also
+            // adjusting the input to `self.pool.of_size` below.
+            pool: strings::Pool::with_size(rng, usize::from(MAX_LENGTH * 4)),
+        }
+    }
+}
+
+impl crate::Serialize for Ascii {
     fn to_bytes<W, R>(&self, mut rng: R, max_bytes: usize, writer: &mut W) -> Result<(), Error>
     where
         R: Rng + Sized,
@@ -23,7 +36,10 @@ impl Serialize for Ascii {
     {
         let mut bytes_remaining = max_bytes;
         loop {
-            let encoding: String = AsciiString::with_maximum_length(MAX_LENGTH).generate(&mut rng);
+            let bytes = rng.gen_range(1..MAX_LENGTH);
+            // SAFETY: the maximum request is always less than the size of the
+            // pool, per our constructor.
+            let encoding: &str = self.pool.of_size(&mut rng, usize::from(bytes)).unwrap();
             let line_length = encoding.len() + 1; // add one for the newline
             match bytes_remaining.checked_sub(line_length) {
                 Some(remainder) => {
@@ -49,8 +65,8 @@ mod test {
         #[test]
         fn payload_not_exceed_max_bytes(seed: u64, max_bytes: u16) {
             let max_bytes = max_bytes as usize;
-            let rng = SmallRng::seed_from_u64(seed);
-            let ascii = Ascii::default();
+            let mut rng = SmallRng::seed_from_u64(seed);
+            let ascii = Ascii::new(&mut rng);
 
             let mut bytes = Vec::with_capacity(max_bytes);
             ascii.to_bytes(rng, max_bytes, &mut bytes).unwrap();

--- a/lading_payload/src/common.rs
+++ b/lading_payload/src/common.rs
@@ -1,5 +1,8 @@
-use super::Generator;
+pub(crate) mod strings;
+
 use std::ops::Range;
+
+use crate::Generator;
 
 const CHARSET: &[u8] = b"abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
 

--- a/lading_payload/src/common/strings.rs
+++ b/lading_payload/src/common/strings.rs
@@ -1,0 +1,128 @@
+//! Code for the quick creation of randomize strings
+
+use rand::seq::SliceRandom;
+
+const ALPHANUM: &[u8] = b"abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
+
+/// A pool of strings
+///
+/// Our payloads need to create a number of small strings. This structures holds
+/// those strings, created at `Pool` initialization. We differ from a slab or
+/// `typed_arena` in that there is no insertion, only creation, and the
+/// structure hands out `&str`, randomly.
+#[derive(Debug, Clone)]
+pub(crate) struct Pool {
+    // The approach for the pool is simple. The user provides an alphabet and a
+    // maximum size in memory and we stuff a `String` until that size is
+    // met. The user calls for a `&str` of a certain size less than the maximum
+    // size and we make a slice of that size in `inner` at a random offset.
+    inner: String,
+}
+
+impl Pool {
+    /// Create a new instance of `Pool` with the default alpha-numeric character
+    /// set of size `bytes`.
+    pub(crate) fn with_size<R>(rng: &mut R, bytes: usize) -> Self
+    where
+        R: rand::Rng + ?Sized,
+    {
+        Self::with_size_and_alphabet(rng, bytes, ALPHANUM)
+    }
+
+    /// Create a new instance of `Pool` with the provided `alphabet` and set of
+    /// size `bytes`.
+    ///
+    /// User should supply an alphabet of ASCII characters.
+    pub(crate) fn with_size_and_alphabet<R>(rng: &mut R, bytes: usize, alphabet: &[u8]) -> Self
+    where
+        R: rand::Rng + ?Sized,
+    {
+        let mut inner = String::new();
+
+        if !alphabet.is_empty() {
+            inner.reserve(bytes);
+            for _ in 0..bytes {
+                inner.push(unsafe {
+                    // Safety: `chars` is not empty so choose will never return
+                    // None and the values passed in `alphabet` will always be
+                    // valid.
+                    char::from_u32_unchecked(u32::from(*alphabet.choose(rng).unwrap()))
+                });
+            }
+        }
+
+        Self { inner }
+    }
+
+    /// Return a `&str` from the interior storage with size `bytes`. Result will
+    /// be `None` if the request cannot be satisfied.
+    pub(crate) fn of_size<'a, R>(&'a self, rng: &mut R, bytes: usize) -> Option<&'a str>
+    where
+        R: rand::Rng + ?Sized,
+    {
+        if bytes >= self.inner.len() {
+            return None;
+        }
+
+        let max_lower_idx = self.inner.len() - bytes;
+        let lower_idx = rng.gen_range(0..max_lower_idx);
+        let upper_idx = lower_idx + bytes;
+
+        Some(&self.inner[lower_idx..upper_idx])
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use proptest::prelude::*;
+
+    use super::{Pool, ALPHANUM};
+    use rand::{rngs::SmallRng, SeedableRng};
+
+    // Ensure that no returned string ever has a non-alphabet character.
+    proptest! {
+        #[test]
+        fn no_nonalphabet_char(seed: u64, max_bytes: u16, of_size_bytes: u16) {
+            let max_bytes = max_bytes as usize;
+            let of_size_bytes = of_size_bytes as usize;
+            let mut rng = SmallRng::seed_from_u64(seed);
+
+            let pool = Pool::with_size_and_alphabet(&mut rng, max_bytes, &ALPHANUM);
+            if let Some(s) = pool.of_size(&mut rng, of_size_bytes) {
+                for c in s.bytes() {
+                    assert!(ALPHANUM.contains(&c));
+                }
+            }
+        }
+    }
+
+    // Ensure that no returned string is ever larger or smaller than of_size_bytes.
+    proptest! {
+        #[test]
+        fn no_size_mismatch(seed: u64, max_bytes: u16, of_size_bytes: u16) {
+            let max_bytes = max_bytes as usize;
+            let of_size_bytes = of_size_bytes as usize;
+            let mut rng = SmallRng::seed_from_u64(seed);
+
+            let pool = Pool::with_size_and_alphabet(&mut rng, max_bytes, &ALPHANUM);
+            if let Some(s) = pool.of_size(&mut rng, of_size_bytes) {
+                assert!(s.len() == of_size_bytes);
+            }
+        }
+    }
+
+    // Ensure that of_size only returns None if the request is larger than the interior size.
+    proptest! {
+        #[test]
+        fn return_none_condition(seed: u64, max_bytes: u16, of_size_bytes: u16) {
+            let max_bytes = max_bytes as usize;
+            let of_size_bytes = of_size_bytes as usize;
+            let mut rng = SmallRng::seed_from_u64(seed);
+
+            let pool = Pool::with_size_and_alphabet(&mut rng, max_bytes, &ALPHANUM);
+            if pool.of_size(&mut rng, of_size_bytes).is_none() {
+                assert!(of_size_bytes > max_bytes);
+            }
+        }
+    }
+}

--- a/lading_throttle/src/stable.rs
+++ b/lading_throttle/src/stable.rs
@@ -193,12 +193,12 @@ mod test {
 
     #[test]
     fn static_capacity_never_exceeds_max_in_interval() {
-        let maximum_capacity = 490301363u32;
+        let maximum_capacity = 490_301_363u32;
         let requests: Vec<NonZeroU32> = vec![
             NonZeroU32::new(1).unwrap(),
-            NonZeroU32::new(490301363).unwrap(),
+            NonZeroU32::new(490_301_363).unwrap(),
         ];
-        capacity_never_exceeds_max_in_interval_inner(maximum_capacity, requests).unwrap()
+        capacity_never_exceeds_max_in_interval_inner(maximum_capacity, requests).unwrap();
     }
 
     fn cap_requests(max: u32) -> impl Strategy<Value = Vec<NonZeroU32>> {
@@ -216,9 +216,9 @@ mod test {
         #[test]
         fn capacity_never_exceeds_max_in_interval(
             maximum_capacity in (1..u32::MAX),
-            requests in cap_requests(u16::MAX as u32)
+            requests in cap_requests(u32::from(u16::MAX))
         ) {
-            capacity_never_exceeds_max_in_interval_inner(maximum_capacity, requests)?
+            capacity_never_exceeds_max_in_interval_inner(maximum_capacity, requests)?;
         }
     }
 }


### PR DESCRIPTION
### What does this PR do?

This commit is born of the work on #666. We realize in that PR that we spend most of our runtime producing small heap allocated strings. This PR introduces `Pool` which allows the user to request a small `&str` of a given size. It is hooked up to only a single payload -- Ascii -- but will be introduced elsewhere in follow-up work.

### Related issues

REF SMP-664
