### PR TITLE
Silence prometheus float format warnings

### DIFF
--- a/lading/src/target_metrics/prometheus.rs
+++ b/lading/src/target_metrics/prometheus.rs
@@ -136,7 +136,7 @@ impl Prometheus {
                     let name_and_labels = parts.next().unwrap();
                     let value = parts.next().unwrap();
 
-                    if value.contains("#") {
+                    if value.contains('#') {
                         trace!("Unknown format: {value}");
                         continue;
                     }

--- a/lading/src/target_metrics/prometheus.rs
+++ b/lading/src/target_metrics/prometheus.rs
@@ -136,6 +136,11 @@ impl Prometheus {
                     let name_and_labels = parts.next().unwrap();
                     let value = parts.next().unwrap();
 
+                    if value.contains("#") {
+                        trace!("Unknown format: {value}");
+                        continue;
+                    }
+
                     let (name, labels) = {
                         if let Some((name, labels)) = name_and_labels.split_once('{') {
                             let labels = labels.trim_end_matches('}');


### PR DESCRIPTION
### What does this PR do?

Silences prometheus target metrics warnings

```
2023-10-10T17:38:53.943589Z  WARN lading::target_metrics::prometheus: invalid float literal: aggregator_tags_store.tagset_refs_count = #0",ge="8"}
```

### Motivation

This format isn't described in the [prometheus format doc](https://github.com/prometheus/docs/blob/main/content/docs/instrumenting/exposition_formats.md). Leave this unimplemented until it's necessary.
