### PR TITLE
Cut release 0.20.0-rc4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## [0.20.0-rc4]
+### Fixed
+- Memory consumption stability issues in Dogstatsd payload generator
+
 ## [0.20.0-rc1]
 ### Added
 - A new 'logrotate' file generator is introduced.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1049,7 +1049,7 @@ dependencies = [
 
 [[package]]
 name = "lading"
-version = "0.20.0-rc1"
+version = "0.20.0-rc4"
 dependencies = [
  "async-pidfd",
  "byte-unit",

--- a/lading/Cargo.toml
+++ b/lading/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lading"
-version = "0.20.0-rc1"
+version = "0.20.0-rc4"
 authors = ["Brian L. Troutwine <brian.troutwine@datadoghq.com>", "George Hahn <george.hahn@datadoghq.com"]
 edition = "2021"
 license = "MIT"


### PR DESCRIPTION
### What does this PR do?

This commit creates an -rc4 release that incorporates the memory fixes and stability done as a part of SMPTNG-79.

