### PR TITLE
Prepare 0.19.0-rc4 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## [0.20.0-rc1]
+### Changed
+- HTTP blackhole can respond with arbitrary data.
+
 ## [0.19.0-rc3]
 ### Changed
 - Dogstatsd payload generation uses snake-case.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
-## [0.20.0-rc1]
+## [0.19.0-rc4]
 ### Changed
 - HTTP blackhole can respond with arbitrary data.
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1010,7 +1010,7 @@ dependencies = [
 
 [[package]]
 name = "lading"
-version = "0.20.0-rc1"
+version = "0.19.0-rc4"
 dependencies = [
  "async-pidfd",
  "byte-unit",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1010,7 +1010,7 @@ dependencies = [
 
 [[package]]
 name = "lading"
-version = "0.19.0-rc3"
+version = "0.20.0-rc1"
 dependencies = [
  "async-pidfd",
  "byte-unit",

--- a/lading/Cargo.toml
+++ b/lading/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lading"
-version = "0.20.0-rc1"
+version = "0.19.0-rc4"
 authors = ["Brian L. Troutwine <brian.troutwine@datadoghq.com>", "George Hahn <george.hahn@datadoghq.com"]
 edition = "2021"
 license = "MIT"

--- a/lading/Cargo.toml
+++ b/lading/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lading"
-version = "0.19.0-rc3"
+version = "0.20.0-rc1"
 authors = ["Brian L. Troutwine <brian.troutwine@datadoghq.com>", "George Hahn <george.hahn@datadoghq.com"]
 edition = "2021"
 license = "MIT"


### PR DESCRIPTION
### What does this PR do?

Prep a 0.19.0-rc4 release candidate

### Motivation

Get https://github.com/DataDog/lading/pull/704 into a released build

Ref PROCS-3308