### PR TITLE
Convert DogStatsD payload to use string pool

### DIFF
--- a/lading_payload/src/bin/lading_rev.rs
+++ b/lading_payload/src/bin/lading_rev.rs
@@ -17,8 +17,8 @@ fn main() {
     // reacquire the stdio lock each write and, also, to elide as many writes as
     // possible.
     let stdout = std::io::stdout();
-    let mut fp = BufWriter::with_capacity(1_000_000, stdout.lock());
-    for _ in 0..1_000 {
+    let mut fp = BufWriter::with_capacity(10_000_000, stdout.lock());
+    for _ in 0..1_000_000 {
         let member = dg.generate(&mut rng);
         writeln!(fp, "{member}").unwrap();
     }

--- a/lading_payload/src/common.rs
+++ b/lading_payload/src/common.rs
@@ -1,7 +1,5 @@
 pub(crate) mod strings;
 
-use std::ops::Range;
-
 use crate::Generator;
 
 const CHARSET: &[u8] = b"abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
@@ -17,21 +15,6 @@ impl Default for AsciiString {
         Self {
             min_length: 1,
             max_length: 16,
-        }
-    }
-}
-
-impl AsciiString {
-    pub(crate) fn with_maximum_length(cap: u16) -> Self {
-        Self {
-            min_length: 1,
-            max_length: cap,
-        }
-    }
-    pub(crate) fn with_length_range(range: Range<u16>) -> Self {
-        Self {
-            min_length: range.start,
-            max_length: range.end,
         }
     }
 }

--- a/lading_payload/src/common/strings.rs
+++ b/lading_payload/src/common/strings.rs
@@ -1,6 +1,8 @@
 //! Code for the quick creation of randomize strings
 
-use rand::seq::SliceRandom;
+use std::ops::Range;
+
+use rand::{distributions::uniform::SampleUniform, seq::SliceRandom};
 
 const ALPHANUM: &[u8] = b"abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
 
@@ -69,6 +71,21 @@ impl Pool {
         let upper_idx = lower_idx + bytes;
 
         Some(&self.inner[lower_idx..upper_idx])
+    }
+
+    /// Return a `&str` from the interior storage with size selected from `bytes_range`. Result will
+    /// be `None` if the request cannot be satisfied.
+    pub(crate) fn of_size_range<'a, R, T>(
+        &'a self,
+        rng: &mut R,
+        bytes_range: Range<T>,
+    ) -> Option<&'a str>
+    where
+        R: rand::Rng + ?Sized,
+        T: Into<usize> + Copy + PartialOrd + SampleUniform,
+    {
+        let bytes: usize = rng.gen_range(bytes_range).into();
+        self.of_size(rng, bytes)
     }
 }
 

--- a/lading_payload/src/dogstatsd.rs
+++ b/lading_payload/src/dogstatsd.rs
@@ -189,18 +189,6 @@ pub struct Config {
     pub metric_weights: MetricWeights,
 }
 
-fn choose_or_not<R, T>(mut rng: &mut R, pool: &[T]) -> Option<T>
-where
-    T: Clone,
-    R: rand::Rng + ?Sized,
-{
-    if rng.gen() {
-        pool.choose(&mut rng).cloned()
-    } else {
-        None
-    }
-}
-
 fn choose_or_not_ref<'a, R, T>(mut rng: &mut R, pool: &'a [T]) -> Option<&'a T>
 where
     R: rand::Rng + ?Sized,
@@ -354,7 +342,7 @@ impl MemberGenerator {
             &WeightedIndex::new(metric_choices).unwrap(),
             small_strings,
             tagsets.clone(),
-            &pool,
+            pool.as_ref(),
             &mut rng,
         );
 
