### PR TITLE
Introduce proofs for block mechanism

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,10 +91,12 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        crate: [lading_throttle]
+        crate: [lading_throttle, lading_payload]
     steps:
       - uses: actions/checkout@v2
       - uses: actions-rust-lang/setup-rust-toolchain@v1.3.7
+      - name: Install protobuf (Apt)
+        run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
       - name: Install kani
         run: cargo install kani-verifier
       - run: cargo kani --solver cadical

--- a/lading/src/generator/file_gen/logrotate.rs
+++ b/lading/src/generator/file_gen/logrotate.rs
@@ -15,9 +15,9 @@
 //! Additional metrics may be emitted by this generator's [throttle].
 //!
 use std::{
-    num::{NonZeroU32, NonZeroUsize},
+    num::NonZeroU32,
     path::{Path, PathBuf},
-    str, thread,
+    thread,
 };
 
 use byte_unit::{Byte, ByteUnit};
@@ -110,7 +110,7 @@ impl Server {
     #[allow(clippy::cast_possible_truncation)]
     pub fn new(general: General, config: Config, shutdown: Shutdown) -> Result<Self, Error> {
         let mut rng = StdRng::from_seed(config.seed);
-        let block_sizes: Vec<NonZeroUsize> = config
+        let block_sizes: Vec<NonZeroU32> = config
             .block_sizes
             .unwrap_or_else(|| {
                 vec![
@@ -123,7 +123,7 @@ impl Server {
                 ]
             })
             .iter()
-            .map(|sz| NonZeroUsize::new(sz.get_bytes() as usize).expect("bytes must be non-zero"))
+            .map(|sz| NonZeroU32::new(sz.get_bytes() as u32).expect("bytes must be non-zero"))
             .collect();
         let mut labels = vec![
             ("component".to_string(), "generator".to_string()),
@@ -149,7 +149,7 @@ impl Server {
             let throttle = Throttle::new_with_config(config.throttle, bytes_per_second);
 
             let total_bytes =
-                NonZeroUsize::new(config.maximum_prebuild_cache_size_bytes.get_bytes() as usize)
+                NonZeroU32::new(config.maximum_prebuild_cache_size_bytes.get_bytes() as u32)
                     .expect("bytes must be non-zero");
             let block_cache = match config.block_cache_method {
                 block::CacheMethod::Streaming => block::Cache::stream(

--- a/lading/src/generator/file_gen/traditional.rs
+++ b/lading/src/generator/file_gen/traditional.rs
@@ -14,9 +14,8 @@
 //! Additional metrics may be emitted by this generator's [throttle].
 //!
 use std::{
-    num::{NonZeroU32, NonZeroUsize},
+    num::NonZeroU32,
     path::PathBuf,
-    str,
     sync::{
         atomic::{AtomicU32, Ordering},
         Arc,
@@ -131,7 +130,7 @@ impl Server {
     #[allow(clippy::cast_possible_truncation)]
     pub fn new(general: General, config: Config, shutdown: Shutdown) -> Result<Self, Error> {
         let mut rng = StdRng::from_seed(config.seed);
-        let block_sizes: Vec<NonZeroUsize> = config
+        let block_sizes: Vec<NonZeroU32> = config
             .block_sizes
             .unwrap_or_else(|| {
                 vec![
@@ -144,7 +143,7 @@ impl Server {
                 ]
             })
             .iter()
-            .map(|sz| NonZeroUsize::new(sz.get_bytes() as usize).expect("bytes must be non-zero"))
+            .map(|sz| NonZeroU32::new(sz.get_bytes() as u32).expect("bytes must be non-zero"))
             .collect();
         let mut labels = vec![
             ("component".to_string(), "generator".to_string()),
@@ -171,7 +170,7 @@ impl Server {
             let throttle = Throttle::new_with_config(config.throttle, bytes_per_second);
 
             let total_bytes =
-                NonZeroUsize::new(config.maximum_prebuild_cache_size_bytes.get_bytes() as usize)
+                NonZeroU32::new(config.maximum_prebuild_cache_size_bytes.get_bytes() as u32)
                     .expect("bytes must be non-zero");
             let block_cache = match config.block_cache_method {
                 block::CacheMethod::Streaming => block::Cache::stream(

--- a/lading/src/generator/grpc.rs
+++ b/lading/src/generator/grpc.rs
@@ -12,12 +12,7 @@
 //! Additional metrics may be emitted by this generator's [throttle].
 //!
 
-use std::{
-    convert::TryFrom,
-    num::{NonZeroU32, NonZeroUsize},
-    thread,
-    time::Duration,
-};
+use std::{convert::TryFrom, num::NonZeroU32, thread, time::Duration};
 
 use bytes::{Buf, BufMut, Bytes};
 use http::{uri::PathAndQuery, Uri};
@@ -159,7 +154,7 @@ impl Grpc {
         use byte_unit::{Byte, ByteUnit};
 
         let mut rng = StdRng::from_seed(config.seed);
-        let block_sizes: Vec<NonZeroUsize> = config
+        let block_sizes: Vec<NonZeroU32> = config
             .block_sizes
             .clone()
             .unwrap_or_else(|| {
@@ -175,7 +170,7 @@ impl Grpc {
                 ]
             })
             .iter()
-            .map(|sz| NonZeroUsize::new(sz.get_bytes() as usize).expect("bytes must be non-zero"))
+            .map(|sz| NonZeroU32::new(sz.get_bytes() as u32).expect("bytes must be non-zero"))
             .collect();
         let mut labels = vec![
             ("component".to_string(), "generator".to_string()),
@@ -193,7 +188,7 @@ impl Grpc {
         );
 
         let total_bytes =
-            NonZeroUsize::new(config.maximum_prebuild_cache_size_bytes.get_bytes() as usize)
+            NonZeroU32::new(config.maximum_prebuild_cache_size_bytes.get_bytes() as u32)
                 .expect("bytes must be non-zero");
         let block_cache = match config.block_cache_method {
             block::CacheMethod::Streaming => block::Cache::stream(

--- a/lading/src/generator/http.rs
+++ b/lading/src/generator/http.rs
@@ -11,10 +11,7 @@
 //! Additional metrics may be emitted by this generator's [throttle].
 //!
 
-use std::{
-    num::{NonZeroU32, NonZeroUsize},
-    thread,
-};
+use std::{num::NonZeroU32, thread};
 
 use byte_unit::{Byte, ByteUnit};
 use hyper::{
@@ -124,7 +121,7 @@ impl Http {
     #[allow(clippy::cast_possible_truncation)]
     pub fn new(general: General, config: Config, shutdown: Shutdown) -> Result<Self, Error> {
         let mut rng = StdRng::from_seed(config.seed);
-        let block_sizes: Vec<NonZeroUsize> = config
+        let block_sizes: Vec<NonZeroU32> = config
             .block_sizes
             .unwrap_or_else(|| {
                 vec![
@@ -137,7 +134,7 @@ impl Http {
                 ]
             })
             .iter()
-            .map(|sz| NonZeroUsize::new(sz.get_bytes() as usize).expect("bytes must be non-zero"))
+            .map(|sz| NonZeroU32::new(sz.get_bytes() as u32).expect("bytes must be non-zero"))
             .collect();
         let mut labels = vec![
             ("component".to_string(), "generator".to_string()),
@@ -161,7 +158,7 @@ impl Http {
                 block_cache_method,
             } => {
                 let total_bytes =
-                    NonZeroUsize::new(maximum_prebuild_cache_size_bytes.get_bytes() as usize)
+                    NonZeroU32::new(maximum_prebuild_cache_size_bytes.get_bytes() as u32)
                         .expect("bytes must be non-zero");
                 let block_cache = match block_cache_method {
                     block::CacheMethod::Streaming => block::Cache::stream(

--- a/lading/src/generator/splunk_hec.rs
+++ b/lading/src/generator/splunk_hec.rs
@@ -16,11 +16,7 @@
 
 mod acknowledgements;
 
-use std::{
-    num::{NonZeroU32, NonZeroUsize},
-    thread,
-    time::Duration,
-};
+use std::{num::NonZeroU32, thread, time::Duration};
 
 use acknowledgements::Channels;
 use byte_unit::{Byte, ByteUnit};
@@ -154,7 +150,7 @@ impl SplunkHec {
     #[allow(clippy::cast_possible_truncation)]
     pub fn new(general: General, config: Config, shutdown: Shutdown) -> Result<Self, Error> {
         let mut rng = StdRng::from_seed(config.seed);
-        let block_sizes: Vec<NonZeroUsize> = config
+        let block_sizes: Vec<NonZeroU32> = config
             .block_sizes
             .unwrap_or_else(|| {
                 vec![
@@ -167,7 +163,7 @@ impl SplunkHec {
                 ]
             })
             .iter()
-            .map(|sz| NonZeroUsize::new(sz.get_bytes() as usize).expect("bytes must be non-zero"))
+            .map(|sz| NonZeroU32::new(sz.get_bytes() as u32).expect("bytes must be non-zero"))
             .collect();
         let mut labels = vec![
             ("component".to_string(), "generator".to_string()),
@@ -190,7 +186,7 @@ impl SplunkHec {
             encoding: config.format,
         };
         let total_bytes =
-            NonZeroUsize::new(config.maximum_prebuild_cache_size_bytes.get_bytes() as usize)
+            NonZeroU32::new(config.maximum_prebuild_cache_size_bytes.get_bytes() as u32)
                 .expect("bytes must be non-zero");
         let block_cache = match config.block_cache_method {
             block::CacheMethod::Streaming => {

--- a/lading/src/generator/tcp.rs
+++ b/lading/src/generator/tcp.rs
@@ -13,7 +13,7 @@
 
 use std::{
     net::{SocketAddr, ToSocketAddrs},
-    num::{NonZeroU32, NonZeroUsize},
+    num::NonZeroU32,
     thread,
 };
 
@@ -87,7 +87,7 @@ impl Tcp {
     #[allow(clippy::cast_possible_truncation)]
     pub fn new(general: General, config: &Config, shutdown: Shutdown) -> Result<Self, Error> {
         let mut rng = StdRng::from_seed(config.seed);
-        let block_sizes: Vec<NonZeroUsize> = config
+        let block_sizes: Vec<NonZeroU32> = config
             .block_sizes
             .clone()
             .unwrap_or_else(|| {
@@ -103,7 +103,7 @@ impl Tcp {
                 ]
             })
             .iter()
-            .map(|sz| NonZeroUsize::new(sz.get_bytes() as usize).expect("bytes must be non-zero"))
+            .map(|sz| NonZeroU32::new(sz.get_bytes() as u32).expect("bytes must be non-zero"))
             .collect();
         let mut labels = vec![
             ("component".to_string(), "generator".to_string()),
@@ -122,7 +122,7 @@ impl Tcp {
 
         let block_cache = block::Cache::fixed(
             &mut rng,
-            NonZeroUsize::new(config.maximum_prebuild_cache_size_bytes.get_bytes() as usize)
+            NonZeroU32::new(config.maximum_prebuild_cache_size_bytes.get_bytes() as u32)
                 .expect("bytes must be non-zero"),
             &block_sizes,
             &config.variant,

--- a/lading/src/generator/udp.rs
+++ b/lading/src/generator/udp.rs
@@ -13,7 +13,7 @@
 
 use std::{
     net::{SocketAddr, ToSocketAddrs},
-    num::{NonZeroU32, NonZeroUsize},
+    num::NonZeroU32,
     thread,
     time::Duration,
 };
@@ -88,7 +88,7 @@ impl Udp {
     #[allow(clippy::cast_possible_truncation)]
     pub fn new(general: General, config: &Config, shutdown: Shutdown) -> Result<Self, Error> {
         let mut rng = StdRng::from_seed(config.seed);
-        let block_sizes: Vec<NonZeroUsize> = config
+        let block_sizes: Vec<NonZeroU32> = config
             .block_sizes
             .clone()
             .unwrap_or_else(|| {
@@ -104,7 +104,7 @@ impl Udp {
                 ]
             })
             .iter()
-            .map(|sz| NonZeroUsize::new(sz.get_bytes() as usize).expect("bytes must be non-zero"))
+            .map(|sz| NonZeroU32::new(sz.get_bytes() as u32).expect("bytes must be non-zero"))
             .collect();
         let mut labels = vec![
             ("component".to_string(), "generator".to_string()),
@@ -123,7 +123,7 @@ impl Udp {
 
         let block_cache = block::Cache::fixed(
             &mut rng,
-            NonZeroUsize::new(config.maximum_prebuild_cache_size_bytes.get_bytes() as usize)
+            NonZeroU32::new(config.maximum_prebuild_cache_size_bytes.get_bytes() as u32)
                 .expect("bytes must be non-zero"),
             &block_sizes,
             &config.variant,

--- a/lading/src/generator/unix_datagram.rs
+++ b/lading/src/generator/unix_datagram.rs
@@ -19,11 +19,7 @@ use lading_throttle::Throttle;
 use metrics::{counter, gauge, register_counter};
 use rand::{rngs::StdRng, SeedableRng};
 use serde::Deserialize;
-use std::{
-    num::{NonZeroU32, NonZeroUsize},
-    path::PathBuf,
-    thread,
-};
+use std::{num::NonZeroU32, path::PathBuf, thread};
 use tokio::{
     net,
     sync::{broadcast::Receiver, mpsc},
@@ -111,7 +107,7 @@ impl UnixDatagram {
     #[allow(clippy::cast_possible_truncation)]
     pub fn new(general: General, config: &Config, shutdown: Shutdown) -> Result<Self, Error> {
         let mut rng = StdRng::from_seed(config.seed);
-        let block_sizes: Vec<NonZeroUsize> = config
+        let block_sizes: Vec<NonZeroU32> = config
             .block_sizes
             .clone()
             .unwrap_or_else(|| {
@@ -127,7 +123,7 @@ impl UnixDatagram {
                 ]
             })
             .iter()
-            .map(|sz| NonZeroUsize::new(sz.get_bytes() as usize).expect("bytes must be non-zero"))
+            .map(|sz| NonZeroU32::new(sz.get_bytes() as u32).expect("bytes must be non-zero"))
             .collect();
         let mut labels = vec![
             ("component".to_string(), "generator".to_string()),
@@ -149,7 +145,7 @@ impl UnixDatagram {
         let mut handles = Vec::new();
         for _ in 0..config.parallel_connections {
             let total_bytes =
-                NonZeroUsize::new(config.maximum_prebuild_cache_size_bytes.get_bytes() as usize)
+                NonZeroU32::new(config.maximum_prebuild_cache_size_bytes.get_bytes() as u32)
                     .expect("bytes must be non-zero");
             let block_cache = match config.block_cache_method {
                 block::CacheMethod::Streaming => block::Cache::stream(

--- a/lading/src/generator/unix_stream.rs
+++ b/lading/src/generator/unix_stream.rs
@@ -18,11 +18,7 @@ use lading_throttle::Throttle;
 use metrics::{counter, gauge, register_counter};
 use rand::{rngs::StdRng, SeedableRng};
 use serde::Deserialize;
-use std::{
-    num::{NonZeroU32, NonZeroUsize},
-    path::PathBuf,
-    thread,
-};
+use std::{num::NonZeroU32, path::PathBuf, thread};
 use tokio::{net, sync::mpsc, task::JoinError};
 use tracing::{debug, error, info};
 
@@ -92,7 +88,7 @@ impl UnixStream {
     #[allow(clippy::cast_possible_truncation)]
     pub fn new(general: General, config: Config, shutdown: Shutdown) -> Result<Self, Error> {
         let mut rng = StdRng::from_seed(config.seed);
-        let block_sizes: Vec<NonZeroUsize> = config
+        let block_sizes: Vec<NonZeroU32> = config
             .block_sizes
             .clone()
             .unwrap_or_else(|| {
@@ -108,7 +104,7 @@ impl UnixStream {
                 ]
             })
             .iter()
-            .map(|sz| NonZeroUsize::new(sz.get_bytes() as usize).expect("bytes must be non-zero"))
+            .map(|sz| NonZeroU32::new(sz.get_bytes() as u32).expect("bytes must be non-zero"))
             .collect();
         let mut labels = vec![
             ("component".to_string(), "generator".to_string()),
@@ -126,7 +122,7 @@ impl UnixStream {
         );
 
         let total_bytes =
-            NonZeroUsize::new(config.maximum_prebuild_cache_size_bytes.get_bytes() as usize)
+            NonZeroU32::new(config.maximum_prebuild_cache_size_bytes.get_bytes() as u32)
                 .expect("bytes must be non-zero");
         let block_cache = match config.block_cache_method {
             block::CacheMethod::Streaming => block::Cache::stream(


### PR DESCRIPTION
### What does this PR do?

This commit adds proofs for the `chunk_bytes` function, converting its interface to be in terms of `u32` -- as matches our configuration -- and also to use a round-robin method internally to avoid randomness. The callers -- two sites -- are responsible for passing  `chunks` in as a mutable reference, allowing us to bound the maximum iterations of this function. The function is now allocation-free, although the change as a whole is neutral in this regard. 

### Motivation

REF #724
REF SMPTNG-79


