### PR TITLE
Use generational storage in the CaptureManager

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1073,6 +1073,7 @@ dependencies = [
  "procfs",
  "proptest",
  "proptest-derive",
+ "quanta",
  "rand",
  "reqwest",
  "rustc-hash",

--- a/lading/Cargo.toml
+++ b/lading/Cargo.toml
@@ -29,6 +29,7 @@ metrics-util = { version = "0.15" }
 nix = { version = "0.26" }
 num_cpus = { version = "1.16" }
 once_cell = "1.18"
+quanta = { version = "0.11", default-features = false, features = [] }
 rand = { workspace = true, default-features = false, features = ["small_rng", "std", "std_rng" ]}
 reqwest = { version = "0.11", default-features = false, features = ["json"] }
 rustc-hash = { workspace = true }


### PR DESCRIPTION
### What does this PR do?

This commit makes use of generational storage in the CaptureManager, expiring keys that have not been written to for ten seconds. After this period the keys will no longer be written out. This is especially important for observer metrics in the presence of short-lived processes.

### Related issues

REF SMPTNG-85
