### PR TITLE
Re-adds generate

### DIFF
--- a/lading_payload/src/dogstatsd.rs
+++ b/lading_payload/src/dogstatsd.rs
@@ -91,6 +91,17 @@ pub struct KindWeights {
     service_check: u8,
 }
 
+impl KindWeights {
+    /// Create a new instance of `KindWeights` according to the args
+    pub fn new(metric: u8, event: u8, service_check: u8) -> Self {
+        Self {
+            metric,
+            event,
+            service_check,
+        }
+    }
+}
+
 impl Default for KindWeights {
     fn default() -> Self {
         KindWeights {
@@ -113,6 +124,20 @@ pub struct MetricWeights {
     distribution: u8,
     set: u8,
     histogram: u8,
+}
+
+impl MetricWeights {
+    /// Create a new instance of `MetricWeights` according to the args
+    pub fn new(count: u8, gauge: u8, timer: u8, distribution: u8, set: u8, histogram: u8) -> Self {
+        Self {
+            count,
+            gauge,
+            timer,
+            distribution,
+            set,
+            histogram,
+        }
+    }
 }
 
 impl Default for MetricWeights {

--- a/lading_payload/src/dogstatsd.rs
+++ b/lading_payload/src/dogstatsd.rs
@@ -569,6 +569,16 @@ impl DogStatsD {
         .unwrap()
     }
 
+    /// Generate a single `Member`.
+    /// Prefer using the Serialize implementation for `DogStatsD` which
+    /// generates a stream of `Member`s according to some constraints.
+    pub fn generate<R>(&self, rng: &mut R) -> Member
+    where
+        R: rand::Rng + ?Sized,
+    {
+        self.member_generator.generate(rng)
+    }
+
     /// Create a new instance of `DogStatsD`.
     ///
     /// # Errors


### PR DESCRIPTION
### What does this PR do?
Re-adds the `DogStatsD#generate` public function that was removed in #727 .

### Motivation

Simple usage of the dogstatsd generator outside of this project.


### Related issues

A list of issues either fixed, containing architectural discussions, otherwise relevant
for this Pull Request.

### Additional Notes

Anything else we should know when reviewing?
Stacked with #741 