### PR TITLE
Make Single Machine Performance official code owners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+* @DataDog/single-machine-performance


### PR DESCRIPTION
### What does this PR do?

This commit makes the Single Machine Performance team required reviewers of every PR. This formalizes an informal process we've kept in place for the last year and change.


