### PR TITLE
Adjust proofs for stable valve in throttle

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,6 +85,22 @@ jobs:
       - run: cargo test -p sheepdog
         timeout-minutes: 30
 
+
+  kani:
+    name: Kani Proofs
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        crate: [lading_throttle]
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rust-lang/setup-rust-toolchain@v1.3.7
+      - name: Install kani
+        run: cargo install kani-verifier
+      - run: cargo kani --solver cadical
+        working-directory: ${{ matrix.crate }}
+        timeout-minutes: 30
+
   buf:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
### What does this PR do?

This commit adjusts the proofs that we have in our stable throttle to avoid a loop and instead rely on a series of smaller proofs. This terminates in a reasonable amount of time. Note I've removed the proptests and this commit will need to be followed by another than runs kani in CI.

I may still be missing a few small properties.

### Related issues

REF SMPTNG-79
