### PR TITLE
Implements warning on unrecognized config keys

### DIFF
--- a/lading/src/bin/lading.rs
+++ b/lading/src/bin/lading.rs
@@ -159,7 +159,7 @@ struct ProcessTreeGen {
     config_content: Option<String>,
 }
 
-fn log_unexpected_keys(specified_config: &String, resolved_config: &String) {
+fn log_unexpected_keys(specified_config: &str, resolved_config: &str) {
     // Parse both configs as generic yaml objects and descend through them
     // logging out a warning for any keys that are present in `specified_config`
     // but not present in `resolved_config`
@@ -258,7 +258,7 @@ fn log_unexpected_keys(specified_config: &String, resolved_config: &String) {
     }
     let mut path = Vec::<String>::new();
     for (k, v) in specified_mapping {
-        path.push(format!("{:}", k.as_str().unwrap_or_default()));
+        path.push(k.as_str().unwrap_or_default().to_string());
         descend_and_log_unexpected_keys(v, resolved_mapping.get(k).unwrap(), &mut path);
         path.pop();
     }

--- a/lading/src/bin/lading.rs
+++ b/lading/src/bin/lading.rs
@@ -226,8 +226,8 @@ fn log_unexpected_keys(specified_config: &String, resolved_config: &String) {
                     } else {
                         let resolved_value = &resolved_sequence[i];
                         descend_and_log_unexpected_keys(v, resolved_value, path);
-                        path.pop();
                     }
+                    path.pop();
                 }
             }
             (serde_yaml::Value::Sequence(_), res) => {
@@ -248,8 +248,8 @@ fn log_unexpected_keys(specified_config: &String, resolved_config: &String) {
                     } else {
                         let resolved_value = resolved_mapping.get(k).unwrap();
                         descend_and_log_unexpected_keys(v, resolved_value, path);
-                        path.pop();
                     }
+                    path.pop();
                 }
             }
             (serde_yaml::Value::Mapping(_), _) => todo!(),

--- a/lading/src/blackhole.rs
+++ b/lading/src/blackhole.rs
@@ -5,7 +5,7 @@
 //! as little as possible with them and respond as minimally as possible in
 //! order to avoid overhead.
 
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 
 use crate::signals::Shutdown;
 
@@ -36,7 +36,7 @@ pub enum Error {
     Sqs(sqs::Error),
 }
 
