### PR TITLE
Report scraped counters without aggregation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Fixed
+- Report scraped Prometheus counters correctly
 
 ## [0.19.0]
 ### Changed

--- a/lading/src/target_metrics/prometheus.rs
+++ b/lading/src/target_metrics/prometheus.rs
@@ -6,7 +6,7 @@
 
 use std::{str::FromStr, time::Duration};
 
-use metrics::{counter, gauge};
+use metrics::{absolute_counter, gauge};
 use rustc_hash::FxHashMap;
 use serde::Deserialize;
 use tracing::{error, info, trace, warn};
@@ -197,7 +197,11 @@ impl Prometheus {
                             };
 
                             trace!("counter: {name} = {value}");
-                            counter!(format!("target/{name}"), value, &labels.unwrap_or_default());
+                            absolute_counter!(
+                                format!("target/{name}"),
+                                value,
+                                &labels.unwrap_or_default()
+                            );
                         }
                         Some(_) | None => {
                             trace!("unsupported metric type: {name} = {value}");


### PR DESCRIPTION
### What does this PR do?

Report scraped Prometheus counters correctly. This fixes a double aggregation that we observed in metrics scraped from targets.

### Motivation

Fixes

### Related issues

SMPTNG-1
