### PR TITLE
Block cache with an infinite stream option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## [0.18.1-rc0]
+### Added
+- `lading-payload` crate is now split out from the `lading` crate
+### Changed
+- The block mechanism is reworked to provide a 'fixed' and 'streaming' model,
+  running in a separate OS thread from the tokio runtime.
+
 ## [0.18.0]
 ### Changed
 - The predictive throttle no longer exists. The only options are stable and

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1010,7 +1010,7 @@ dependencies = [
 
 [[package]]
 name = "lading"
-version = "0.18.0"
+version = "0.18.1-rc0"
 dependencies = [
  "async-pidfd",
  "byte-unit",

--- a/lading/Cargo.toml
+++ b/lading/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lading"
-version = "0.18.0"
+version = "0.18.1-rc0"
 authors = ["Brian L. Troutwine <brian.troutwine@datadoghq.com>", "George Hahn <george.hahn@datadoghq.com"]
 edition = "2021"
 license = "MIT"

--- a/lading/src/config.rs
+++ b/lading/src/config.rs
@@ -73,6 +73,8 @@ mod tests {
 
     use http::HeaderMap;
 
+    use crate::block;
+
     use super::*;
 
     #[test]
@@ -114,7 +116,8 @@ blackhole:
                                 8_f64,
                                 byte_unit::ByteUnit::MB
                             )
-                            .unwrap()
+                            .unwrap(),
+                            block_cache_method: block::CacheMethod::Fixed,
                         },
                         headers: HeaderMap::default(),
                         bytes_per_second: byte_unit::Byte::from_unit(


### PR DESCRIPTION
### What does this PR do?

This commit makes two major changes to the block cache. The most important is that the block cache's major CPU consumption -- the construction of `Block` instances -- is now done in a separate OS thread from the tokio runtime. This allows us to introduce the second more important change: infinite streams of `Blocks`. It is now possible for users to construct an unending stream of `Block` instances that do not loop. We maintain a cache of constructed `Block`s up to the maximum total bytes allow to minimize any potential latency impact.

### Additional Notes

Configuration is changed but not in a backward incompatible way.

### Related issues

REF SMP-664