-#[derive(Debug, Deserialize, Clone, PartialEq, Eq)]
+#[derive(Debug, Deserialize, Clone, PartialEq, Eq, Serialize)]
 #[serde(rename_all = "snake_case")]
 /// Configuration for [`Server`]
 pub struct Config {
@@ -48,7 +48,7 @@ pub struct Config {
     pub inner: Inner,
 }
 
-#[derive(Debug, Deserialize, Clone, PartialEq, Eq)]
+#[derive(Debug, Deserialize, Clone, PartialEq, Eq, Serialize)]
 #[serde(rename_all = "snake_case")]
 /// Configurations common to all [`Server`] variants
 pub struct General {
@@ -56,7 +56,7 @@ pub struct General {
     pub id: Option<String>,
 }
 
-#[derive(Debug, Deserialize, Clone, PartialEq, Eq)]
+#[derive(Debug, Deserialize, Clone, PartialEq, Eq, Serialize)]
 #[serde(rename_all = "snake_case")]
 /// Configuration for [`Server`]
 pub enum Inner {

--- a/lading/src/blackhole/http.rs
+++ b/lading/src/blackhole/http.rs
@@ -43,7 +43,7 @@ pub enum Error {
 }
 
 /// Body variant supported by this blackhole.
-#[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Deserialize, PartialEq, Eq, Serialize)]
 #[serde(rename_all = "snake_case")]
 pub enum BodyVariant {
     /// All response bodies will be empty.
@@ -70,7 +70,7 @@ fn default_headers() -> HeaderMap {
     map
 }
 
-#[derive(Debug, Deserialize, Clone, PartialEq, Eq)]
+#[derive(Debug, Deserialize, Clone, PartialEq, Eq, Serialize)]
 /// Configuration for [`Http`]
 pub struct Config {
     /// number of concurrent HTTP connections to allow

--- a/lading/src/blackhole/splunk_hec.rs
+++ b/lading/src/blackhole/splunk_hec.rs
@@ -43,7 +43,7 @@ pub enum Error {
     Hyper(hyper::Error),
 }
 
-#[derive(Debug, Deserialize, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Deserialize, Clone, Copy, PartialEq, Eq, Serialize)]
 /// Configuration for [`SplunkHec`].
 pub struct Config {
     /// number of concurrent HTTP connections to allow

--- a/lading/src/blackhole/sqs.rs
+++ b/lading/src/blackhole/sqs.rs
@@ -16,7 +16,7 @@ use hyper::{
 };
 use metrics::{register_counter, Counter};
 use rand::{distributions::Alphanumeric, thread_rng, Rng};
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use tokio::time::Duration;
 use tower::ServiceBuilder;
 use tracing::{debug, error, info};
@@ -36,7 +36,7 @@ fn default_concurrent_requests_max() -> usize {
     100
 }
 
-#[derive(Debug, Deserialize, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Deserialize, Clone, Copy, PartialEq, Eq, Serialize)]
 /// Configuration for [`Sqs`]
 pub struct Config {
     /// number of concurrent HTTP connections to allow

--- a/lading/src/blackhole/tcp.rs
+++ b/lading/src/blackhole/tcp.rs
@@ -11,7 +11,7 @@ use std::{io, net::SocketAddr};
 
 use futures::stream::StreamExt;
 use metrics::register_counter;
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use tokio::net::{TcpListener, TcpStream};
 use tokio_util::io::ReaderStream;
 use tracing::info;
@@ -27,7 +27,7 @@ pub enum Error {
     Io(io::Error),
 }
 
-#[derive(Debug, Deserialize, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Deserialize, Clone, Copy, PartialEq, Eq, Serialize)]
 /// Configuration for [`Tcp`]
 pub struct Config {
     /// address -- IP plus port -- to bind to

--- a/lading/src/blackhole/udp.rs
+++ b/lading/src/blackhole/udp.rs
@@ -9,7 +9,7 @@
 use std::{io, net::SocketAddr};
 
 use metrics::register_counter;
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use tokio::net::UdpSocket;
 use tracing::info;
 
@@ -24,7 +24,7 @@ pub enum Error {
     Io(io::Error),
 }
 
-#[derive(Debug, Deserialize, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Deserialize, Clone, Copy, PartialEq, Eq, Serialize)]
 /// Configuration for [`Udp`].
 pub struct Config {
     /// address -- IP plus port -- to bind to

--- a/lading/src/blackhole/unix_datagram.rs
+++ b/lading/src/blackhole/unix_datagram.rs
@@ -9,7 +9,7 @@ use std::{io, path::PathBuf};
 
 use futures::TryFutureExt;
 use metrics::register_counter;
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use tokio::net;
 use tracing::info;
 
@@ -24,7 +24,7 @@ pub enum Error {
     Io(io::Error),
 }
 
-#[derive(Debug, Deserialize, Clone, PartialEq, Eq)]
+#[derive(Debug, Deserialize, Clone, PartialEq, Eq, Serialize)]
 /// Configuration for [`UnixDatagram`].
 pub struct Config {
     /// The path of the socket to read from.

--- a/lading/src/blackhole/unix_stream.rs
+++ b/lading/src/blackhole/unix_stream.rs
@@ -11,7 +11,7 @@ use std::{io, path::PathBuf};
 
 use futures::StreamExt;
 use metrics::register_counter;
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use tokio::net;
 use tokio_util::io::ReaderStream;
 use tracing::info;
@@ -27,7 +27,7 @@ pub enum Error {
     Io(io::Error),
 }
 
-#[derive(Debug, Deserialize, Clone, PartialEq, Eq)]
+#[derive(Debug, Deserialize, Clone, PartialEq, Eq, Serialize)]
 /// Configuration for [`UnixStream`].
 pub struct Config {
     /// The path of the socket to read from.

--- a/lading/src/common.rs
+++ b/lading/src/common.rs
@@ -1,9 +1,9 @@
 use std::{fmt, fs, path::PathBuf, process::Stdio, str};
 
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use tokio::sync::mpsc;
 
-#[derive(Debug, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Deserialize, PartialEq, Eq, Serialize)]
 /// Defines how sub-process stderr and stdout are handled.
 pub struct Output {
     #[serde(default)]
@@ -14,7 +14,7 @@ pub struct Output {
     pub stdout: Behavior,
 }
 
-#[derive(Debug, Deserialize, Clone, PartialEq, Eq)]
+#[derive(Debug, Deserialize, Clone, PartialEq, Eq, Serialize)]
 #[serde(untagged)]
 /// Defines the [`Output`] behavior for stderr and stdout.
 pub enum Behavior {

--- a/lading/src/config.rs
+++ b/lading/src/config.rs
@@ -4,12 +4,12 @@
 use std::{net::SocketAddr, path::PathBuf};
 
 use rustc_hash::FxHashMap;
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 
 use crate::{blackhole, generator, inspector, observer, target, target_metrics};
 
 /// Main configuration struct for this program
-#[derive(Debug, Default, Deserialize, PartialEq)]
+#[derive(Debug, Default, Deserialize, PartialEq, Serialize)]
 pub struct Config {
     /// The method by which to express telemetry
     #[serde(default)]
@@ -22,7 +22,7 @@ pub struct Config {
     #[serde(skip_deserializing)]
     pub observer: observer::Config,
     /// The program being targetted by this rig
-    #[serde(skip_deserializing)]
+    #[serde(skip_deserializing, skip_serializing)]
     pub target: Option<target::Config>,
     /// The blackhole to supply for the target
     #[serde(default)]
@@ -36,7 +36,7 @@ pub struct Config {
     pub inspector: Option<inspector::Config>,
 }
 
-#[derive(Debug, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Deserialize, PartialEq, Eq, Serialize)]
 #[serde(rename_all = "snake_case")]
 #[serde(untagged)]
 /// Defines the manner of lading's telemetry.

--- a/lading/src/generator.rs
+++ b/lading/src/generator.rs
@@ -10,7 +10,7 @@
 //! indefinitely, paying higher memory and longer startup for better
 //! experimental control.
 
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use tracing::error;
 
 use crate::{signals::Shutdown, target::TargetPidReceiver};
@@ -61,7 +61,7 @@ pub enum Error {
     ProcessTree(#[from] process_tree::Error),
 }
 
-#[derive(Debug, Deserialize, PartialEq)]
+#[derive(Debug, Deserialize, PartialEq, Serialize)]
 #[serde(rename_all = "snake_case")]
 /// Configuration for [`Server`]
 pub struct Config {
@@ -73,7 +73,7 @@ pub struct Config {
     pub inner: Inner,
 }
 
-#[derive(Debug, Deserialize, PartialEq)]
+#[derive(Debug, Deserialize, PartialEq, Serialize)]
 #[serde(rename_all = "snake_case")]
 /// Configurations common to all [`Server`] variants
 pub struct General {
@@ -81,7 +81,7 @@ pub struct General {
     pub id: Option<String>,
 }
 
-#[derive(Debug, Deserialize, PartialEq)]
+#[derive(Debug, Deserialize, PartialEq, Serialize)]
 #[serde(rename_all = "snake_case")]
 /// Configuration for [`Server`]
 pub enum Inner {

--- a/lading/src/generator/file_gen.rs
+++ b/lading/src/generator/file_gen.rs
@@ -17,7 +17,7 @@ pub mod traditional;
 
 use std::str;
 
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 
 use crate::signals::Shutdown;
 
@@ -35,7 +35,7 @@ pub enum Error {
 }
 
 /// Configuration of [`FileGen`]
-#[derive(Debug, Deserialize, PartialEq)]
+#[derive(Debug, Deserialize, PartialEq, Serialize)]
 #[serde(rename_all = "snake_case")]
 pub enum Config {
     /// See [`traditional::Config`].

--- a/lading/src/generator/file_gen/logrotate.rs
+++ b/lading/src/generator/file_gen/logrotate.rs
@@ -25,7 +25,7 @@ use futures::future::join_all;
 use lading_throttle::Throttle;
 use metrics::{gauge, register_counter};
 use rand::{prelude::StdRng, Rng, SeedableRng};
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use tokio::{
     fs,
     io::{AsyncWriteExt, BufWriter},
@@ -53,7 +53,7 @@ pub enum Error {
     Child(#[from] JoinError),
 }
 
-#[derive(Debug, Deserialize, PartialEq)]
+#[derive(Debug, Deserialize, PartialEq, Serialize)]
 /// Configuration of [`FileGen`]
 pub struct Config {
     /// The seed for random operations against this target

--- a/lading/src/generator/file_gen/traditional.rs
+++ b/lading/src/generator/file_gen/traditional.rs
@@ -28,7 +28,7 @@ use futures::future::join_all;
 use lading_throttle::Throttle;
 use metrics::{gauge, register_counter};
 use rand::{prelude::StdRng, SeedableRng};
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use tokio::{
     fs,
     io::{AsyncWriteExt, BufWriter},
@@ -63,7 +63,7 @@ fn default_rotation() -> bool {
     true
 }
 
-#[derive(Debug, Deserialize, PartialEq)]
+#[derive(Debug, Deserialize, PartialEq, Serialize)]
 /// Configuration of [`FileGen`]
 pub struct Config {
     /// The seed for random operations against this target

--- a/lading/src/generator/file_tree.rs
+++ b/lading/src/generator/file_tree.rs
@@ -25,7 +25,7 @@ use std::{
 };
 
 use rand::{prelude::StdRng, SeedableRng};
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use tokio::{fs::create_dir, fs::rename, fs::File};
 use tracing::info;
 
@@ -75,7 +75,7 @@ fn default_rename_per_name() -> NonZeroU32 {
     NonZeroU32::new(1).unwrap()
 }
 
-#[derive(Debug, Deserialize, PartialEq, Clone)]
+#[derive(Debug, Deserialize, PartialEq, Clone, Serialize)]
 /// Configuration of [`FileTree`]
 pub struct Config {
     /// The seed for random operations against this target

--- a/lading/src/generator/grpc.rs
+++ b/lading/src/generator/grpc.rs
@@ -20,7 +20,7 @@ use lading_throttle::Throttle;
 use metrics::{counter, gauge, register_counter};
 use rand::rngs::StdRng;
 use rand::SeedableRng;
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use tokio::sync::mpsc;
 use tonic::{
     codec::{DecodeBuf, Decoder, EncodeBuf, Encoder},
@@ -51,7 +51,7 @@ pub enum Error {
 }
 
 /// Config for [`Grpc`]
-#[derive(Debug, Deserialize, PartialEq)]
+#[derive(Debug, Deserialize, PartialEq, Serialize)]
 pub struct Config {
     /// The gRPC URI. Looks like http://host/service.path/endpoint
     pub target_uri: String,

--- a/lading/src/generator/http.rs
+++ b/lading/src/generator/http.rs
@@ -23,7 +23,7 @@ use lading_throttle::Throttle;
 use metrics::{counter, gauge};
 use once_cell::sync::OnceCell;
 use rand::{prelude::StdRng, SeedableRng};
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use tokio::sync::{mpsc, Semaphore};
 use tracing::info;
 
@@ -35,7 +35,7 @@ use super::General;
 static CONNECTION_SEMAPHORE: OnceCell<Semaphore> = OnceCell::new();
 
 /// The HTTP method to be used in requests
-#[derive(Debug, Deserialize, PartialEq)]
+#[derive(Debug, Deserialize, PartialEq, Serialize)]
 #[serde(rename_all = "snake_case")]
 pub enum Method {
     /// Make HTTP Post requests
@@ -50,7 +50,7 @@ pub enum Method {
     },
 }
 
-#[derive(Debug, Deserialize, PartialEq)]
+#[derive(Debug, Deserialize, PartialEq, Serialize)]
 /// Configuration of this generator.
 pub struct Config {
     /// The seed for random operations against this target

--- a/lading/src/generator/splunk_hec.rs
+++ b/lading/src/generator/splunk_hec.rs
@@ -29,7 +29,7 @@ use lading_throttle::Throttle;
 use metrics::{counter, gauge};
 use once_cell::sync::OnceCell;
 use rand::{prelude::StdRng, SeedableRng};
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use tokio::{
     sync::{mpsc, Semaphore, SemaphorePermit},
     time::timeout,
@@ -50,7 +50,7 @@ const SPLUNK_HEC_TEXT_PATH: &str = "/services/collector/raw";
 const SPLUNK_HEC_CHANNEL_HEADER: &str = "x-splunk-request-channel";
 
 /// Optional Splunk HEC indexer acknowledgements configuration
-#[derive(Deserialize, Debug, Clone, Copy, PartialEq)]
+#[derive(Deserialize, Debug, Clone, Copy, PartialEq, Serialize)]
 pub struct AckSettings {
     /// The time in seconds between queries to /services/collector/ack
     pub ack_query_interval_seconds: u64,
@@ -60,7 +60,7 @@ pub struct AckSettings {
 }
 
 /// Configuration for [`SplunkHec`]
-#[derive(Deserialize, Debug, PartialEq)]
+#[derive(Deserialize, Debug, PartialEq, Serialize)]
 pub struct Config {
     /// The seed for random operations against this target
     pub seed: [u8; 32],

--- a/lading/src/generator/tcp.rs
+++ b/lading/src/generator/tcp.rs
@@ -21,7 +21,7 @@ use byte_unit::{Byte, ByteUnit};
 use lading_throttle::Throttle;
 use metrics::{counter, gauge, register_counter};
 use rand::{rngs::StdRng, SeedableRng};
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use tokio::{io::AsyncWriteExt, net::TcpStream, sync::mpsc};
 use tracing::{info, trace};
 
@@ -30,7 +30,7 @@ use lading_payload::block::{self, Block};
 
 use super::General;
 
-#[derive(Debug, Deserialize, PartialEq)]
+#[derive(Debug, Deserialize, PartialEq, Serialize)]
 /// Configuration of this generator.
 pub struct Config {
     /// The seed for random operations against this target

--- a/lading/src/generator/udp.rs
+++ b/lading/src/generator/udp.rs
@@ -22,7 +22,7 @@ use byte_unit::{Byte, ByteUnit};
 use lading_throttle::Throttle;
 use metrics::{counter, gauge, register_counter};
 use rand::{rngs::StdRng, SeedableRng};
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use tokio::{net::UdpSocket, sync::mpsc};
 use tracing::{debug, info, trace};
 
@@ -31,7 +31,7 @@ use lading_payload::block::{self, Block};
 
 use super::General;
 
-#[derive(Debug, Deserialize, PartialEq)]
+#[derive(Debug, Deserialize, PartialEq, Serialize)]
 /// Configuration of this generator.
 pub struct Config {
     /// The seed for random operations against this target

--- a/lading/src/generator/unix_datagram.rs
+++ b/lading/src/generator/unix_datagram.rs
@@ -18,7 +18,7 @@ use lading_payload::block::{self, Block};
 use lading_throttle::Throttle;
 use metrics::{counter, gauge, register_counter};
 use rand::{rngs::StdRng, SeedableRng};
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use std::{num::NonZeroU32, path::PathBuf, thread};
 use tokio::{
     net,
@@ -33,7 +33,7 @@ fn default_parallel_connections() -> u16 {
     1
 }
 
-#[derive(Debug, Deserialize, PartialEq)]
+#[derive(Debug, Deserialize, PartialEq, Serialize)]
 /// Configuration of this generator.
 pub struct Config {
     /// The seed for random operations against this target

--- a/lading/src/generator/unix_stream.rs
+++ b/lading/src/generator/unix_stream.rs
@@ -17,14 +17,14 @@ use lading_payload::block::{self, Block};
 use lading_throttle::Throttle;
 use metrics::{counter, gauge, register_counter};
 use rand::{rngs::StdRng, SeedableRng};
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use std::{num::NonZeroU32, path::PathBuf, thread};
 use tokio::{net, sync::mpsc, task::JoinError};
 use tracing::{debug, error, info};
 
 use super::General;
 
-#[derive(Debug, Deserialize, PartialEq)]
+#[derive(Debug, Deserialize, PartialEq, Serialize)]
 /// Configuration of this generator.
 pub struct Config {
     /// The seed for random operations against this target

--- a/lading/src/inspector.rs
+++ b/lading/src/inspector.rs
@@ -20,7 +20,7 @@ use nix::{
     unistd::Pid,
 };
 use rustc_hash::FxHashMap;
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use tokio::process::Command;
 use tracing::{error, info};
 
@@ -39,7 +39,7 @@ pub enum Error {
     Io(io::Error),
 }
 
-#[derive(Debug, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Deserialize, PartialEq, Eq, Serialize)]
 #[serde(rename_all = "snake_case")]
 /// Configuration for [`Server`]
 pub struct Config {

--- a/lading/src/observer.rs
+++ b/lading/src/observer.rs
@@ -11,7 +11,7 @@
 use std::{io, sync::atomic::AtomicU64};
 
 use crate::target::TargetPidReceiver;
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 
 use crate::signals::Shutdown;
 
@@ -38,7 +38,7 @@ pub enum Error {
     Linux(#[from] linux::Error),
 }
 
-#[derive(Debug, Deserialize, Clone, Copy, Default, PartialEq, Eq)]
+#[derive(Debug, Deserialize, Clone, Copy, Default, PartialEq, Eq, Serialize)]
 #[serde(rename_all = "snake_case")]
 /// Configuration for [`Server`]
 pub struct Config {}

--- a/lading/src/target_metrics.rs
+++ b/lading/src/target_metrics.rs
@@ -4,7 +4,7 @@
 //! include them in the captures file.
 //!
 
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 
 use crate::signals::Shutdown;
 
@@ -20,7 +20,7 @@ pub enum Error {
     Prometheus(prometheus::Error),
 }
 
-#[derive(Debug, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Deserialize, PartialEq, Eq, Serialize)]
 #[serde(rename_all = "snake_case")]
 /// Configuration for [`Server`]
 pub enum Config {

--- a/lading/src/target_metrics/expvar.rs
+++ b/lading/src/target_metrics/expvar.rs
@@ -6,7 +6,7 @@
 use std::time::Duration;
 
 use metrics::gauge;
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use tracing::{error, info, trace};
 
@@ -20,7 +20,7 @@ pub enum Error {
     EarlyShutdown,
 }
 
-#[derive(Debug, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Deserialize, PartialEq, Eq, Serialize)]
 #[serde(rename_all = "snake_case")]
 /// Configuration for collecting Go Expvar based target metrics
 pub struct Config {

--- a/lading/src/target_metrics/prometheus.rs
+++ b/lading/src/target_metrics/prometheus.rs
@@ -8,7 +8,7 @@ use std::{str::FromStr, time::Duration};
 
 use metrics::{absolute_counter, gauge};
 use rustc_hash::FxHashMap;
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use tracing::{error, info, trace, warn};
 
 use crate::signals::Shutdown;
@@ -21,7 +21,7 @@ pub enum Error {
     EarlyShutdown,
 }
 
-#[derive(Debug, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Deserialize, PartialEq, Eq, Serialize)]
 #[serde(rename_all = "snake_case")]
 /// Configuration for collecting Prometheus based target metrics
 pub struct Config {

--- a/lading_payload/src/block.rs
+++ b/lading_payload/src/block.rs
@@ -10,6 +10,7 @@ use std::{collections::VecDeque, num::NonZeroU32};
 use bytes::{buf::Writer, BufMut, Bytes, BytesMut};
 use rand::{prelude::SliceRandom, rngs::StdRng, Rng, SeedableRng};
 use serde::Deserialize;
+use serde::Serialize as SerdeSerialize;
 use tokio::sync::mpsc::{self, error::SendError, Sender};
 
 use crate::dogstatsd;
@@ -93,7 +94,7 @@ impl<'a> arbitrary::Arbitrary<'a> for Block {
     }
 }
 
-#[derive(Debug, Deserialize, PartialEq, Clone, Copy)]
+#[derive(Debug, Deserialize, PartialEq, Clone, Copy, SerdeSerialize)]
 /// The method for which caching will be configure
 pub enum CacheMethod {
     /// Create a single fixed size block cache and rotate through it

--- a/lading_payload/src/dogstatsd.rs
+++ b/lading_payload/src/dogstatsd.rs
@@ -9,6 +9,7 @@ use rand::{
     Rng,
 };
 use serde::Deserialize;
+use serde::Serialize as SerdeSerialize;
 
 use crate::{common::strings, Serialize};
 
@@ -81,7 +82,7 @@ fn multivalue_pack_probability() -> f32 {
 /// Weights for `DogStatsD` kinds: metrics, events, service checks
 ///
 /// Defines the relative probability of each kind of `DogStatsD` datagram.
-#[derive(Debug, Deserialize, Clone, Copy, PartialEq)]
+#[derive(Debug, Deserialize, Clone, Copy, PartialEq, SerdeSerialize)]
 #[serde(rename_all = "snake_case")]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 
@@ -114,7 +115,7 @@ impl Default for KindWeights {
 }
 
 /// Weights for `DogStatsD` metrics: gauges, counters, etc
-#[derive(Debug, Deserialize, Clone, Copy, PartialEq)]
+#[derive(Debug, Deserialize, Clone, Copy, PartialEq, SerdeSerialize)]
 #[serde(rename_all = "snake_case")]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 
@@ -156,7 +157,7 @@ impl Default for MetricWeights {
 }
 
 /// Configuration for the values of a metric.
-#[derive(Debug, Deserialize, Clone, PartialEq, Copy)]
+#[derive(Debug, Deserialize, Clone, PartialEq, Copy, SerdeSerialize)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 
 pub struct ValueConf {
@@ -183,10 +184,9 @@ impl Default for ValueConf {
     }
 }
 /// Range expression for configuration
-#[derive(Debug, Deserialize, Clone, PartialEq, Copy)]
+#[derive(Debug, Deserialize, Clone, PartialEq, Copy, SerdeSerialize)]
 #[serde(rename_all = "snake_case")]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
-
 pub enum ConfRange<T>
 where
     T: PartialEq + cmp::PartialOrd + Clone + Copy,
@@ -246,7 +246,7 @@ where
 }
 
 /// Configure the `DogStatsD` payload.
-#[derive(Debug, Deserialize, Clone, PartialEq, Copy)]
+#[derive(Debug, Deserialize, Clone, PartialEq, Copy, SerdeSerialize)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct Config {
     /// The unique metric contexts to generate. A context is a set of unique

--- a/lading_payload/src/lib.rs
+++ b/lading_payload/src/lib.rs
@@ -26,6 +26,7 @@ use std::{
 
 use rand::Rng;
 use serde::Deserialize;
+use serde::Serialize as SerdeSerialize;
 
 pub mod block;
 
@@ -87,7 +88,7 @@ pub trait Serialize {
 }
 
 /// Sub-configuration for `TraceAgent` format
-#[derive(Debug, Deserialize, Clone, Copy, PartialEq)]
+#[derive(Debug, Deserialize, Clone, Copy, PartialEq, SerdeSerialize)]
 #[serde(rename_all = "snake_case")]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum Encoding {
@@ -99,7 +100,7 @@ pub enum Encoding {
 }
 
 /// Configuration for `Payload`
-#[derive(Debug, Deserialize, Clone, PartialEq)]
+#[derive(Debug, Deserialize, Clone, PartialEq, SerdeSerialize)]
 #[serde(rename_all = "snake_case")]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum Config {

--- a/lading_payload/src/splunk_hec.rs
+++ b/lading_payload/src/splunk_hec.rs
@@ -3,7 +3,7 @@
 use std::io::Write;
 
 use rand::{distributions::Standard, prelude::Distribution, seq::SliceRandom, Rng};
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 
 use crate::Error;
 
@@ -108,7 +108,7 @@ impl Distribution<Member> for Standard {
 }
 
 ///
-#[derive(Deserialize, Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Deserialize, Debug, Clone, Copy, PartialEq, Eq, Serialize)]
 #[serde(rename_all = "snake_case")]
 #[cfg_attr(test, derive(proptest_derive::Arbitrary))]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]


### PR DESCRIPTION
### What does this PR do?

- Adds `Serialize` to all `Config` structs (recursively) in order to get a yaml representation of the _actual_ config being used.
- Prints out the resolved config as yaml at `debug` log level
- Implements a function to warn about unrecognized keys that the user may have specified

### Motivation

#745 

### Related issues


### Additional Notes
I really wish this were supported at the `serde` level. I'd even go so far as to say it should be a deserialization error if extra keys are present.

I don't love all the custom DFS/yaml code, but I do think its useful.
But I won't be offended if we don't want to merge this because it is really an edge case (mismatched configs/lading versions).

(Good test case for co-pilot though 😄  )

Example output:
```
2023-11-22T19:28:52.747874Z  INFO lading: Starting lading run.
2023-11-22T19:28:52.748802Z DEBUG lading: Attempting to open configuration file at: ./examples/old-dogstatsd.yaml
2023-11-22T19:28:52.750836Z  WARN lading: Unknown key specified: generator[0].unix_datagram.variant.dogstatsd.metric_names
2023-11-22T19:28:52.750855Z  WARN lading: Unknown key specified: generator[0].unix_datagram.variant.dogstatsd.metric_names.tag_keys
2023-11-22T19:28:52.750911Z  INFO lading: Effective Config for this run:
 telemetry:
  prometheus_addr: 0.0.0.0:9000
  global_labels: {}
generator:
- id: dogstatsd
  unix_datagram:
    seed:
    - 2
    - 3
  <... snip rest of config ...>
```