### PR TITLE
Adjust dogstatsd configuration to allow for constant values

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,7 +70,9 @@ jobs:
       - uses: actions-rust-lang/setup-rust-toolchain@v1.3.7
       - name: Install protobuf (Apt)
         run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
-      - run: cargo test
+      - name: Install nextest
+        uses: taiki-e/install-action@nextest
+      - run: cargo nextest run
 
   integration-test:
     name: Integration Tests

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## [0.19.0-rc2]
+### Changed
+- Dogstatsd payload generation now takes range configuration, allows constant settings.
+
 ## [0.18.1]
 ### Added
 - `lading-payload` crate is now split out from the `lading` crate

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## [0.19.0-rc3]
+### Changed
+- Dogstatsd payload generation uses snake-case.
+
 ## [0.19.0-rc2]
 ### Changed
 - Dogstatsd payload generation now takes range configuration, allows constant settings.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1010,7 +1010,7 @@ dependencies = [
 
 [[package]]
 name = "lading"
-version = "0.18.1"
+version = "0.19.0-rc1"
 dependencies = [
  "async-pidfd",
  "byte-unit",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1010,7 +1010,7 @@ dependencies = [
 
 [[package]]
 name = "lading"
-version = "0.19.0-rc2"
+version = "0.19.0-rc3"
 dependencies = [
  "async-pidfd",
  "byte-unit",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1010,7 +1010,7 @@ dependencies = [
 
 [[package]]
 name = "lading"
-version = "0.19.0-rc1"
+version = "0.19.0-rc2"
 dependencies = [
  "async-pidfd",
  "byte-unit",

--- a/lading/Cargo.toml
+++ b/lading/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lading"
-version = "0.19.0-rc1"
+version = "0.19.0-rc2"
 authors = ["Brian L. Troutwine <brian.troutwine@datadoghq.com>", "George Hahn <george.hahn@datadoghq.com"]
 edition = "2021"
 license = "MIT"

--- a/lading/Cargo.toml
+++ b/lading/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lading"
-version = "0.18.1"
+version = "0.19.0-rc1"
 authors = ["Brian L. Troutwine <brian.troutwine@datadoghq.com>", "George Hahn <george.hahn@datadoghq.com"]
 edition = "2021"
 license = "MIT"

--- a/lading/Cargo.toml
+++ b/lading/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lading"
-version = "0.19.0-rc2"
+version = "0.19.0-rc3"
 authors = ["Brian L. Troutwine <brian.troutwine@datadoghq.com>", "George Hahn <george.hahn@datadoghq.com"]
 edition = "2021"
 license = "MIT"

--- a/lading/src/block.rs
+++ b/lading/src/block.rs
@@ -139,38 +139,25 @@ impl Cache {
                 &block_chunks,
             ),
             payload::Config::DogStatsD(payload::dogstatsd::Config {
-                contexts_minimum,
-                contexts_maximum,
-                name_length_minimum,
-                name_length_maximum,
-                tag_key_length_minimum,
-                tag_key_length_maximum,
-                tag_value_length_minimum,
-                tag_value_length_maximum,
-                tags_per_msg_minimum,
-                tags_per_msg_maximum,
+                contexts,
+                name_length,
+                tag_key_length,
+                tag_value_length,
+                tags_per_msg,
                 // TODO -- Validate user input for multivalue_pack_probability.
                 multivalue_pack_probability,
-                multivalue_count_minimum,
-                multivalue_count_maximum,
+                multivalue_count,
                 kind_weights,
                 metric_weights,
                 value,
             }) => {
-                let context_range = *contexts_minimum..*contexts_maximum;
-                let tags_per_msg_range = *tags_per_msg_minimum..*tags_per_msg_maximum;
-                let name_length_range = *name_length_minimum..*name_length_maximum;
-                let tag_key_length_range = *tag_key_length_minimum..*tag_key_length_maximum;
-                let tag_value_length_range = *tag_value_length_minimum..*tag_value_length_maximum;
-                let multivalue_count_range = *multivalue_count_minimum..*multivalue_count_maximum;
-
                 let serializer = payload::DogStatsD::new(
-                    context_range,
-                    name_length_range,
-                    tag_key_length_range,
-                    tag_value_length_range,
-                    tags_per_msg_range,
-                    multivalue_count_range,
+                    *contexts,
+                    *name_length,
+                    *tag_key_length,
+                    *tag_value_length,
+                    *tags_per_msg,
+                    *multivalue_count,
                     *multivalue_pack_probability,
                     *kind_weights,
                     *metric_weights,
@@ -272,38 +259,25 @@ fn stream_inner(
             stream_block_inner(&mut rng, total_bytes, &pyld, block_chunks, &snd)
         }
         payload::Config::DogStatsD(payload::dogstatsd::Config {
-            contexts_minimum,
-            contexts_maximum,
-            name_length_minimum,
-            name_length_maximum,
-            tag_key_length_minimum,
-            tag_key_length_maximum,
-            tag_value_length_minimum,
-            tag_value_length_maximum,
-            tags_per_msg_minimum,
-            tags_per_msg_maximum,
+            contexts,
+            name_length,
+            tag_key_length,
+            tag_value_length,
+            tags_per_msg,
             // TODO -- Validate user input for multivalue_pack_probability.
             multivalue_pack_probability,
-            multivalue_count_minimum,
-            multivalue_count_maximum,
+            multivalue_count,
             kind_weights,
             metric_weights,
             value,
         }) => {
-            let context_range = *contexts_minimum..*contexts_maximum;
-            let tags_per_msg_range = *tags_per_msg_minimum..*tags_per_msg_maximum;
-            let name_length_range = *name_length_minimum..*name_length_maximum;
-            let tag_key_length_range = *tag_key_length_minimum..*tag_key_length_maximum;
-            let tag_value_length_range = *tag_value_length_minimum..*tag_value_length_maximum;
-            let multivalue_count_range = *multivalue_count_minimum..*multivalue_count_maximum;
-
             let pyld = payload::DogStatsD::new(
-                context_range,
-                name_length_range,
-                tag_key_length_range,
-                tag_value_length_range,
-                tags_per_msg_range,
-                multivalue_count_range,
+                *contexts,
+                *name_length,
+                *tag_key_length,
+                *tag_value_length,
+                *tags_per_msg,
+                *multivalue_count,
                 *multivalue_pack_probability,
                 *kind_weights,
                 *metric_weights,

--- a/lading_payload/proptest-regressions/common/strings.txt
+++ b/lading_payload/proptest-regressions/common/strings.txt
@@ -7,3 +7,4 @@
 cc af61ca38851fafeed4d96b45d1d1aca38e2ab8a1489b51ccae6e0e178640e569 # shrinks to seed = 0, max_bytes = 2, of_size_bytes = 0, alphabet = "￼a🈐aAaA0𐦀A𐠊A\u{e0100}"
 cc e4740adac235cc14baefdb17ab4e7b825a9100e1e140031f72c0eb66783a6bdc # shrinks to seed = 49880598398515969, max_bytes = 3977, of_size_bytes = 0, alphabet = "ힰA\u{11c92}® "
 cc 7d00cd4ac860c10fd2a903761b1540638fb95f92bfd352cbf952ec53760bedb4 # shrinks to seed = 170628173656970550, max_bytes = 7313, of_size_bytes = 0, alphabet = " 𒒀"
+cc c3bbc5eb64e117c599cfe76df189ae8ec8238c47e76a942970505e5da6dcee1b # shrinks to seed = 0, max_bytes = 43894, of_size_bytes = 43894

--- a/lading_payload/proptest-regressions/dogstatsd.txt
+++ b/lading_payload/proptest-regressions/dogstatsd.txt
@@ -1,0 +1,7 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+cc 97158e48115dce6b53c08d3f3744ebd92cb711273b19aee225daa774f71f6e23 # shrinks to seed = 0, max_bytes = 0

--- a/lading_payload/src/common/strings.rs
+++ b/lading_payload/src/common/strings.rs
@@ -128,7 +128,8 @@ mod test {
         }
     }
 
-    // Ensure that of_size only returns None if the request is larger than the interior size.
+    // Ensure that of_size only returns None if the request is greater than or
+    // equal to the interior size.
     proptest! {
         #[test]
         fn return_none_condition(seed: u64, max_bytes: u16, of_size_bytes: u16) {
@@ -138,7 +139,7 @@ mod test {
 
             let pool = Pool::with_size_and_alphabet(&mut rng, max_bytes, ALPHANUM);
             if pool.of_size(&mut rng, of_size_bytes).is_none() {
-                assert!(of_size_bytes > max_bytes);
+                assert!(of_size_bytes >= max_bytes);
             }
         }
     }

--- a/lading_payload/src/dogstatsd.rs
+++ b/lading_payload/src/dogstatsd.rs
@@ -122,6 +122,7 @@ pub struct ValueConf {
 
 /// Range expression for configuration
 #[derive(Debug, Deserialize, Clone, PartialEq, Copy)]
+#[serde(rename_all = "snake_case")]
 pub enum ConfRange<T>
 where
     T: PartialEq + cmp::PartialOrd + Clone + Copy,

--- a/lading_payload/src/dogstatsd/common.rs
+++ b/lading_payload/src/dogstatsd/common.rs
@@ -8,7 +8,7 @@ use rand::{
 
 use crate::Generator;
 
-use super::{ValueConf, ValueRange};
+use super::{ConfRange, ValueConf};
 
 pub(crate) mod tags;
 
@@ -36,12 +36,12 @@ impl NumValueGenerator {
     #[allow(clippy::cast_possible_truncation)]
     pub(crate) fn new(conf: ValueConf) -> Self {
         match conf.range {
-            ValueRange::Constant(c) => Self::Constant {
+            ConfRange::Constant(c) => Self::Constant {
                 float_probability: conf.float_probability,
                 int: c,
                 float: c as f64,
             },
-            ValueRange::Inclusive { min, max } => Self::Uniform {
+            ConfRange::Inclusive { min, max } => Self::Uniform {
                 float_probability: conf.float_probability,
                 int_distr: Uniform::new_inclusive(min, max),
                 float_distr: Uniform::new_inclusive(min as f64, max as f64),

--- a/lading_payload/src/dogstatsd/common/tags.rs
+++ b/lading_payload/src/dogstatsd/common/tags.rs
@@ -1,6 +1,6 @@
-use std::{ops::Range, rc::Rc};
+use std::rc::Rc;
 
-use crate::common::strings;
+use crate::{common::strings, dogstatsd::ConfRange};
 
 // This represents a list of tags that will be present on a single
 // dogstatsd message.
@@ -10,9 +10,9 @@ pub(crate) type Tagsets = Vec<Tagset>;
 
 pub(crate) struct Generator {
     pub(crate) num_tagsets: usize,
-    pub(crate) tags_per_msg_range: Range<usize>,
-    pub(crate) tag_key_length_range: Range<u16>,
-    pub(crate) tag_value_length_range: Range<u16>,
+    pub(crate) tags_per_msg: ConfRange<u16>,
+    pub(crate) tag_key_length: ConfRange<u16>,
+    pub(crate) tag_value_length: ConfRange<u16>,
     pub(crate) str_pool: Rc<strings::Pool>,
 }
 
@@ -24,25 +24,17 @@ impl<'a> crate::Generator<'a> for Generator {
     where
         R: rand::Rng + ?Sized,
     {
-        let tags_per_msg_range = self.tags_per_msg_range.clone();
-
         let mut tagsets: Vec<Tagset> = Vec::with_capacity(self.num_tagsets);
         for _ in 0..self.num_tagsets {
-            let tags_per_msg_range = tags_per_msg_range.clone();
-
-            let num_tags_for_this_msg = rng.gen_range(tags_per_msg_range);
+            let num_tags_for_this_msg = self.tags_per_msg.sample(rng) as usize;
             let mut tagset = Vec::with_capacity(num_tags_for_this_msg);
             for _ in 0..num_tags_for_this_msg {
                 let mut tag = String::new();
                 tag.reserve(512); // a guess, big-ish but not too big
-                let key = self
-                    .str_pool
-                    .of_size_range(&mut rng, self.tag_key_length_range.clone())
-                    .unwrap();
-                let value = self
-                    .str_pool
-                    .of_size_range(&mut rng, self.tag_value_length_range.clone())
-                    .unwrap();
+                let key_sz = self.tag_key_length.sample(&mut rng) as usize;
+                let key = self.str_pool.of_size(&mut rng, key_sz).unwrap();
+                let value_sz = self.tag_value_length.sample(&mut rng) as usize;
+                let value = self.str_pool.of_size(&mut rng, value_sz).unwrap();
                 tag.push_str(key);
                 tag.push(':');
                 tag.push_str(value);
@@ -51,5 +43,36 @@ impl<'a> crate::Generator<'a> for Generator {
             tagsets.push(tagset);
         }
         tagsets
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use proptest::prelude::*;
+    use rand::{rngs::SmallRng, SeedableRng};
+
+    use crate::dogstatsd::{strings, tags, ConfRange};
+    use crate::Generator;
+    use std::rc::Rc;
+
+    // We want to be sure that the serialized size of the payload does not
+    // exceed `max_bytes`.
+    proptest! {
+        #[test]
+        fn generator_not_exceed_tagset_max(seed: u64, num_tagsets in 0..100_000) {
+            let mut rng = SmallRng::seed_from_u64(seed);
+            let num_tagsets = num_tagsets as usize;
+            let pool = Rc::new(strings::Pool::with_size(&mut rng, 8_000_000));
+
+            let generator = tags::Generator {
+                num_tagsets,
+                tags_per_msg: ConfRange::Inclusive{min: 0, max: 1_000},
+                tag_key_length: ConfRange::Inclusive{min: 1, max: 64 },
+                tag_value_length: ConfRange::Inclusive{min: 1, max: 64 },
+                str_pool: pool,
+            };
+            let tagsets = generator.generate(&mut rng);
+            assert!(tagsets.len() == num_tagsets);
+        }
     }
 }

--- a/lading_payload/src/dogstatsd/common/tags.rs
+++ b/lading_payload/src/dogstatsd/common/tags.rs
@@ -59,7 +59,7 @@ mod test {
     // exceed `max_bytes`.
     proptest! {
         #[test]
-        fn generator_not_exceed_tagset_max(seed: u64, num_tagsets in 0..100_000) {
+        fn generator_not_exceed_tagset_max(seed: u64, num_tagsets in 0..1_000) {
             let mut rng = SmallRng::seed_from_u64(seed);
             let num_tagsets = num_tagsets as usize;
             let pool = Rc::new(strings::Pool::with_size(&mut rng, 8_000_000));

--- a/lading_payload/src/dogstatsd/event.rs
+++ b/lading_payload/src/dogstatsd/event.rs
@@ -4,11 +4,11 @@ use rand::{distributions::Standard, prelude::Distribution, Rng};
 
 use crate::{common::strings, Generator};
 
-use super::{choose_or_not_fn, choose_or_not_ref, common};
+use super::{choose_or_not_fn, choose_or_not_ref, common, ConfRange};
 
 #[derive(Debug, Clone)]
 pub(crate) struct EventGenerator {
-    pub(crate) title_length_range: Range<u16>,
+    pub(crate) title_length: ConfRange<u16>,
     pub(crate) texts_or_messages_length_range: Range<u16>,
     pub(crate) small_strings_length_range: Range<u16>,
     pub(crate) str_pool: Rc<strings::Pool>,
@@ -22,10 +22,8 @@ impl<'a> Generator<'a> for EventGenerator {
     where
         R: rand::Rng + ?Sized,
     {
-        let title = self
-            .str_pool
-            .of_size_range(&mut rng, self.title_length_range.clone())
-            .unwrap();
+        let title_sz = self.title_length.sample(&mut rng) as usize;
+        let title = self.str_pool.of_size(&mut rng, title_sz).unwrap();
         let text = self
             .str_pool
             .of_size_range(&mut rng, self.texts_or_messages_length_range.clone())


### PR DESCRIPTION
### What does this PR do?

We have the need to specify constant values for some of our range constructions in dogstatsd payloads. This commit allows that behavior, although users must now be explicit about the constant or inclusive setup they intend. This will be very helpful in experimenting with the Agent, we believe.

REF https://github.com/DataDog/datadog-agent/pull/19993 
REF SMPTNG-24
