### PR TITLE
Allow the user to configure the range of DogStatsD metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## [0.18.1-rc2]
+### Fixed
+- DogStatsD value min/max is now 2**63 symmetric. This avoids a range issue in the `rand` crate.
+
 ## [0.18.1-rc1]
 ### Added
 - It is now possible for users to configure the range of DogStatsD payloads

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,35 +6,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
-## [0.18.1-rc6]
-### Changed
-- The configuration option `float_weight` is changed to `float_probability`.
-
-## [0.18.1-rc5]
-### Changed
-- Capitalization is renamed to snake-case in value configuration.
-
-## [0.18.1-rc4]
-### Changed
-- The int-only experiment is now reverted.
-- Configuration for numeric values now explicitly allows constant values.
-
-## [0.18.1-rc3]
-### Changed
-- DogStatsD NumValue is now int-only for experimental purposes, range is also made inclusive. The inclusivity will remain.
-
-## [0.18.1-rc2]
-### Fixed
-- DogStatsD value min/max is now 2**63 symmetric. This avoids a range issue in the `rand` crate.
-
-## [0.18.1-rc1]
-### Added
-- It is now possible for users to configure the range of DogStatsD payloads
-  values. Previously the range was 64-bits wide.
-
-## [0.18.1-rc0]
+## [0.18.1]
 ### Added
 - `lading-payload` crate is now split out from the `lading` crate
+- It is now possible for users to configure the range of DogStatsD payloads
+  values. Previously the range was 64-bits wide. The range is inclusive or
+  constant. Additionally, users may configure a probability for values being a
+  floating point or not.
 ### Changed
 - The block mechanism is reworked to provide a 'fixed' and 'streaming' model,
   running in a separate OS thread from the tokio runtime.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## [0.18.1-rc6]
+### Changed
+- The configuration option `float_weight` is changed to `float_probability`.
+
 ## [0.18.1-rc5]
 ### Changed
 - Capitalization is renamed to snake-case in value configuration.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## [0.18.1-rc3]
+### Changed
+- DogStatsD NumValue is now int-only for experimental purposes, range is also made inclusive. The inclusivity will remain.
+
 ## [0.18.1-rc2]
 ### Fixed
 - DogStatsD value min/max is now 2**63 symmetric. This avoids a range issue in the `rand` crate.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## [0.18.1-rc4]
+### Changed
+- The int-only experiment is now reverted.
+- Configuration for numeric values now explicitly allows constant values.
+
 ## [0.18.1-rc3]
 ### Changed
 - DogStatsD NumValue is now int-only for experimental purposes, range is also made inclusive. The inclusivity will remain.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## [0.18.1-rc1]
