### PR TITLE
add support for raw byte for http response body

### DIFF
--- a/lading/src/blackhole/http.rs
+++ b/lading/src/blackhole/http.rs
@@ -93,7 +93,7 @@ pub struct Config {
     pub status: u16,
     /// raw array of bytes if the raw_bytes body variant is selected
     #[serde(default)]
-    pub raw_bytes: Vec<u8>
+    pub raw_bytes: Vec<u8>,
 }
 
 #[derive(Serialize)]

--- a/lading/src/blackhole/http.rs
+++ b/lading/src/blackhole/http.rs
@@ -258,3 +258,51 @@ impl Http {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use std::str::FromStr;
+
+    use super::*;
+
+    #[test]
+    fn config_deserializes_variant_nothing() {
+        let contents = r#"
+binding_addr: "127.0.0.1:1000"
+body_variant: "nothing"
+"#;
+        let config: Config = serde_yaml::from_str(contents).unwrap();
+        assert_eq!(
+            config,
+            Config {
+                concurrent_requests_max: default_concurrent_requests_max(),
+                binding_addr: SocketAddr::from_str("127.0.0.1:1000").unwrap(),
+                body_variant: BodyVariant::Nothing,
+                headers: default_headers(),
+                status: default_status_code(),
+                raw_bytes: vec![],
+            },
+        );
+    }
+
+    #[test]
+    fn config_deserializes_raw_bytes() {
+        let contents = r#"
+binding_addr: "127.0.0.1:1000"
+body_variant: "raw_bytes"
+raw_bytes: [0x01, 0x02, 0x10]
+"#;
+        let config: Config = serde_yaml::from_str(contents).unwrap();
+        assert_eq!(
+            config,
+            Config {
+                concurrent_requests_max: default_concurrent_requests_max(),
+                binding_addr: SocketAddr::from_str("127.0.0.1:1000").unwrap(),
+                body_variant: BodyVariant::RawBytes,
+                headers: default_headers(),
+                status: default_status_code(),
+                raw_bytes: vec![0x01, 0x02, 0x10],
+            },
+        );
+    }
+}

--- a/lading/src/blackhole/http.rs
+++ b/lading/src/blackhole/http.rs
@@ -192,7 +192,7 @@ impl Http {
 
         Ok(Self {
             httpd_addr: config.binding_addr,
-            body_bytes: body_bytes,
+            body_bytes,
             concurrency_limit: config.concurrent_requests_max,
             headers: config.headers.clone(),
             status,

--- a/lading/src/blackhole/http.rs
+++ b/lading/src/blackhole/http.rs
@@ -171,24 +171,24 @@ impl Http {
         }
 
         let body_bytes = RESPONSE
-        .get_or_init(|| match &config.body_variant {
-            BodyVariant::AwsKinesis => {
-                let response = KinesisPutRecordBatchResponse {
-                    encrypted: None,
-                    failed_put_count: 0,
-                    request_responses: vec![KinesisPutRecordBatchResponseEntry {
-                        error_code: None,
-                        error_message: None,
-                        record_id: "foobar".to_string(),
-                    }],
-                };
-                serde_json::to_vec(&response).unwrap()
-            }
-            BodyVariant::Nothing => vec![],
-            BodyVariant::RawBytes => config.raw_bytes.clone(),
-            BodyVariant::Static(val) => val.as_bytes().to_vec(),
-        })
-        .clone();
+            .get_or_init(|| match &config.body_variant {
+                BodyVariant::AwsKinesis => {
+                    let response = KinesisPutRecordBatchResponse {
+                        encrypted: None,
+                        failed_put_count: 0,
+                        request_responses: vec![KinesisPutRecordBatchResponseEntry {
+                            error_code: None,
+                            error_message: None,
+                            record_id: "foobar".to_string(),
+                        }],
+                    };
+                    serde_json::to_vec(&response).unwrap()
+                }
+                BodyVariant::Nothing => vec![],
+                BodyVariant::RawBytes => config.raw_bytes.clone(),
+                BodyVariant::Static(val) => val.as_bytes().to_vec(),
+            })
+            .clone();
 
         Ok(Self {
             httpd_addr: config.binding_addr,


### PR DESCRIPTION
### What does this PR do?

Add support to the blackhole to return a raw byte array/vector response. This is to support custom binary types which is used by the datadog process agent.

### Testing

**1. Baseline**
Running the agent with the `nothing` response from lading shows the process agent logs errors due to the invalid/empty response
```yaml
  - http:
      binding_addr: "127.0.0.1:9092"
      body_variant: "nothing"
```
```
2023-10-16 20:11:43 UTC | PROCESS | ERROR | (pkg/process/runner/runner.go:489 in readResponseStatuses) | [process] Could not decode response body: invalid message length: 0
```

**1. Process Response RT Mode Disabled**
```yaml
  - http:
      binding_addr: "127.0.0.1:9092"
      body_variant: "raw_bytes"
      # process agent RT mode disabled response
      raw_bytes: [0x1, 0x0, 0x17, 0x0, 0xa, 0x2, 0x20, 0x17, 0x1a, 0x2, 0x10, 0xa]
```
The process agent logs show no errors from the response

**2. Process Response RT Mode Enabled**
```yaml
- http:
  binding_addr: "127.0.0.1:9092"
  # process agent RT mode enabled response
  raw_bytes: [0x1, 0x0, 0x17, 0x0, 0xa, 0x2, 0x20, 0x17, 0x1a, 0x4, 0x8, 0x2, 0x10, 0x2]
```
The process agent logs show RT mode is enabled
```
2023-10-16 20:36:53 UTC | PROCESS | INFO | (pkg/process/runner/runner.go:229 in logCheckDuration) | Finished process check #2 in 20.911458ms
2023-10-16 20:36:53 UTC | PROCESS | INFO | (pkg/process/runner/runner.go:415 in UpdateRTStatus) | Detected 2 active clients, enabling real-time mode
```


### Motivation

What inspired you to submit this pull request?

### Related issues

A list of issues either fixed, containing architectural discussions, otherwise relevant
for this Pull Request.

### Additional Notes

Anything else we should know when reviewing?