@@ -397,7 +385,7 @@ impl MemberGenerator {
 /// Supra-type for all dogstatsd variants
 pub enum Member<'a> {
     /// Metrics
-    Metric(metric::Metric),
+    Metric(metric::Metric<'a>),
     /// Events, think syslog.
     Event(event::Event<'a>),
     /// Services, checked.

--- a/lading_payload/src/dogstatsd.rs
+++ b/lading_payload/src/dogstatsd.rs
@@ -201,14 +201,25 @@ where
     }
 }
 
-fn choose_or_not_fn<R, T, F>(mut rng: &mut R, func: F) -> Option<T>
+fn choose_or_not_ref<'a, R, T>(mut rng: &mut R, pool: &'a [T]) -> Option<&'a T>
+where
+    R: rand::Rng + ?Sized,
+{
+    if rng.gen() {
+        pool.choose(&mut rng)
+    } else {
+        None
+    }
+}
+
+fn choose_or_not_fn<R, T, F>(rng: &mut R, func: F) -> Option<T>
 where
     T: Clone,
     R: rand::Rng + ?Sized,
     F: FnOnce(&mut R) -> Option<T>,
 {
     if rng.gen() {
-        func(&mut rng)
+        func(rng)
     } else {
         None
     }
@@ -373,7 +384,7 @@ pub enum Member<'a> {
     /// Events, think syslog.
     Event(event::Event<'a>),
     /// Services, checked.
-    ServiceCheck(service_check::ServiceCheck),
+    ServiceCheck(service_check::ServiceCheck<'a>),
 }
 
 impl<'a> fmt::Display for Member<'a> {

--- a/lading_payload/src/dogstatsd/common/tags.rs
+++ b/lading_payload/src/dogstatsd/common/tags.rs
@@ -1,6 +1,6 @@
-use std::ops::Range;
+use std::{ops::Range, rc::Rc};
 
-use crate::common::AsciiString;
+use crate::common::strings;
 
 // This represents a list of tags that will be present on a single
 // dogstatsd message.
@@ -13,19 +13,16 @@ pub(crate) struct Generator {
     pub(crate) tags_per_msg_range: Range<usize>,
     pub(crate) tag_key_length_range: Range<u16>,
     pub(crate) tag_value_length_range: Range<u16>,
+    pub(crate) str_pool: Rc<strings::Pool>,
 }
 
 // https://docs.datadoghq.com/getting_started/tagging/#define-tags
 impl crate::Generator<Tagsets> for Generator {
-    fn generate<R>(&self, rng: &mut R) -> Tagsets
+    fn generate<R>(&self, mut rng: &mut R) -> Tagsets
     where
         R: rand::Rng + ?Sized,
     {
         let tags_per_msg_range = self.tags_per_msg_range.clone();
-
-        let tag_key_generator = AsciiString::with_length_range(self.tag_key_length_range.clone());
-        let tag_value_generator =
-            AsciiString::with_length_range(self.tag_value_length_range.clone());
 
         let mut tagsets: Vec<Tagset> = Vec::with_capacity(self.num_tagsets);
         for _ in 0..self.num_tagsets {
@@ -34,10 +31,19 @@ impl crate::Generator<Tagsets> for Generator {
             let num_tags_for_this_msg = rng.gen_range(tags_per_msg_range);
             let mut tagset = Vec::with_capacity(num_tags_for_this_msg);
             for _ in 0..num_tags_for_this_msg {
-                let mut tag = tag_key_generator.generate(rng);
-                let tag_value = tag_value_generator.generate(rng);
+                let mut tag = String::new();
+                tag.reserve(512); // a guess, big-ish but not too big
+                let key = self
+                    .str_pool
+                    .of_size_range(&mut rng, self.tag_key_length_range.clone())
+                    .unwrap();
+                let value = self
+                    .str_pool
+                    .of_size_range(&mut rng, self.tag_value_length_range.clone())
+                    .unwrap();
+                tag.push_str(key);
                 tag.push(':');
-                tag.push_str(&tag_value);
+                tag.push_str(value);
                 tagset.push(tag);
             }
             tagsets.push(tagset);

--- a/lading_payload/src/dogstatsd/event.rs
+++ b/lading_payload/src/dogstatsd/event.rs
@@ -1,26 +1,34 @@
-use std::fmt;
+use std::{fmt, ops::Range, rc::Rc};
 
-use rand::{distributions::Standard, prelude::Distribution, seq::SliceRandom, Rng};
+use rand::{distributions::Standard, prelude::Distribution, Rng};
 
-use crate::Generator;
+use crate::common::strings;
 
-use super::{choose_or_not, common};
+use super::{choose_or_not, choose_or_not_fn, common};
 
 #[derive(Debug, Clone)]
 pub(crate) struct EventGenerator {
-    pub(crate) titles: Vec<String>,
-    pub(crate) texts_or_messages: Vec<String>,
-    pub(crate) small_strings: Vec<String>,
+    pub(crate) title_length_range: Range<u16>,
+    pub(crate) texts_or_messages_length_range: Range<u16>,
+    pub(crate) small_strings_length_range: Range<u16>,
+    pub(crate) str_pool: Rc<strings::Pool>,
+    // TODO adjust so that tagsets is not allocating
     pub(crate) tagsets: common::tags::Tagsets,
 }
 
-impl Generator<Event> for EventGenerator {
-    fn generate<R>(&self, mut rng: &mut R) -> Event
+impl EventGenerator {
+    pub(crate) fn generate<'a, R>(&'a self, mut rng: &mut R) -> Event<'a>
     where
         R: rand::Rng + ?Sized,
     {
-        let title = self.titles.choose(&mut rng).unwrap().clone();
-        let text = self.texts_or_messages.choose(&mut rng).unwrap().clone();
+        let title = self
+            .str_pool
+            .of_size_range(&mut rng, self.title_length_range.clone())
+            .unwrap();
+        let text = self
+            .str_pool
+            .of_size_range(&mut rng, self.texts_or_messages_length_range.clone())
+            .unwrap();
         let tags = choose_or_not(&mut rng, &self.tagsets);
 
         Event {
@@ -29,10 +37,19 @@ impl Generator<Event> for EventGenerator {
             title,
             text,
             timestamp_second: rng.gen(),
-            hostname: choose_or_not(&mut rng, &self.small_strings),
-            aggregation_key: choose_or_not(&mut rng, &self.small_strings),
+            hostname: choose_or_not_fn(&mut rng, |r| {
+                self.str_pool
+                    .of_size_range(r, self.small_strings_length_range.clone())
+            }),
+            aggregation_key: choose_or_not_fn(&mut rng, |r| {
+                self.str_pool
+                    .of_size_range(r, self.small_strings_length_range.clone())
+            }),
             priority: rng.gen(),
-            source_type_name: choose_or_not(&mut rng, &self.small_strings),
+            source_type_name: choose_or_not_fn(&mut rng, |r| {
+                self.str_pool
+                    .of_size_range(r, self.small_strings_length_range.clone())
+            }),
             alert_type: rng.gen(),
             tags,
         }
@@ -41,21 +58,21 @@ impl Generator<Event> for EventGenerator {
 
 /// An event, like a syslog kind of.
 #[derive(Debug)]
-pub struct Event {
-    title: String,
-    text: String,
+pub struct Event<'a> {
+    title: &'a str,
+    text: &'a str,
     title_utf8_length: usize,
     text_utf8_length: usize,
     timestamp_second: Option<u32>,
-    hostname: Option<String>,
-    aggregation_key: Option<String>,
+    hostname: Option<&'a str>,
+    aggregation_key: Option<&'a str>,
     priority: Option<Priority>,
-    source_type_name: Option<String>,
+    source_type_name: Option<&'a str>,
     alert_type: Option<Alert>,
     tags: Option<common::tags::Tagset>,
 }
 
-impl fmt::Display for Event {
+impl<'a> fmt::Display for Event<'a> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         // _e{<TITLE_UTF8_LENGTH>,<TEXT_UTF8_LENGTH>}:<TITLE>|<TEXT>|d:<TIMESTAMP>|h:<HOSTNAME>|p:<PRIORITY>|t:<ALERT_TYPE>|#<TAG_KEY_1>:<TAG_VALUE_1>,<TAG_2>
         write!(

--- a/lading_payload/src/dogstatsd/metric.rs
+++ b/lading_payload/src/dogstatsd/metric.rs
@@ -6,7 +6,7 @@ use rand::{
     Rng,
 };
 
-use crate::{common::AsciiString, Generator};
+use crate::{common::strings, Generator};
 use tracing::debug;
 
 use super::{
@@ -33,7 +33,8 @@ impl MetricGenerator {
         metric_weights: &WeightedIndex<u8>,
         container_ids: Vec<String>,
         tagsets: common::tags::Tagsets,
-        rng: &mut R,
+        str_pool: &strings::Pool,
+        mut rng: &mut R,
     ) -> Self
     where
         R: Rng + ?Sized,
@@ -42,9 +43,12 @@ impl MetricGenerator {
 
         assert!(tagsets.len() >= num_contexts);
         debug!("Generating metric templates for {} contexts.", num_contexts);
-        let name_generator = AsciiString::with_length_range(name_length_range);
         for tagset in tagsets {
-            let name = name_generator.generate(rng);
+            let name = String::from(
+                str_pool
+                    .of_size_range(&mut rng, name_length_range.clone())
+                    .unwrap(),
+            );
 
             let res = match metric_weights.sample(rng) {
                 0 => Metric::Count(Count {

--- a/lading_payload/src/dogstatsd/metric/template.rs
+++ b/lading_payload/src/dogstatsd/metric/template.rs
@@ -1,0 +1,55 @@
+use crate::dogstatsd::common;
+
+#[derive(Clone, Debug)]
+/// A metric `Template` is a `super::Metric` that lacks values and has no
+/// container ID but has every other attribute of a `super::Metric`.
+pub(crate) enum Template {
+    Count(Count),
+    Gauge(Gauge),
+    Timer(Timer),
+    Histogram(Histogram),
+    Set(Set),
+    Distribution(Dist),
+}
+
+#[derive(Clone, Debug)]
+/// The count type in `DogStatsD` metric format. Monotonically increasing value.
+pub(crate) struct Count {
+    pub(crate) name: String,
+    pub(crate) tags: common::tags::Tagset,
+}
+
+#[derive(Clone, Debug)]
+/// The gauge type in `DogStatsD` format.
+pub(crate) struct Gauge {
+    pub(crate) name: String,
+    pub(crate) tags: common::tags::Tagset,
+}
+
+#[derive(Clone, Debug)]
+/// The timer type in `DogStatsD` format.
+pub(crate) struct Timer {
+    pub(crate) name: String,
+    pub(crate) tags: common::tags::Tagset,
+}
+
+#[derive(Clone, Debug)]
+/// The distribution type in `DogStatsD` format.
+pub(crate) struct Dist {
+    pub(crate) name: String,
+    pub(crate) tags: common::tags::Tagset,
+}
+
+#[derive(Clone, Debug)]
+/// The set type in `DogStatsD` format.
+pub(crate) struct Set {
+    pub(crate) name: String,
+    pub(crate) tags: common::tags::Tagset,
+}
+
+#[derive(Clone, Debug)]
+/// The histogram type in `DogStatsD` format.
+pub(crate) struct Histogram {
+    pub(crate) name: String,
+    pub(crate) tags: common::tags::Tagset,
+}


### PR DESCRIPTION
### What does this PR do?

This commit begins the process of converting the dogstatsd payload generation to use the new string pool, introduced in #675. I have only partially converted the event sub-payload -- note that tagsets have not been switched yet -- and this shows a 6% improvement to `dogstatsd_setup` and a 5% - 74% improvement to `dogstatsd_all`. It shows there's some promise to the technique that improves as we scale up the total-bytes emitted.

EDIT: By the final commit we're capping _all out at 1Gb/s, up from ~300Mb/s. 

Of note I will need to eventually convert the `Generator` trait to emit a type with a lifetime. Since I can't do that incrementally the `generate` function in select areas temporarily does not come from the trait. This will have to be resolved by converting all the payloads to non-copying implementations, which will take some time and is outside of the scope of this PR.

### Related issues

REF SMP-664