+### Added
+- It is now possible for users to configure the range of DogStatsD payloads
+  values. Previously the range was 64-bits wide.
+
 ## [0.18.1-rc0]
 ### Added
 - `lading-payload` crate is now split out from the `lading` crate

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## [0.18.1-rc5]
+### Changed
+- Capitalization is renamed to snake-case in value configuration.
+
 ## [0.18.1-rc4]
 ### Changed
 - The int-only experiment is now reverted.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1010,7 +1010,7 @@ dependencies = [
 
 [[package]]
 name = "lading"
-version = "0.18.1-rc1"
+version = "0.18.1-rc2"
 dependencies = [
  "async-pidfd",
  "byte-unit",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1010,7 +1010,7 @@ dependencies = [
 
 [[package]]
 name = "lading"
-version = "0.18.1-rc6"
+version = "0.18.1"
 dependencies = [
  "async-pidfd",
  "byte-unit",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1010,7 +1010,7 @@ dependencies = [
 
 [[package]]
 name = "lading"
-version = "0.18.1-rc5"
+version = "0.18.1-rc6"
 dependencies = [
  "async-pidfd",
  "byte-unit",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1010,7 +1010,7 @@ dependencies = [
 
 [[package]]
 name = "lading"
-version = "0.18.1-rc4"
+version = "0.18.1-rc5"
 dependencies = [
  "async-pidfd",
  "byte-unit",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1010,7 +1010,7 @@ dependencies = [
 
 [[package]]
 name = "lading"
-version = "0.18.1-rc0"
+version = "0.18.1-rc1"
 dependencies = [
  "async-pidfd",
  "byte-unit",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1010,7 +1010,7 @@ dependencies = [
 
 [[package]]
 name = "lading"
-version = "0.18.1-rc2"
+version = "0.18.1-rc4"
 dependencies = [
  "async-pidfd",
  "byte-unit",

--- a/lading/Cargo.toml
+++ b/lading/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lading"
-version = "0.18.1-rc4"
+version = "0.18.1-rc5"
 authors = ["Brian L. Troutwine <brian.troutwine@datadoghq.com>", "George Hahn <george.hahn@datadoghq.com"]
 edition = "2021"
 license = "MIT"

--- a/lading/Cargo.toml
+++ b/lading/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lading"
-version = "0.18.1-rc1"
+version = "0.18.1-rc2"
 authors = ["Brian L. Troutwine <brian.troutwine@datadoghq.com>", "George Hahn <george.hahn@datadoghq.com"]
 edition = "2021"
 license = "MIT"

--- a/lading/Cargo.toml
+++ b/lading/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lading"
-version = "0.18.1-rc2"
+version = "0.18.1-rc4"
 authors = ["Brian L. Troutwine <brian.troutwine@datadoghq.com>", "George Hahn <george.hahn@datadoghq.com"]
 edition = "2021"
 license = "MIT"

--- a/lading/Cargo.toml
+++ b/lading/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lading"
-version = "0.18.1-rc5"
+version = "0.18.1-rc6"
 authors = ["Brian L. Troutwine <brian.troutwine@datadoghq.com>", "George Hahn <george.hahn@datadoghq.com"]
 edition = "2021"
 license = "MIT"

--- a/lading/Cargo.toml
+++ b/lading/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lading"
-version = "0.18.1-rc0"
+version = "0.18.1-rc1"
 authors = ["Brian L. Troutwine <brian.troutwine@datadoghq.com>", "George Hahn <george.hahn@datadoghq.com"]
 edition = "2021"
 license = "MIT"

--- a/lading/Cargo.toml
+++ b/lading/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lading"
-version = "0.18.1-rc6"
+version = "0.18.1"
 authors = ["Brian L. Troutwine <brian.troutwine@datadoghq.com>", "George Hahn <george.hahn@datadoghq.com"]
 edition = "2021"
 license = "MIT"

--- a/lading/src/block.rs
+++ b/lading/src/block.rs
@@ -155,6 +155,8 @@ impl Cache {
                 multivalue_count_maximum,
                 kind_weights,
                 metric_weights,
+                value_minimum,
+                value_maximum,
             }) => {
                 let context_range = *contexts_minimum..*contexts_maximum;
                 let tags_per_msg_range = *tags_per_msg_minimum..*tags_per_msg_maximum;
@@ -173,6 +175,7 @@ impl Cache {
                     *multivalue_pack_probability,
                     *kind_weights,
                     *metric_weights,
+                    *value_minimum..*value_maximum,
                     &mut rng,
                 );
 
@@ -286,6 +289,8 @@ fn stream_inner(
             multivalue_count_maximum,
             kind_weights,
             metric_weights,
+            value_minimum,
+            value_maximum,
         }) => {
             let context_range = *contexts_minimum..*contexts_maximum;
             let tags_per_msg_range = *tags_per_msg_minimum..*tags_per_msg_maximum;
@@ -304,6 +309,7 @@ fn stream_inner(
                 *multivalue_pack_probability,
                 *kind_weights,
                 *metric_weights,
+                *value_minimum..*value_maximum,
                 &mut rng,
             );
 

--- a/lading/src/block.rs
+++ b/lading/src/block.rs
@@ -155,8 +155,7 @@ impl Cache {
                 multivalue_count_maximum,
                 kind_weights,
                 metric_weights,
-                value_minimum,
-                value_maximum,
+                value,
             }) => {
                 let context_range = *contexts_minimum..*contexts_maximum;
                 let tags_per_msg_range = *tags_per_msg_minimum..*tags_per_msg_maximum;
@@ -175,7 +174,7 @@ impl Cache {
                     *multivalue_pack_probability,
                     *kind_weights,
                     *metric_weights,
-                    *value_minimum..*value_maximum,
+                    *value,
                     &mut rng,
                 );
 
@@ -289,8 +288,7 @@ fn stream_inner(
             multivalue_count_maximum,
             kind_weights,
             metric_weights,
-            value_minimum,
-            value_maximum,
+            value,
         }) => {
             let context_range = *contexts_minimum..*contexts_maximum;
             let tags_per_msg_range = *tags_per_msg_minimum..*tags_per_msg_maximum;
@@ -309,7 +307,7 @@ fn stream_inner(
                 *multivalue_pack_probability,
                 *kind_weights,
                 *metric_weights,
-                *value_minimum..*value_maximum,
+                *value,
                 &mut rng,
             );
 

--- a/lading_payload/src/dogstatsd.rs
+++ b/lading_payload/src/dogstatsd.rs
@@ -27,12 +27,12 @@ fn contexts_maximum() -> u16 {
     10_000
 }
 
-fn value_minimum() -> f64 {
-    -2_f64.powi(63)
+fn value_minimum() -> i64 {
+    i64::MIN
 }
 
-fn value_maximum() -> f64 {
-    2_f64.powi(63)
+fn value_maximum() -> i64 {
+    i64::MAX
 }
 
 // https://docs.datadoghq.com/developers/guide/what-best-practices-are-recommended-for-naming-metrics-and-tags/#rules-and-best-practices-for-naming-metrics
@@ -199,11 +199,11 @@ pub struct Config {
 
     /// The minimum value to appear in metrics.
     #[serde(default = "value_minimum")]
-    pub value_minimum: f64,
+    pub value_minimum: i64,
 
     /// The maximum value to appear in metrics.
     #[serde(default = "value_maximum")]
-    pub value_maximum: f64,
+    pub value_maximum: i64,
 }
 
 fn choose_or_not_ref<'a, R, T>(mut rng: &mut R, pool: &'a [T]) -> Option<&'a T>
@@ -289,7 +289,7 @@ impl MemberGenerator {
         multivalue_pack_probability: f32,
         kind_weights: KindWeights,
         metric_weights: MetricWeights,
-        num_value_range: Range<f64>,
+        num_value_range: Range<i64>,
         mut rng: &mut R,
     ) -> Self
     where
@@ -474,7 +474,7 @@ impl DogStatsD {
         multivalue_pack_probability: f32,
         kind_weights: KindWeights,
         metric_weights: MetricWeights,
-        num_value_range: Range<f64>,
+        num_value_range: Range<i64>,
         rng: &mut R,
     ) -> Self
     where

--- a/lading_payload/src/dogstatsd.rs
+++ b/lading_payload/src/dogstatsd.rs
@@ -138,6 +138,7 @@ pub struct ValueConf {
 
 /// Configuration for the values range of a metric.
 #[derive(Debug, Deserialize, Clone, PartialEq, Copy)]
+#[serde(rename_all = "snake_case")]
 pub enum ValueRange {
     /// Metric values are always constant.
     Constant(i64),

--- a/lading_payload/src/dogstatsd.rs
+++ b/lading_payload/src/dogstatsd.rs
@@ -28,11 +28,11 @@ fn contexts_maximum() -> u16 {
 }
 
 fn value_minimum() -> f64 {
-    f64::MIN
+    -2_f64.powi(63)
 }
 
 fn value_maximum() -> f64 {
-    f64::MAX
+    2_f64.powi(63)
 }
 
 // https://docs.datadoghq.com/developers/guide/what-best-practices-are-recommended-for-naming-metrics-and-tags/#rules-and-best-practices-for-naming-metrics

--- a/lading_payload/src/dogstatsd.rs
+++ b/lading_payload/src/dogstatsd.rs
@@ -27,6 +27,14 @@ fn contexts_maximum() -> u16 {
     10_000
 }
 
+fn value_minimum() -> f64 {
+    f64::MIN
+}
+
+fn value_maximum() -> f64 {
+    f64::MAX
+}
+
 // https://docs.datadoghq.com/developers/guide/what-best-practices-are-recommended-for-naming-metrics-and-tags/#rules-and-best-practices-for-naming-metrics
 fn name_length_minimum() -> u16 {
     1
@@ -184,9 +192,18 @@ pub struct Config {
     /// payload.
     #[serde(default)]
     pub kind_weights: KindWeights,
+
     /// Defines the relative probability of each kind of DogStatsD metric.
     #[serde(default)]
     pub metric_weights: MetricWeights,
+
+    /// The minimum value to appear in metrics.
+    #[serde(default = "value_minimum")]
+    pub value_minimum: f64,
+
+    /// The maximum value to appear in metrics.
+    #[serde(default = "value_maximum")]
+    pub value_maximum: f64,
 }
 
 fn choose_or_not_ref<'a, R, T>(mut rng: &mut R, pool: &'a [T]) -> Option<&'a T>
@@ -272,6 +289,7 @@ impl MemberGenerator {
         multivalue_pack_probability: f32,
         kind_weights: KindWeights,
         metric_weights: MetricWeights,
+        num_value_range: Range<f64>,
         mut rng: &mut R,
     ) -> Self
     where
@@ -343,6 +361,7 @@ impl MemberGenerator {
             small_strings,
             tagsets.clone(),
             pool.as_ref(),
+            num_value_range,
             &mut rng,
         );
 
@@ -425,6 +444,7 @@ impl DogStatsD {
             multivalue_pack_probability(),
             KindWeights::default(),
             MetricWeights::default(),
+            value_minimum()..value_maximum(),
             rng,
         )
     }
@@ -454,6 +474,7 @@ impl DogStatsD {
         multivalue_pack_probability: f32,
         kind_weights: KindWeights,
         metric_weights: MetricWeights,
+        num_value_range: Range<f64>,
         rng: &mut R,
     ) -> Self
     where
@@ -469,6 +490,7 @@ impl DogStatsD {
             multivalue_pack_probability,
             kind_weights,
             metric_weights,
+            num_value_range,
             rng,
         );
 

--- a/lading_payload/src/dogstatsd.rs
+++ b/lading_payload/src/dogstatsd.rs
@@ -29,7 +29,7 @@ fn contexts_maximum() -> u16 {
 
 fn value_config() -> ValueConf {
     ValueConf {
-        float_weight: 128, // 50%
+        float_probability: 0.5, // 50%
         range: ValueRange::Inclusive {
             min: i64::MIN,
             max: i64::MAX,
@@ -132,7 +132,7 @@ impl Default for MetricWeights {
 #[derive(Debug, Deserialize, Clone, PartialEq, Copy)]
 pub struct ValueConf {
     /// Odds out of 256 that the value will be a float and not an integer.
-    float_weight: u8,
+    float_probability: f32,
     range: ValueRange,
 }
 

--- a/lading_payload/src/dogstatsd.rs
+++ b/lading_payload/src/dogstatsd.rs
@@ -531,8 +531,8 @@ mod test {
             contexts_maximum, contexts_minimum, multivalue_count_maximum, multivalue_count_minimum,
             multivalue_pack_probability, name_length_maximum, name_length_minimum,
             tag_key_length_maximum, tag_key_length_minimum, tag_value_length_maximum,
-            tag_value_length_minimum, tags_per_msg_maximum, tags_per_msg_minimum, KindWeights,
-            MetricWeights,
+            tag_value_length_minimum, tags_per_msg_maximum, tags_per_msg_minimum, value_maximum,
+            value_minimum, KindWeights, MetricWeights,
         },
         DogStatsD, Serialize,
     };
@@ -551,11 +551,14 @@ mod test {
             let tags_per_msg_range = tags_per_msg_minimum()..tags_per_msg_maximum();
             let multivalue_count_range = multivalue_count_minimum()..multivalue_count_maximum();
             let multivalue_pack_probability = multivalue_pack_probability();
+            let num_value_range = value_minimum()..value_maximum();
 
             let kind_weights = KindWeights::default();
             let metric_weights = MetricWeights::default();
-            let dogstatsd = DogStatsD::new(context_range, name_length_range, tag_key_length_range, tag_value_length_range, tags_per_msg_range, multivalue_count_range, multivalue_pack_probability, kind_weights,
-                                           metric_weights, &mut rng);
+            let dogstatsd = DogStatsD::new(context_range, name_length_range, tag_key_length_range,
+                                           tag_value_length_range, tags_per_msg_range,
+                                           multivalue_count_range, multivalue_pack_probability, kind_weights,
+                                           metric_weights, num_value_range, &mut rng);
 
             let mut bytes = Vec::with_capacity(max_bytes);
             dogstatsd.to_bytes(rng, max_bytes, &mut bytes).unwrap();

--- a/lading_payload/src/dogstatsd/common.rs
+++ b/lading_payload/src/dogstatsd/common.rs
@@ -1,4 +1,4 @@
-use std::{fmt, ops::Range};
+use std::fmt;
 
 use rand::{
     distributions::{Standard, Uniform},
@@ -8,23 +8,44 @@ use rand::{
 
 use crate::Generator;
 
+use super::{ValueConf, ValueRange};
+
 pub(crate) mod tags;
 
 #[derive(Clone, Debug)]
 pub(crate) enum NumValue {
     Int(i64),
+    Float(f64),
 }
 
 #[derive(Clone, Debug)]
-pub(crate) struct NumValueGenerator {
-    int_distr: Uniform<i64>,
+pub(crate) enum NumValueGenerator {
+    Constant {
+        float_weight: u8,
+        int: i64,
+        float: f64,
+    },
+    Uniform {
+        float_weight: u8,
+        int_distr: Uniform<i64>,
+        float_distr: Uniform<f64>,
+    },
 }
 
 impl NumValueGenerator {
     #[allow(clippy::cast_possible_truncation)]
-    pub(crate) fn new(range: Range<i64>) -> Self {
-        Self {
-            int_distr: Uniform::new_inclusive(range.start, range.end),
+    pub(crate) fn new(conf: ValueConf) -> Self {
+        match conf.range {
+            ValueRange::Constant(c) => Self::Constant {
+                float_weight: conf.float_weight,
+                int: c,
+                float: c as f64,
+            },
+            ValueRange::Inclusive { min, max } => Self::Uniform {
+                float_weight: conf.float_weight,
+                int_distr: Uniform::new_inclusive(min, max),
+                float_distr: Uniform::new_inclusive(min as f64, max as f64),
+            },
         }
     }
 }
@@ -36,7 +57,30 @@ impl<'a> Generator<'a> for NumValueGenerator {
     where
         R: rand::Rng + ?Sized,
     {
-        NumValue::Int(self.int_distr.sample(rng))
+        match self {
+            Self::Constant {
+                float_weight,
+                int,
+                float,
+            } => {
+                if rng.gen_ratio(u32::from(*float_weight), 256) {
+                    NumValue::Float(*float)
+                } else {
+                    NumValue::Int(*int)
+                }
+            }
+            Self::Uniform {
+                float_weight,
+                int_distr,
+                float_distr,
+            } => {
+                if rng.gen_ratio(u32::from(*float_weight), 256) {
+                    NumValue::Float(float_distr.sample(rng))
+                } else {
+                    NumValue::Int(int_distr.sample(rng))
+                }
+            }
+        }
     }
 }
 
@@ -44,6 +88,7 @@ impl fmt::Display for NumValue {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::Int(val) => write!(f, "{val}"),
+            Self::Float(val) => write!(f, "{val}"),
         }
     }
 }

--- a/lading_payload/src/dogstatsd/common.rs
+++ b/lading_payload/src/dogstatsd/common.rs
@@ -12,22 +12,19 @@ pub(crate) mod tags;
 
 #[derive(Clone, Debug)]
 pub(crate) enum NumValue {
-    Float(f64),
     Int(i64),
 }
 
 #[derive(Clone, Debug)]
 pub(crate) struct NumValueGenerator {
-    float_distr: Uniform<f64>,
     int_distr: Uniform<i64>,
 }
 
 impl NumValueGenerator {
     #[allow(clippy::cast_possible_truncation)]
-    pub(crate) fn new(range: Range<f64>) -> Self {
+    pub(crate) fn new(range: Range<i64>) -> Self {
         Self {
-            float_distr: Uniform::new(range.start, range.end),
-            int_distr: Uniform::new(range.start as i64, range.end as i64),
+            int_distr: Uniform::new_inclusive(range.start, range.end),
         }
     }
 }
@@ -39,18 +36,13 @@ impl<'a> Generator<'a> for NumValueGenerator {
     where
         R: rand::Rng + ?Sized,
     {
-        match rng.gen_range(0..=1) {
-            0 => NumValue::Float(self.float_distr.sample(rng)),
-            1 => NumValue::Int(self.int_distr.sample(rng)),
-            _ => unreachable!(),
-        }
+        NumValue::Int(self.int_distr.sample(rng))
     }
 }
 
 impl fmt::Display for NumValue {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            Self::Float(val) => write!(f, "{val}"),
             Self::Int(val) => write!(f, "{val}"),
         }
     }

--- a/lading_payload/src/dogstatsd/metric.rs
+++ b/lading_payload/src/dogstatsd/metric.rs
@@ -36,7 +36,7 @@ impl MetricGenerator {
         container_ids: Vec<String>,
         tagsets: common::tags::Tagsets,
         str_pool: &strings::Pool,
-        num_value_range: Range<f64>,
+        num_value_range: Range<i64>,
         mut rng: &mut R,
     ) -> Self
     where

--- a/lading_payload/src/dogstatsd/metric.rs
+++ b/lading_payload/src/dogstatsd/metric.rs
@@ -12,6 +12,7 @@ use tracing::debug;
 use super::{
     choose_or_not_ref,
     common::{self, NumValueGenerator},
+    ValueConf,
 };
 
 mod template;
@@ -36,7 +37,7 @@ impl MetricGenerator {
         container_ids: Vec<String>,
         tagsets: common::tags::Tagsets,
         str_pool: &strings::Pool,
-        num_value_range: Range<i64>,
+        value_conf: ValueConf,
         mut rng: &mut R,
     ) -> Self
     where
@@ -70,7 +71,7 @@ impl MetricGenerator {
             templates,
             multivalue_count_range,
             multivalue_pack_probability,
-            num_value_generator: NumValueGenerator::new(num_value_range),
+            num_value_generator: NumValueGenerator::new(value_conf),
         }
     }
 }


### PR DESCRIPTION
### What does this PR do?

This commit introduces a configuration option to allow the user to define the range of values that appear in DogStatsD metrics. This range applies to all metric kinds. The distribution is changed from Standard -- "numerically uniform" -- to actually Uniform. We do not allow users to configure the distribution.

### Related issues

REF SMP-694
