### PR TITLE
Convert target metrics where possible to stream

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## [0.20.0-rc3]
+### Changed
+- Instrumentation of content length changed to logs to avoid expanding capture files.
+
 ## [0.20.0-rc2]
 ### Changed
 - Target metrics now stream where possible, instrument content length from target.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## [0.20.0-rc2]
+### Changed
+- Target metrics now stream where possible, instrument content length from target.
+
 ## [0.20.0-rc1]
 ### Added
 - A new 'logrotate' file generator is introduced.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1026,7 +1026,7 @@ dependencies = [
 
 [[package]]
 name = "lading"
-version = "0.20.0-rc1"
+version = "0.20.0-rc2"
 dependencies = [
  "async-pidfd",
  "byte-unit",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1937,10 +1937,12 @@ dependencies = [
  "serde_urlencoded",
  "system-configuration",
  "tokio",
+ "tokio-util",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
+ "wasm-streams",
  "web-sys",
  "winreg",
 ]
@@ -2859,6 +2861,19 @@ name = "wasm-bindgen-shared"
 version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca6ad05a4870b2bf5fe995117d3728437bd27d7cd5f06f13c17443ef369775a1"
+
+[[package]]
+name = "wasm-streams"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4609d447824375f43e1ffbc051b50ad8f4b3ae8219680c94452ea05eb240ac7"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
 
 [[package]]
 name = "web-sys"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1026,7 +1026,7 @@ dependencies = [
 
 [[package]]
 name = "lading"
-version = "0.20.0-rc2"
+version = "0.20.0-rc3"
 dependencies = [
  "async-pidfd",
  "byte-unit",

--- a/lading/Cargo.toml
+++ b/lading/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lading"
-version = "0.20.0-rc2"
+version = "0.20.0-rc3"
 authors = ["Brian L. Troutwine <brian.troutwine@datadoghq.com>", "George Hahn <george.hahn@datadoghq.com"]
 edition = "2021"
 license = "MIT"

--- a/lading/Cargo.toml
+++ b/lading/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lading"
-version = "0.20.0-rc1"
+version = "0.20.0-rc2"
 authors = ["Brian L. Troutwine <brian.troutwine@datadoghq.com>", "George Hahn <george.hahn@datadoghq.com"]
 edition = "2021"
 license = "MIT"

--- a/lading/Cargo.toml
+++ b/lading/Cargo.toml
@@ -30,7 +30,7 @@ nix = { version = "0.26" }
 num_cpus = { version = "1.16" }
 once_cell = "1.18"
 rand = { workspace = true, default-features = false, features = ["small_rng", "std", "std_rng" ]}
-reqwest = { version = "0.11", default-features = false, features = ["json"] }
+reqwest = { version = "0.11", default-features = false, features = ["json", "stream"] }
 rustc-hash = { workspace = true }
 serde = { workspace = true }
 serde_json = {workspace = true }

--- a/lading/src/target_metrics.rs
+++ b/lading/src/target_metrics.rs
@@ -11,11 +11,13 @@ use crate::signals::Shutdown;
 pub mod expvar;
 pub mod prometheus;
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, thiserror::Error)]
 /// Errors produced by [`Server`]
 pub enum Error {
+    #[error(transparent)]
     /// See [`crate::target_metrics::expvar::Error`] for details.
     Expvar(expvar::Error),
+    #[error(transparent)]
     /// See [`crate::target_metrics::prometheus::Error`] for details.
     Prometheus(prometheus::Error),
 }

--- a/lading/src/target_metrics/expvar.rs
+++ b/lading/src/target_metrics/expvar.rs
@@ -5,7 +5,7 @@
 
 use std::time::Duration;
 
-use metrics::gauge;
+use metrics::{gauge, register_histogram};
 use serde::Deserialize;
 use serde_json::Value;
 use tracing::{error, info, trace};
@@ -62,39 +62,42 @@ impl Expvar {
         info!("Expvar target metrics scraper running");
         let client = reqwest::Client::new();
 
-        let server = async move {
-            loop {
-                tokio::time::sleep(Duration::from_secs(1)).await;
+        let mut timer = tokio::time::interval(Duration::from_secs(1));
 
-                let Ok(resp) = client.get(&self.config.uri).timeout(Duration::from_secs(1)).send().await else {
-                    info!("failed to get expvar uri");
-                    continue;
-                };
+        let content_length =
+            register_histogram!("target_metrics_content_length", "source" => "expvar");
 
-                let Ok(json) = resp.json::<Value>().await else {
-                    info!("failed to parse expvar json");
-                    continue;
-                };
+        loop {
+            tokio::select! {
+                _ = timer.tick() => {
+                    let Ok(resp) = client.get(&self.config.uri).timeout(Duration::from_secs(1)).send().await else {
+                        info!("failed to get expvar uri");
+                        continue;
+                    };
+                    if let Some(cl) = resp.content_length() {
+                        content_length.record(cl as f64);
+                    }
 
-                for var_name in &self.config.vars {
-                    let val = json.pointer(var_name).and_then(serde_json::Value::as_f64);
-                    if let Some(val) = val {
-                        trace!("expvar: {} = {}", var_name, val);
-                        gauge!(format!("target/{name}", name = var_name.trim_start_matches('/')), val, "source" => "target_metrics/expvar");
+                    let Ok(json) = resp.json::<Value>().await else {
+                        info!("failed to parse expvar json");
+                        continue;
+                    };
+
+                    for var_name in &self.config.vars {
+                        let val = json.pointer(var_name).and_then(serde_json::Value::as_f64);
+                        if let Some(val) = val {
+                            trace!("expvar: {} = {}", var_name, val);
+                            gauge!(format!("target/{name}", name = var_name.trim_start_matches('/')), val, "source" => "target_metrics/expvar");
+                        }
                     }
                 }
-            }
-        };
-
-        tokio::select! {
-            _res = server => {
-                error!("server shutdown unexpectedly");
-                 Err(Error::EarlyShutdown)
-            }
-            _ = self.shutdown.recv() => {
-                info!("shutdown signal received");
-                 Ok(())
+                _ = self.shutdown.recv() => {
+                    info!("shutdown signal received");
+                    break;
+                }
             }
         }
+
+        Ok(())
     }
 }

--- a/lading/src/target_metrics/prometheus.rs
+++ b/lading/src/target_metrics/prometheus.rs
@@ -6,19 +6,25 @@
 
 use std::{str::FromStr, time::Duration};
 
-use metrics::{absolute_counter, gauge};
+use futures::TryStreamExt;
+use metrics::{absolute_counter, gauge, register_histogram};
 use rustc_hash::FxHashMap;
 use serde::Deserialize;
+use tokio::io::AsyncBufReadExt;
+use tokio_util::io::StreamReader;
 use tracing::{error, info, trace, warn};
 
 use crate::signals::Shutdown;
 
-#[derive(Debug, Clone, Copy, thiserror::Error)]
+#[derive(Debug, thiserror::Error)]
 /// Errors produced by [`Prometheus`]
 pub enum Error {
     /// Prometheus scraper shut down unexpectedly
     #[error("Unexpected shutdown")]
     EarlyShutdown,
+    /// IO Error
+    #[error(transparent)]
+    Io(#[from] std::io::Error),
 }
 
 #[derive(Debug, Deserialize, PartialEq, Eq)]
@@ -58,6 +64,14 @@ impl FromStr for MetricType {
     }
 }
 
+/// Intentionally dump the reqwest error but log it out.
+#[inline]
+#[allow(clippy::needless_pass_by_value)]
+fn convert_err(err: reqwest::Error) -> std::io::Error {
+    error!("reqwest error: {err}");
+    std::io::Error::new(std::io::ErrorKind::Other, "reqwest error")
+}
+
 /// The `Prometheus` target metrics implementation.
 #[derive(Debug)]
 pub struct Prometheus {
@@ -93,132 +107,140 @@ impl Prometheus {
         info!("Prometheus target metrics scraper running");
         let client = reqwest::Client::new();
 
-        let server = async move {
-            loop {
-                tokio::time::sleep(Duration::from_secs(1)).await;
+        let mut timer = tokio::time::interval(Duration::from_secs(1));
 
-                let Ok(resp) = client.get(&self.config.uri).timeout(Duration::from_secs(1)).send().await else {
-                    info!("failed to get Prometheus uri");
-                    continue;
-                };
+        let content_length =
+            register_histogram!("target_metrics_content_length", "source" => "prometheus");
 
-                let Ok(text) = resp.text().await else {
-                    info!("failed to read Prometheus response");
-                    continue;
-                };
-
-                // remember the type for each metric across lines
-                let mut typemap = FxHashMap::default();
-
-                // this deserves a real parser, but this will do for now.
-                // Format doc: https://github.com/prometheus/docs/blob/main/content/docs/instrumenting/exposition_formats.md
-                for line in text.lines() {
-                    if line.starts_with("# HELP") {
+        loop {
+            tokio::select! {
+                _ = timer.tick() => {
+                    let Ok(resp) = client.get(&self.config.uri).timeout(Duration::from_secs(1)).send().await else {
+                        info!("failed to get Prometheus uri");
                         continue;
-                    }
-
-                    if line.starts_with("# TYPE") {
-                        let mut parts = line.split_ascii_whitespace().skip(2);
-                        let name = parts.next().unwrap();
-                        let metric_type = parts.next().unwrap();
-                        let metric_type: MetricType = metric_type.parse().unwrap();
-                        // summary and histogram metrics additionally report names suffixed with _sum, _count, _bucket
-                        if matches!(metric_type, MetricType::Histogram | MetricType::Summary) {
-                            typemap.insert(format!("{name}_sum"), metric_type);
-                            typemap.insert(format!("{name}_count"), metric_type);
-                            typemap.insert(format!("{name}_bucket"), metric_type);
-                        }
-                        typemap.insert(name.to_owned(), metric_type);
-                        continue;
-                    }
-
-                    let mut parts = line.split_ascii_whitespace();
-                    let name_and_labels = parts.next().unwrap();
-                    let value = parts.next().unwrap();
-
-                    if value.contains('#') {
-                        trace!("Unknown format: {value}");
-                        continue;
-                    }
-
-                    let (name, labels) = {
-                        if let Some((name, labels)) = name_and_labels.split_once('{') {
-                            let labels = labels.trim_end_matches('}');
-                            let labels = labels.split(',').map(|label| {
-                                let (label_name, label_value) = label.split_once('=').unwrap();
-                                let label_value = label_value.trim_matches('\"');
-                                (label_name.to_owned(), label_value.to_owned())
-                            });
-                            let labels = labels.collect::<Vec<_>>();
-                            (name, Some(labels))
-                        } else {
-                            (name_and_labels, None)
-                        }
                     };
-
-                    let metric_type = typemap.get(name);
-                    let name = name.replace("__", ".");
-
-                    if let Some(metrics) = &self.config.metrics {
-                        if !metrics.contains(&name) {
-                            continue;
-                        }
+                    if let Some(cl) = resp.content_length() {
+                    content_length.record(cl as f64);
                     }
 
-                    match metric_type {
-                        Some(MetricType::Gauge) => {
-                            let Ok(value): Result<f64, _> = value.parse() else {
-                                let e = value.parse::<f64>().unwrap_err();
-                                warn!("{e}: {name} = {value}");
-                                continue;
-                            };
+                    let reader = StreamReader::new(resp.bytes_stream().map_err(convert_err));
+                    let mut lines = reader.lines();
 
-                            trace!("gauge: {name} = {value}");
-                            gauge!(format!("target/{name}"), value, &labels.unwrap_or_default());
-                        }
-                        Some(MetricType::Counter) => {
-                            let Ok(value): Result<f64, _> = value.parse() else {
-                                let e = value.parse::<f64>().unwrap_err();
-                                warn!("{e}: {name} = {value}");
-                                continue;
-                            };
-
-                            let value = if value < 0.0 {
-                                warn!("Negative counter value unhandled");
-                                continue;
-                            } else {
-                                // clippy shows "error: casting `f64` to `u64` may lose the sign of the value". This is
-                                // guarded by the sign check above.
-                                if value > u64::MAX as f64 {
-                                    warn!("Counter value above maximum limit");
-                                    continue;
-                                }
-                                value as u64
-                            };
-
-                            trace!("counter: {name} = {value}");
-                            absolute_counter!(
-                                format!("target/{name}"),
-                                value,
-                                &labels.unwrap_or_default()
-                            );
-                        }
-                        Some(_) | None => {
-                            trace!("unsupported metric type: {name} = {value}");
-                        }
+                    // Used to preserve types across prometheus lines. We could
+                    // potentially elide this if we adjusted our parser to have
+                    // look-ahead, rather than being line by line. Or
+                    // constrained the lines to require types just prior to the
+                    // values.
+                    let mut typemap = FxHashMap::default();
+                    while let Some(line) = lines.next_line().await? {
+                        // Process the line immediately
+                        self.process_line(&line, &mut typemap);
                     }
+                    gauge!("total_client_prometheus_metrics", typemap.len() as f64);
                 }
+                _ = self.shutdown.recv() => {
+                    info!("shutdown signal received");
+                    break;
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    #[allow(clippy::cast_possible_truncation)]
+    #[allow(clippy::cast_sign_loss)]
+    fn process_line(&self, line: &str, typemap: &mut FxHashMap<String, MetricType>) {
+        // this deserves a real parser, but this will do for now.
+        // Format doc: https://github.com/prometheus/docs/blob/main/content/docs/instrumenting/exposition_formats.md
+        if line.starts_with("# HELP") {
+            return;
+        }
+
+        if line.starts_with("# TYPE") {
+            let mut parts = line.split_ascii_whitespace().skip(2);
+            let name = parts.next().unwrap();
+            let metric_type = parts.next().unwrap();
+            let metric_type: MetricType = metric_type.parse().unwrap();
+            // summary and histogram metrics additionally report names suffixed with _sum, _count, _bucket
+            if matches!(metric_type, MetricType::Histogram | MetricType::Summary) {
+                typemap.insert(format!("{name}_sum"), metric_type);
+                typemap.insert(format!("{name}_count"), metric_type);
+                typemap.insert(format!("{name}_bucket"), metric_type);
+            }
+            typemap.insert(name.to_owned(), metric_type);
+            return;
+        }
+
+        let mut parts = line.split_ascii_whitespace();
+        let name_and_labels = parts.next().unwrap();
+        let value = parts.next().unwrap();
+
+        if value.contains('#') {
+            trace!("Unknown format: {value}");
+            return;
+        }
+
+        let (name, labels) = {
+            if let Some((name, labels)) = name_and_labels.split_once('{') {
+                let labels = labels.trim_end_matches('}');
+                let labels = labels.split(',').map(|label| {
+                    let (label_name, label_value) = label.split_once('=').unwrap();
+                    let label_value = label_value.trim_matches('\"');
+                    (label_name.to_owned(), label_value.to_owned())
+                });
+                let labels = labels.collect::<Vec<_>>();
+                (name, Some(labels))
+            } else {
+                (name_and_labels, None)
             }
         };
 
-        tokio::select! {
-            _res = server => {
-                error!("server shutdown unexpectedly");
-                 Err(Error::EarlyShutdown)
+        let metric_type = typemap.get(name);
+        let name = name.replace("__", ".");
+
+        if let Some(metrics) = &self.config.metrics {
+            if !metrics.contains(&name) {
+                return;
             }
-            _ = self.shutdown.recv() => {
-                info!("shutdown signal received");
-                 Ok(())
+        }
+
+        match metric_type {
+            Some(MetricType::Gauge) => {
+                let Ok(value): Result<f64, _> = value.parse() else {
+                        let e = value.parse::<f64>().unwrap_err();
+                        warn!("{e}: {name} = {value}");
+                        return;
+                    };
+
+                trace!("gauge: {name} = {value}");
+                gauge!(format!("target/{name}"), value, &labels.unwrap_or_default());
+            }
+            Some(MetricType::Counter) => {
+                let Ok(value): Result<f64, _> = value.parse() else {
+                        let e = value.parse::<f64>().unwrap_err();
+                        warn!("{e}: {name} = {value}");
+                        return;
+                    };
+
+                let value = if value < 0.0 {
+                    warn!("Negative counter value unhandled");
+                    return;
+                } else {
+                    // clippy shows "error: casting `f64` to `u64` may lose the sign of the value". This is
+                    // guarded by the sign check above.
+                    if value > u64::MAX as f64 {
+                        warn!("Counter value above maximum limit");
+                        return;
+                    }
+                    value as u64
+                };
+
+                trace!("counter: {name} = {value}");
+                absolute_counter!(format!("target/{name}"), value, &labels.unwrap_or_default());
+            }
+            Some(_) | None => {
+                trace!("unsupported metric type: {name} = {value}");
             }
         }
     }


### PR DESCRIPTION
### What does this PR do?

This commit converts our expvar and prometheus metrics to the use of streaming bodies where possible, especially on the prometheus side. The implementation of both is adjusted to be similar and we now record the content-length from the target.

### Related issues

REF SMPTNG-79
