### PR TITLE
Use associated types in Generator trait

### DIFF
--- a/lading_payload/src/apache_common.rs
+++ b/lading_payload/src/apache_common.rs
@@ -1,6 +1,6 @@
 //! Apache common payload.
 
-use crate::{common::strings, Error};
+use crate::{common::strings, Error, Generator};
 
 use core::fmt;
 use rand::{distributions::Standard, prelude::Distribution, seq::SliceRandom, Rng};
@@ -310,8 +310,12 @@ impl ApacheCommon {
             str_pool: strings::Pool::with_size(rng, 1_000_000),
         }
     }
+}
 
-    pub(crate) fn generate<'a, R>(&'a self, mut rng: &mut R) -> Member<'a>
+impl<'a> Generator<'a> for ApacheCommon {
+    type Output = Member<'a>;
+
+    fn generate<R>(&'a self, mut rng: &mut R) -> Self::Output
     where
         R: rand::Rng + ?Sized,
     {

--- a/lading_payload/src/datadog_logs.rs
+++ b/lading_payload/src/datadog_logs.rs
@@ -4,7 +4,7 @@ use std::io::Write;
 
 use rand::{distributions::Standard, prelude::Distribution, seq::SliceRandom, Rng};
 
-use crate::{common::strings, Error};
+use crate::{common::strings, Error, Generator};
 
 const STATUSES: [&str; 3] = ["notice", "info", "warning"];
 const HOSTNAMES: [&str; 4] = ["alpha", "beta", "gamma", "localhost"];
@@ -95,8 +95,12 @@ impl DatadogLog {
             str_pool: strings::Pool::with_size(rng, 1_000_000),
         }
     }
+}
 
-    pub(crate) fn generate<'a, R>(&'a self, mut rng: &mut R) -> Member<'a>
+impl<'a> Generator<'a> for DatadogLog {
+    type Output = Member<'a>;
+
+    fn generate<R>(&'a self, mut rng: &mut R) -> Self::Output
     where
         R: rand::Rng + ?Sized,
     {

--- a/lading_payload/src/dogstatsd/common/tags.rs
+++ b/lading_payload/src/dogstatsd/common/tags.rs
@@ -17,8 +17,10 @@ pub(crate) struct Generator {
 }
 
 // https://docs.datadoghq.com/getting_started/tagging/#define-tags
-impl crate::Generator<Tagsets> for Generator {
-    fn generate<R>(&self, mut rng: &mut R) -> Tagsets
+impl<'a> crate::Generator<'a> for Generator {
+    type Output = Tagsets;
+
+    fn generate<R>(&'a self, mut rng: &mut R) -> Self::Output
     where
         R: rand::Rng + ?Sized,
     {

--- a/lading_payload/src/dogstatsd/event.rs
+++ b/lading_payload/src/dogstatsd/event.rs
@@ -2,7 +2,7 @@ use std::{fmt, ops::Range, rc::Rc};
 
 use rand::{distributions::Standard, prelude::Distribution, Rng};
 
-use crate::common::strings;
+use crate::{common::strings, Generator};
 
 use super::{choose_or_not_fn, choose_or_not_ref, common};
 
@@ -15,8 +15,10 @@ pub(crate) struct EventGenerator {
     pub(crate) tagsets: common::tags::Tagsets,
 }
 
-impl EventGenerator {
-    pub(crate) fn generate<'a, R>(&'a self, mut rng: &mut R) -> Event<'a>
+impl<'a> Generator<'a> for EventGenerator {
+    type Output = Event<'a>;
+
+    fn generate<R>(&'a self, mut rng: &mut R) -> Self::Output
     where
         R: rand::Rng + ?Sized,
     {

--- a/lading_payload/src/dogstatsd/metric.rs
+++ b/lading_payload/src/dogstatsd/metric.rs
@@ -6,7 +6,7 @@ use rand::{
     Rng,
 };
 
-use crate::{common::strings, dogstatsd::metric::template::Template};
+use crate::{common::strings, dogstatsd::metric::template::Template, Generator};
 use tracing::debug;
 
 use super::{choose_or_not_ref, common};
@@ -67,8 +67,12 @@ impl MetricGenerator {
             multivalue_pack_probability,
         }
     }
+}
 
-    pub(crate) fn generate<'a, R>(&'a self, mut rng: &mut R) -> Metric<'a>
+impl<'a> Generator<'a> for MetricGenerator {
+    type Output = Metric<'a>;
+
+    fn generate<R>(&'a self, mut rng: &mut R) -> Self::Output
     where
         R: rand::Rng + ?Sized,
     {

--- a/lading_payload/src/dogstatsd/service_check.rs
+++ b/lading_payload/src/dogstatsd/service_check.rs
@@ -2,6 +2,8 @@ use std::fmt;
 
 use rand::{distributions::Standard, prelude::Distribution, seq::SliceRandom, Rng};
 
+use crate::Generator;
+
 use super::{choose_or_not_ref, common};
 
 #[derive(Debug, Clone)]
@@ -12,8 +14,10 @@ pub(crate) struct ServiceCheckGenerator {
     pub(crate) tagsets: common::tags::Tagsets,
 }
 
-impl ServiceCheckGenerator {
-    pub(crate) fn generate<'a, R>(&'a self, mut rng: &mut R) -> ServiceCheck<'a>
+impl<'a> Generator<'a> for ServiceCheckGenerator {
+    type Output = ServiceCheck<'a>;
+
+    fn generate<R>(&'a self, mut rng: &mut R) -> Self::Output
     where
         R: rand::Rng + ?Sized,
     {

--- a/lading_payload/src/fluent.rs
+++ b/lading_payload/src/fluent.rs
@@ -7,7 +7,7 @@ use std::{collections::HashMap, io::Write};
 use rand::Rng;
 use serde_tuple::Serialize_tuple;
 
-use crate::{common::strings, Error};
+use crate::{common::strings, Error, Generator};
 
 #[derive(Debug, Clone)]
 /// Fluent payload
@@ -25,8 +25,12 @@ impl Fluent {
             str_pool: strings::Pool::with_size(rng, 1_000_000),
         }
     }
+}
 
-    pub(crate) fn generate<'a, R>(&'a self, rng: &mut R) -> Member<'a>
+impl<'a> Generator<'a> for Fluent {
+    type Output = Member<'a>;
+
+    fn generate<R>(&'a self, rng: &mut R) -> Self::Output
     where
         R: rand::Rng + ?Sized,
     {

--- a/lading_payload/src/json.rs
+++ b/lading_payload/src/json.rs
@@ -12,7 +12,7 @@ const SIZES: [usize; 13] = [0, 1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 2048
 
 /// A simplistic 'Payload' structure without self-reference
 #[derive(Debug, serde::Serialize, serde::Deserialize)]
-struct Member {
+pub struct Member {
     /// A u64. Its name has no meaning.
     pub(crate) id: u64,
     /// A u64. Its name has no meaning.
@@ -44,8 +44,10 @@ impl Distribution<Member> for Standard {
 /// A JSON payload
 pub struct Json;
 
-impl Generator<Member> for Json {
-    fn generate<R>(&self, rng: &mut R) -> Member
+impl<'a> Generator<'a> for Json {
+    type Output = Member;
+
+    fn generate<R>(&'a self, rng: &mut R) -> Self::Output
     where
         R: rand::Rng + ?Sized,
     {

--- a/lading_payload/src/lib.rs
+++ b/lading_payload/src/lib.rs
@@ -197,8 +197,10 @@ const fn div_ceil(lhs: usize, rhs: usize) -> usize {
 }
 
 /// Generate instance of `I` from source of randomness `S`.
-pub(crate) trait Generator<I> {
-    fn generate<R>(&self, rng: &mut R) -> I
+pub(crate) trait Generator<'a> {
+    type Output: 'a;
+
+    fn generate<R>(&'a self, rng: &mut R) -> Self::Output
     where
         R: rand::Rng + ?Sized;
 }

--- a/lading_payload/src/opentelemetry_log.rs
+++ b/lading_payload/src/opentelemetry_log.rs
@@ -59,8 +59,10 @@ impl OpentelemetryLogs {
     }
 }
 
-impl Generator<LogRecord> for OpentelemetryLogs {
-    fn generate<R>(&self, mut rng: &mut R) -> LogRecord
+impl<'a> Generator<'a> for OpentelemetryLogs {
+    type Output = LogRecord;
+
+    fn generate<R>(&'a self, mut rng: &mut R) -> Self::Output
     where
         R: rand::Rng + ?Sized,
     {

--- a/lading_payload/src/opentelemetry_metric.rs
+++ b/lading_payload/src/opentelemetry_metric.rs
@@ -37,7 +37,10 @@ impl ExportMetricsServiceRequest {
     }
 }
 
-struct Metric(v1::Metric);
+/// A OTLP metric
+#[derive(Debug)]
+pub struct Metric(v1::Metric);
+
 struct NumberDataPoint(v1::NumberDataPoint);
 struct Gauge(v1::Gauge);
 struct Sum(v1::Sum);
@@ -122,8 +125,10 @@ impl OpentelemetryMetrics {
     }
 }
 
-impl Generator<Metric> for OpentelemetryMetrics {
-    fn generate<R>(&self, mut rng: &mut R) -> Metric
+impl<'a> Generator<'a> for OpentelemetryMetrics {
+    type Output = Metric;
+
+    fn generate<R>(&'a self, mut rng: &mut R) -> Self::Output
     where
         R: rand::Rng + ?Sized,
     {

--- a/lading_payload/src/opentelemetry_trace.rs
+++ b/lading_payload/src/opentelemetry_trace.rs
@@ -36,7 +36,10 @@ impl ExportTraceServiceRequest {
         }
     }
 }
-struct Span(v1::Span);
+
+/// An OTLP span
+#[derive(Debug)]
+pub struct Span(v1::Span);
 
 #[derive(Debug, Clone)]
 /// OTLP trace payload
@@ -56,8 +59,10 @@ impl OpentelemetryTraces {
     }
 }
 
-impl Generator<Span> for OpentelemetryTraces {
-    fn generate<R>(&self, mut rng: &mut R) -> Span
+impl<'a> Generator<'a> for OpentelemetryTraces {
+    type Output = Span;
+
+    fn generate<R>(&'a self, mut rng: &mut R) -> Self::Output
     where
         R: rand::Rng + ?Sized,
     {

--- a/lading_payload/src/trace_agent.rs
+++ b/lading_payload/src/trace_agent.rs
@@ -5,7 +5,7 @@ use std::{collections::HashMap, io::Write};
 use rand::{seq::SliceRandom, Rng};
 use rmp_serde::Serializer;
 
-use crate::{common::strings, Error};
+use crate::{common::strings, Error, Generator};
 use serde::Serialize;
 
 const SERVICES: [&str; 7] = [
@@ -145,8 +145,12 @@ impl TraceAgent {
             str_pool: strings::Pool::with_size(rng, 1_000_000),
         }
     }
+}
 
-    pub(crate) fn generate<'a, R>(&'a self, mut rng: &mut R) -> Span<'a>
+impl<'a> Generator<'a> for TraceAgent {
+    type Output = Span<'a>;
+
+    fn generate<R>(&'a self, mut rng: &mut R) -> Self::Output
     where
         R: rand::Rng + ?Sized,
     {


### PR DESCRIPTION
### What does this PR do?

Follow-up to #680. I realized that the Generator trait could be used with an associated type to cover owned and reference returns just after #680 merged up. This commit slightly expands the definition of `Generator` and ensures its general use.

### Related issues

REF SMP-664
