### PR TITLE
Introduce 'default tags' to the dogstatsd payload

### DIFF
--- a/lading_payload/src/block.rs
+++ b/lading_payload/src/block.rs
@@ -221,6 +221,7 @@ impl Cache {
                     metric_weights,
                     value,
                     service_check_names,
+                    default_tags,
                 },
             ) => {
                 if !conf.valid() {
@@ -233,6 +234,7 @@ impl Cache {
                     *tag_key_length,
                     *tag_value_length,
                     *tags_per_msg,
+                    default_tags.clone(),
                     *multivalue_count,
                     *multivalue_pack_probability,
                     *sampling_range,
@@ -357,6 +359,7 @@ fn stream_inner(
                 kind_weights,
                 metric_weights,
                 value,
+                default_tags,
             },
         ) => {
             if !conf.valid() {
@@ -369,6 +372,7 @@ fn stream_inner(
                 *tag_key_length,
                 *tag_value_length,
                 *tags_per_msg,
+                default_tags.clone(),
                 *multivalue_count,
                 *multivalue_pack_probability,
                 *sampling,

--- a/lading_payload/src/dogstatsd.rs
+++ b/lading_payload/src/dogstatsd.rs
@@ -86,6 +86,10 @@ fn sampling_probability() -> f32 {
     0.5
 }
 
+fn default_tags() -> Vec<String> {
+    Vec::new()
+}
+
 /// Weights for `DogStatsD` kinds: metrics, events, service checks
 ///
 /// Defines the relative probability of each kind of `DogStatsD` datagram.
@@ -258,7 +262,7 @@ where
 }
 
 /// Configure the `DogStatsD` payload.
-#[derive(Debug, Deserialize, Clone, PartialEq, Copy)]
+#[derive(Debug, Deserialize, Clone, PartialEq)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[serde(deny_unknown_fields)]
 pub struct Config {
@@ -287,6 +291,11 @@ pub struct Config {
     /// separated by a :
     #[serde(default = "tags_per_msg")]
     pub tags_per_msg: ConfRange<u8>,
+
+    /// Selection of tag pairs to always prepend to tagsets. Assumed to be
+    /// valid, do not count toward `tags_per_msg`.
+    #[serde(default = "default_tags")]
+    pub default_tags: Vec<String>,
 
     /// Probability between 0 and 1 that a given dogstatsd msg
     /// contains multiple values
@@ -427,6 +436,7 @@ impl MemberGenerator {
         tag_key_length: ConfRange<u8>,
         tag_value_length: ConfRange<u8>,
         tags_per_msg: ConfRange<u8>,
+        default_tags: Vec<String>,
         multivalue_count: ConfRange<u16>,
         multivalue_pack_probability: f32,
         sampling: ConfRange<f32>,
@@ -448,6 +458,7 @@ impl MemberGenerator {
         let mut tags_generator = tags::Generator::new(
             rng.gen(),
             tags_per_msg,
+            default_tags,
             tag_key_length,
             tag_value_length,
             Rc::clone(&pool),
@@ -587,6 +598,7 @@ impl DogStatsD {
             tag_key_length(),
             tag_value_length(),
             tags_per_msg(),
+            default_tags(),
             multivalue_count(),
             multivalue_pack_probability(),
             sampling_range(),
@@ -622,6 +634,7 @@ impl DogStatsD {
         tag_key_length: ConfRange<u8>,
         tag_value_length: ConfRange<u8>,
         tags_per_msg: ConfRange<u8>,
+        default_tags: Vec<String>,
         multivalue_count: ConfRange<u16>,
         multivalue_pack_probability: f32,
         sampling: ConfRange<f32>,
@@ -641,6 +654,7 @@ impl DogStatsD {
             tag_key_length,
             tag_value_length,
             tags_per_msg,
+            default_tags,
             multivalue_count,
             multivalue_pack_probability,
             sampling,

--- a/lading_payload/src/dogstatsd.rs
+++ b/lading_payload/src/dogstatsd.rs
@@ -704,7 +704,7 @@ mod test {
 
     use crate::{
         dogstatsd::{
-            contexts, multivalue_count, multivalue_pack_probability, name_length,
+            contexts, default_tags, multivalue_count, multivalue_pack_probability, name_length,
             sampling_probability, sampling_range, service_check_names, tag_key_length,
             tag_value_length, tags_per_msg, value_config, KindWeights, MetricWeights,
         },
@@ -725,7 +725,7 @@ mod test {
             let metric_weights = MetricWeights::default();
             let dogstatsd = DogStatsD::new(contexts(), service_check_names(),
                                            name_length(), tag_key_length(),
-                                           tag_value_length(), tags_per_msg(),
+                                           tag_value_length(), tags_per_msg(), default_tags(),
                                            multivalue_count(), multivalue_pack_probability, sampling_range(), sampling_probability(), kind_weights,
                                            metric_weights, value_conf, &mut rng).unwrap();
 

--- a/lading_payload/src/dogstatsd/common/tags.rs
+++ b/lading_payload/src/dogstatsd/common/tags.rs
@@ -125,6 +125,7 @@ mod test {
             let generator = tags::Generator::new(
                 seed,
                 ConfRange::Inclusive{min: 0, max: tags_per_msg_max},
+                Vec::new(),
                 ConfRange::Inclusive{min: 1, max: 64},
                 ConfRange::Inclusive{min: 1, max: 64},
                 pool.clone(),


### PR DESCRIPTION
### What does this PR do?

This commit allows the user to specify a list of default tags to prefix on any generated tagset. These tags are assumed to be in valid form -- key:value,key:value -- without a trailing comma. Users may pass an empty string.

### Related issues

REF SMPTNG-91
