### PR TITLE
Prefer the use of FxHash over Hash

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1057,6 +1057,7 @@ version = "0.1.1"
 dependencies = [
  "prost",
  "prost-build",
+ "rustc-hash",
  "serde",
  "serde_json",
  "uuid",
@@ -1073,6 +1074,7 @@ dependencies = [
  "prost",
  "rand",
  "rmp-serde",
+ "rustc-hash",
  "serde",
  "serde_json",
  "serde_tuple",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ tokio = { version = "1.32" }
 tracing = { version = "0.1" }
 uuid =  { version = "1.2", default-features = false, features = ["v4", "serde"] }
 prost = "0.11"
+rustc-hash = { version = "1.1.0" }
 
 [profile.release]
 lto = true        # Optimize our binary at link stage.

--- a/lading/Cargo.toml
+++ b/lading/Cargo.toml
@@ -31,7 +31,7 @@ num_cpus = { version = "1.16" }
 once_cell = "1.18"
 rand = { workspace = true, default-features = false, features = ["small_rng", "std", "std_rng" ]}
 reqwest = { version = "0.11", default-features = false, features = ["json"] }
-rustc-hash = { version = "1.1.0" }
+rustc-hash = { workspace = true }
 serde = { workspace = true }
 serde_json = {workspace = true }
 serde_qs = "0.12"

--- a/lading/src/bin/lading.rs
+++ b/lading/src/bin/lading.rs
@@ -1,5 +1,4 @@
 use std::{
-    collections::HashMap,
     env,
     fmt::{self, Display},
     io::Read,
@@ -13,10 +12,7 @@ use lading::{
     blackhole,
     captures::CaptureManager,
     config::{Config, Telemetry},
-    generator::{
-        self,
-        process_tree::{self},
-    },
+    generator::{self, process_tree},
     inspector, observer,
     signals::Shutdown,
     target::{self, Behavior, Output},
@@ -24,6 +20,7 @@ use lading::{
 };
 use metrics_exporter_prometheus::PrometheusBuilder;
 use rand::{rngs::StdRng, SeedableRng};
+use rustc_hash::FxHashMap;
 use tokio::{
     runtime::Builder,
     signal,
@@ -42,7 +39,7 @@ fn default_target_behavior() -> Behavior {
 
 #[derive(Default, Clone)]
 struct CliKeyValues {
-    inner: HashMap<String, String>,
+    inner: FxHashMap<String, String>,
 }
 
 impl Display for CliKeyValues {
@@ -59,7 +56,7 @@ impl FromStr for CliKeyValues {
 
     fn from_str(input: &str) -> Result<Self, Self::Err> {
         let pair_err = String::from("pairs must be separated by '='");
-        let mut labels = HashMap::new();
+        let mut labels = FxHashMap::default();
         for kv in input.split(',') {
             if kv.is_empty() {
                 continue;

--- a/lading/src/blackhole/splunk_hec.rs
+++ b/lading/src/blackhole/splunk_hec.rs
@@ -7,7 +7,6 @@
 //!
 
 use std::{
-    collections::HashMap,
     net::SocketAddr,
     sync::{
         atomic::{AtomicU64, Ordering},
@@ -22,6 +21,7 @@ use hyper::{
     service::{make_service_fn, service_fn},
     Body, Method, Request, Response, Server, StatusCode,
 };
+use rustc_hash::FxHashMap;
 use serde::{Deserialize, Serialize};
 use tower::ServiceBuilder;
 use tracing::{error, info};
@@ -60,7 +60,7 @@ struct HecAckRequest {
 
 #[derive(Serialize)]
 struct HecAckResponse {
-    acks: HashMap<u64, bool>,
+    acks: FxHashMap<u64, bool>,
 }
 
 impl From<HecAckRequest> for HecAckResponse {

--- a/lading/src/captures.rs
+++ b/lading/src/captures.rs
@@ -9,7 +9,6 @@
 
 use std::{
     borrow::Cow,
-    collections::HashMap,
     ffi::OsStr,
     io,
     path::PathBuf,
@@ -19,6 +18,7 @@ use std::{
 
 use lading_capture::json;
 use metrics_util::registry::{AtomicStorage, Registry};
+use rustc_hash::FxHashMap;
 use tokio::{
     fs::File,
     io::{AsyncWriteExt, BufWriter},
@@ -46,7 +46,7 @@ pub struct CaptureManager {
     capture_path: PathBuf,
     shutdown: Shutdown,
     inner: Arc<Inner>,
-    global_labels: HashMap<String, String>,
+    global_labels: FxHashMap<String, String>,
 }
 
 impl CaptureManager {
@@ -66,7 +66,7 @@ impl CaptureManager {
             inner: Arc::new(Inner {
                 registry: Registry::atomic(),
             }),
-            global_labels: HashMap::new(),
+            global_labels: FxHashMap::default(),
         }
     }
 

--- a/lading/src/config.rs
+++ b/lading/src/config.rs
@@ -1,8 +1,9 @@
 //! This module controls configuration parsing from the end user, providing a
 //! convenience mechanism for the rest of the program. Crashes are most likely
 //! to originate from this code, intentionally.
-use std::{collections::HashMap, net::SocketAddr, path::PathBuf};
+use std::{net::SocketAddr, path::PathBuf};
 
+use rustc_hash::FxHashMap;
 use serde::Deserialize;
 
 use crate::{blackhole, generator, inspector, observer, target, target_metrics};
@@ -46,7 +47,7 @@ pub enum Telemetry {
         /// Address and port for prometheus exporter
         prometheus_addr: SocketAddr,
         /// Additional labels to include in every metric
-        global_labels: HashMap<String, String>,
+        global_labels: FxHashMap<String, String>,
     },
     /// In log mode lading will emit its internal telemetry to a structured log
     /// file, the "capture" file.
@@ -54,7 +55,7 @@ pub enum Telemetry {
         /// Location on disk to write captures
         path: PathBuf,
         /// Additional labels to include in every metric
-        global_labels: HashMap<String, String>,
+        global_labels: FxHashMap<String, String>,
     },
 }
 
@@ -62,7 +63,7 @@ impl Default for Telemetry {
     fn default() -> Self {
         Self::Prometheus {
             prometheus_addr: "0.0.0.0:9000".parse().unwrap(),
-            global_labels: HashMap::default(),
+            global_labels: FxHashMap::default(),
         }
     }
 }

--- a/lading/src/inspector.rs
+++ b/lading/src/inspector.rs
@@ -9,7 +9,6 @@
 //! run an appropriate shell script, or take samples of the target's CPU use.
 
 use std::{
-    collections::HashMap,
     io,
     path::PathBuf,
     process::{ExitStatus, Stdio},
@@ -20,6 +19,7 @@ use nix::{
     sys::signal::{kill, SIGTERM},
     unistd::Pid,
 };
+use rustc_hash::FxHashMap;
 use serde::Deserialize;
 use tokio::process::Command;
 use tracing::{error, info};
@@ -49,7 +49,7 @@ pub struct Config {
     pub arguments: Vec<String>,
     /// Environment variables to set for the inspector sub-process. Lading's own
     /// environment variables are not propagated to the sub-process.
-    pub environment_variables: HashMap<String, String>,
+    pub environment_variables: FxHashMap<String, String>,
     /// Manages stderr, stdout of the inspector sub-process.
     pub output: Output,
 }

--- a/lading/src/target.rs
+++ b/lading/src/target.rs
@@ -16,7 +16,6 @@
 //! watched process terminates early.
 
 use std::{
-    collections::HashMap,
     io,
     num::NonZeroU32,
     path::PathBuf,
@@ -30,6 +29,7 @@ use nix::{
     sys::signal::{kill, SIGTERM},
     unistd::Pid,
 };
+use rustc_hash::FxHashMap;
 use tokio::process::Command;
 use tracing::{error, info};
 
@@ -138,7 +138,7 @@ pub struct BinaryConfig {
     /// Environment variables to set for the target sub-process. Lading's own
     /// environment variables are only propagated to the target sub-process if
     /// `inherit_environment` is set.
-    pub environment_variables: HashMap<String, String>,
+    pub environment_variables: FxHashMap<String, String>,
     /// Manages stderr, stdout of the target sub-process.
     pub output: Output,
 }

--- a/lading/src/target_metrics/prometheus.rs
+++ b/lading/src/target_metrics/prometheus.rs
@@ -4,9 +4,10 @@
 //! software.
 //!
 
-use std::{collections::HashMap, str::FromStr, time::Duration};
+use std::{str::FromStr, time::Duration};
 
 use metrics::{counter, gauge};
+use rustc_hash::FxHashMap;
 use serde::Deserialize;
 use tracing::{error, info, trace, warn};
 
@@ -107,7 +108,7 @@ impl Prometheus {
                 };
 
                 // remember the type for each metric across lines
-                let mut typemap = HashMap::new();
+                let mut typemap = FxHashMap::default();
 
                 // this deserves a real parser, but this will do for now.
                 // Format doc: https://github.com/prometheus/docs/blob/main/content/docs/instrumenting/exposition_formats.md

--- a/lading_capture/Cargo.toml
+++ b/lading_capture/Cargo.toml
@@ -11,6 +11,7 @@ description = "A tool for load testing daemons."
 
 [dependencies]
 prost = "0.11"
+rustc-hash = { workspace = true }
 serde = { workspace = true }
 serde_json = {workspace = true }
 uuid = { workspace = true, features = ["serde", "v4"] }

--- a/lading_capture/src/json.rs
+++ b/lading_capture/src/json.rs
@@ -1,8 +1,9 @@
 //! JSON form of a Lading capture Line, meant to be read line by line from a
 //! file.
 
+use rustc_hash::FxHashMap;
 use serde::{Deserialize, Serialize};
-use std::{borrow::Cow, collections::HashMap};
+use std::borrow::Cow;
 use uuid::Uuid;
 
 #[derive(Debug, Serialize, Deserialize, Clone, Copy)]
@@ -59,7 +60,7 @@ pub struct Line<'a> {
     pub value: LineValue,
     #[serde(flatten)]
     /// The labels associated with this metric.
-    pub labels: HashMap<String, String>,
+    pub labels: FxHashMap<String, String>,
 }
 
 impl<'a> Line<'a> {

--- a/lading_payload/Cargo.toml
+++ b/lading_payload/Cargo.toml
@@ -10,16 +10,17 @@ categories = ["development-tools::profiling"]
 description = "A tool for load testing daemons."
 
 [dependencies]
+opentelemetry-proto = { version = "0.1.0", features = ["traces", "metrics", "logs", "gen-tonic" ] }
+prost = { workspace = true }
 rand = { workspace = true, default-features = false, features = ["small_rng", "std", "std_rng" ]}
+rmp-serde = { version = "1.1", default-features = false }
+rustc-hash = { workspace = true }
 serde = { workspace = true }
 serde_json = {workspace = true }
-opentelemetry-proto = { version = "0.1.0", features = ["traces", "metrics", "logs", "gen-tonic" ] }
-thiserror = { workspace = true }
-tracing = { workspace = true }
 serde_tuple = { version = "0.5", default-features = false }
-rmp-serde = { version = "1.1", default-features = false }
-prost = { workspace = true }
+thiserror = { workspace = true }
 time = { version = "0.3", features = ["formatting"] }
+tracing = { workspace = true }
 
 [dev-dependencies]
 proptest = "1.2"

--- a/lading_payload/src/trace_agent.rs
+++ b/lading_payload/src/trace_agent.rs
@@ -1,9 +1,10 @@
 //! Trace-agent payload.
 
-use std::{collections::HashMap, io::Write};
+use std::io::Write;
 
 use rand::{seq::SliceRandom, Rng};
 use rmp_serde::Serializer;
+use rustc_hash::FxHashMap;
 
 use crate::{common::strings, Error, Generator};
 use serde::Serialize;
@@ -92,14 +93,14 @@ pub(crate) struct Span<'a> {
     /// error is 1 if there is an error associated with this span, or 0 if there is not.
     error: i32,
     /// meta is a mapping from tag name to tag value for string-valued tags.
-    meta: HashMap<&'a str, &'a str>,
+    meta: FxHashMap<&'a str, &'a str>,
     /// metrics is a mapping from tag name to tag value for numeric-valued tags.
-    metrics: HashMap<&'a str, f64>,
+    metrics: FxHashMap<&'a str, f64>,
     /// type is the type of the service with which this span is associated.  Example values: web, db, lambda.
     #[serde(alias = "type")]
     kind: &'a str,
     /// meta_struct is a registry of structured "other" data used by, e.g., AppSec.
-    meta_struct: HashMap<&'a str, Vec<u8>>,
+    meta_struct: FxHashMap<&'a str, Vec<u8>>,
 }
 
 #[derive(Debug, Clone, Copy, Default)]
@@ -155,7 +156,7 @@ impl<'a> Generator<'a> for TraceAgent {
         R: rand::Rng + ?Sized,
     {
         let total_metrics = rng.gen_range(0..6);
-        let mut metrics: HashMap<&'static str, f64> = HashMap::new();
+        let mut metrics: FxHashMap<&'static str, f64> = FxHashMap::default();
         for _ in 0..total_metrics {}
         for k in TAG_NAMES.choose_multiple(rng, total_metrics) {
             metrics.insert(*k, rng.gen());
@@ -174,10 +175,10 @@ impl<'a> Generator<'a> for TraceAgent {
             start: rng.gen(),
             duration: rng.gen(),
             error: rng.gen_range(0..=1),
-            meta: HashMap::new(),
+            meta: FxHashMap::default(),
             metrics,
             kind: SERVICE_KIND.choose(rng).unwrap(),
-            meta_struct: HashMap::new(),
+            meta_struct: FxHashMap::default(),
         }
     }
 }


### PR DESCRIPTION
### What does this PR do?

This commit adjusts more of our codebase to use the FxHash instead of the randomly seeded Hash{Map|Set}. We want to avoid sources of non-determinism. We believe many of our dependencies will use randomly seeded HashMaps and this commit does nothing to address that.

### Related issues

REF SMP-687
