### PR TITLE
HTTP blackhole: fix `bytes_received` and `requests_received` metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+- Correct metrics emitted by http blackhole
+
 ## [0.19.0]
 ### Changed
 - HTTP blackhole can respond with arbitrary data.

--- a/lading/src/blackhole/http.rs
+++ b/lading/src/blackhole/http.rs
@@ -117,7 +117,7 @@ async fn srv(
     req: Request<Body>,
     headers: HeaderMap,
 ) -> Result<Response<Body>, hyper::Error> {
-    bytes_received.increment(1);
+    requests_received.increment(1);
 
     let (parts, body) = req.into_parts();
 
@@ -126,7 +126,7 @@ async fn srv(
     match crate::codec::decode(parts.headers.get(hyper::header::CONTENT_ENCODING), bytes) {
         Err(response) => Ok(response),
         Ok(body) => {
-            requests_received.increment(body.len() as u64);
+            bytes_received.increment(body.len() as u64);
 
             let mut okay = Response::default();
             *okay.status_mut() = status;


### PR DESCRIPTION
### What does this PR do?

Fix the metrics emitted by lading's http blackhole.

### Motivation

Fix our view of agent egress.

### Related issues

SMPTNG-1
