### PR TITLE
Update lading to Rust 1.74.0

### DIFF
--- a/amd64.Dockerfile
+++ b/amd64.Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/rust:1.71.0-bullseye@sha256:bef59af02f103760cd57e8d6ccadf364954b0ae5e74ea7c7203d26744aeec051 as builder
+FROM docker.io/rust:1.74.0-bullseye@sha256:63c58c3619f2f8c22b51603da68ed6561930db5750ab5508559643b827af1a1 as builder
 
 RUN apt-get update && apt-get install -y \
     protobuf-compiler \

--- a/amd64.Dockerfile
+++ b/amd64.Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/rust:1.74.0-bullseye@sha256:63c58c3619f2f8c22b51603da68ed6561930db5750ab5508559643b827af1a1 as builder
+FROM docker.io/rust:1.74.0-bullseye@sha256:763c58c3619f2f8c22b51603da68ed6561930db5750ab5508559643b827af1a1 as builder
 
 RUN apt-get update && apt-get install -y \
     protobuf-compiler \

--- a/arm64.Dockerfile
+++ b/arm64.Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/rust:1.71.0-bullseye@sha256:4ca63d7dc4792e2069e3d302fdf6b48de5ca8016c7abbe50f14466d769117a83 as builder
+FROM docker.io/rust:1.74.0-bullseye@sha256:cbf2fab601f7884e19ded0b582f67d35fb5e76b2ff2365d4007a6086befeb9ec as builder
 
 RUN apt-get update && apt-get install -y \
     protobuf-compiler \

--- a/lading/src/blackhole/http.rs
+++ b/lading/src/blackhole/http.rs
@@ -246,16 +246,14 @@ impl Http {
             .map_err(Error::Hyper)?;
 
         let server = Server::builder(addr).serve(svc);
-        loop {
-            tokio::select! {
-                res = server => {
-                    error!("server shutdown unexpectedly");
-                    return res.map_err(Error::Hyper);
-                }
-                _ = self.shutdown.recv() => {
-                    info!("shutdown signal received");
-                    return Ok(())
-                }
+        tokio::select! {
+            res = server => {
+                error!("server shutdown unexpectedly");
+                 res.map_err(Error::Hyper)
+            }
+            () = self.shutdown.recv() => {
+                info!("shutdown signal received");
+                Ok(())
             }
         }
     }

--- a/lading/src/blackhole/splunk_hec.rs
+++ b/lading/src/blackhole/splunk_hec.rs
@@ -209,16 +209,14 @@ impl SplunkHec {
             })
             .map_err(Error::Hyper)?;
         let server = Server::builder(addr).serve(svc);
-        loop {
-            tokio::select! {
-                res = server => {
-                    error!("server shutdown unexpectedly");
-                    return res.map_err(Error::Hyper);
-                }
-                _ = self.shutdown.recv() => {
-                    info!("shutdown signal received");
-                    return Ok(())
-                }
+        tokio::select! {
+            res = server => {
+                error!("server shutdown unexpectedly");
+                res.map_err(Error::Hyper)
+            }
+            () = self.shutdown.recv() => {
+                info!("shutdown signal received");
+                Ok(())
             }
         }
     }

--- a/lading/src/blackhole/sqs.rs
+++ b/lading/src/blackhole/sqs.rs
@@ -115,16 +115,14 @@ impl Sqs {
             })
             .unwrap();
         let server = Server::builder(addr).serve(svc);
-        loop {
-            tokio::select! {
-                res = server => {
-                    error!("server shutdown unexpectedly");
-                    return res.map_err(Error::Hyper);
-                }
-                _ = self.shutdown.recv() => {
-                    info!("shutdown signal received");
-                    return Ok(())
-                }
+        tokio::select! {
+            res = server => {
+                error!("server shutdown unexpectedly");
+                res.map_err(Error::Hyper)
+            }
+            () = self.shutdown.recv() => {
+                info!("shutdown signal received");
+                Ok(())
             }
         }
     }

--- a/lading/src/blackhole/tcp.rs
+++ b/lading/src/blackhole/tcp.rs
@@ -104,7 +104,7 @@ impl Tcp {
                         Self::handle_connection(socket, labels)
                     );
                 }
-                _ = self.shutdown.recv() => {
+                () = self.shutdown.recv() => {
                     info!("shutdown signal received");
                     return Ok(())
                 }

--- a/lading/src/blackhole/udp.rs
+++ b/lading/src/blackhole/udp.rs
@@ -88,7 +88,7 @@ impl Udp {
                     packet_received.increment(1);
                     bytes_received.increment(bytes as u64);
                 }
-                _ = self.shutdown.recv() => {
+                () = self.shutdown.recv() => {
                     info!("shutdown signal received");
                     return Ok(())
                 }

--- a/lading/src/blackhole/unix_datagram.rs
+++ b/lading/src/blackhole/unix_datagram.rs
@@ -86,7 +86,7 @@ impl UnixDatagram {
                     let n: usize = res.map_err(Error::Io)?;
                     bytes_received.increment(n as u64);
                 }
-                _ = self.shutdown.recv() => {
+                () = self.shutdown.recv() => {
                     info!("shutdown signal received");
                     return Ok(())
                 }

--- a/lading/src/blackhole/unix_stream.rs
+++ b/lading/src/blackhole/unix_stream.rs
@@ -89,7 +89,7 @@ impl UnixStream {
                         Self::handle_connection(socket, labels)
                     );
                 }
-                _ = self.shutdown.recv() => {
+                () = self.shutdown.recv() => {
                     info!("shutdown signal received");
                     return Ok(())
                 }

--- a/lading/src/captures.rs
+++ b/lading/src/captures.rs
@@ -196,7 +196,7 @@ impl CaptureManager {
                     self.record_captures().await;
                     self.fetch_index += 1;
                 }
-                _ = self.shutdown.recv() => {
+                () = self.shutdown.recv() => {
                     self.record_captures().await;
                     info!("shutdown signal received");
                     return Ok(())

--- a/lading/src/generator/file_gen/logrotate.rs
+++ b/lading/src/generator/file_gen/logrotate.rs
@@ -337,7 +337,7 @@ impl Child {
                         total_bytes_written = 0;
                     }
                 }
-                _ = self.shutdown.recv() => {
+                () = self.shutdown.recv() => {
                     fp.flush().await?;
                     info!("shutdown signal received");
                     return Ok(());

--- a/lading/src/generator/file_gen/traditional.rs
+++ b/lading/src/generator/file_gen/traditional.rs
@@ -305,7 +305,7 @@ impl Child {
                         total_bytes_written = 0;
                     }
                 }
-                _ = self.shutdown.recv() => {
+                () = self.shutdown.recv() => {
                     fp.flush().await?;
                     info!("shutdown signal received");
                     return Ok(());

--- a/lading/src/generator/file_tree.rs
+++ b/lading/src/generator/file_tree.rs
@@ -189,7 +189,7 @@ impl FileTree {
                         rename_folder(&mut self.rng, folder, self.name_len.get()).await?;
                     }
                 }
-                _ = self.shutdown.recv() => {
+                () = self.shutdown.recv() => {
                     info!("shutdown signal received");
                     break;
                 },

--- a/lading/src/generator/grpc.rs
+++ b/lading/src/generator/grpc.rs
@@ -317,7 +317,7 @@ impl Grpc {
                         }
                     }
                 },
-                _ = self.shutdown.recv() => {
+                () = self.shutdown.recv() => {
                     info!("shutdown signal received");
                     break;
                 },

--- a/lading/src/generator/http.rs
+++ b/lading/src/generator/http.rs
@@ -265,7 +265,7 @@ impl Http {
                         drop(permit);
                     });
                 },
-                _ = self.shutdown.recv() => {
+                () = self.shutdown.recv() => {
                     info!("shutdown signal received");
                     // Acquire all available connections, meaning that we have
                     // no outstanding tasks in flight.

--- a/lading/src/generator/process_tree.rs
+++ b/lading/src/generator/process_tree.rs
@@ -327,7 +327,7 @@ impl ProcessTree {
                     }
                 },
 
-                _ = self.shutdown.recv() => {
+                () = self.shutdown.recv() => {
                     info!("shutdown signal received");
                     break;
                 },

--- a/lading/src/generator/splunk_hec.rs
+++ b/lading/src/generator/splunk_hec.rs
@@ -292,7 +292,7 @@ impl SplunkHec {
                     let permit = CONNECTION_SEMAPHORE.get().unwrap().acquire().await.unwrap();
                     tokio::spawn(send_hec_request(permit, block_length, labels, channel, client, request, self.shutdown.clone()));
                 }
-                _ = self.shutdown.recv() => {
+                () = self.shutdown.recv() => {
                     info!("shutdown signal received");
                     // When we shut down we may leave dangling, active
                     // requests. This is acceptable. As we do not today
@@ -352,7 +352,7 @@ async fn send_hec_request(
                 }
             }
         }
-        _ = shutdown.recv() => {},
+        () = shutdown.recv() => {},
     }
     drop(permit);
 }

--- a/lading/src/generator/tcp.rs
+++ b/lading/src/generator/tcp.rs
@@ -204,7 +204,7 @@ impl Tcp {
                         }
                     }
                 }
-                _ = self.shutdown.recv() => {
+                () = self.shutdown.recv() => {
                     info!("shutdown signal received");
                     return Ok(());
                 },

--- a/lading/src/generator/udp.rs
+++ b/lading/src/generator/udp.rs
@@ -213,7 +213,7 @@ impl Udp {
                         }
                     }
                 }
-                _ = self.shutdown.recv() => {
+                () = self.shutdown.recv() => {
                     info!("shutdown signal received");
                     return Ok(());
                 },

--- a/lading/src/generator/unix_datagram.rs
+++ b/lading/src/generator/unix_datagram.rs
@@ -276,7 +276,7 @@ impl Child {
                         }
                     }
                 }
-                _ = self.shutdown.recv() => {
+                () = self.shutdown.recv() => {
                     info!("shutdown signal received");
                     return Ok(());
                 },

--- a/lading/src/generator/unix_stream.rs
+++ b/lading/src/generator/unix_stream.rs
@@ -238,7 +238,7 @@ impl UnixStream {
                         unix_stream = Some(stream);
                     }
                 }
-                _ = self.shutdown.recv() => {
+                () = self.shutdown.recv() => {
                     info!("shutdown signal received");
                     return Ok(());
                 },

--- a/lading/src/inspector.rs
+++ b/lading/src/inspector.rs
@@ -141,7 +141,7 @@ impl Server {
                     }
                 }
             },
-            _ = self.shutdown.recv() => {
+            () = self.shutdown.recv() => {
                 info!("shutdown signal received");
                 // Note that `Child::kill` sends SIGKILL which is not what we
                 // want. We instead send SIGTERM so that the child has a chance

--- a/lading/src/observer.rs
+++ b/lading/src/observer.rs
@@ -118,7 +118,7 @@ impl Server {
                 _ = sample_delay.tick() => {
                     sampler.sample()?;
                 }
-                _ = self.shutdown.recv() => {
+                () = self.shutdown.recv() => {
                     tracing::info!("shutdown signal received");
                     return Ok(());
                 }

--- a/lading/src/target.rs
+++ b/lading/src/target.rs
@@ -286,7 +286,7 @@ impl Server {
                     Err(Error::TargetExited(None))
                 }
             },
-            _ = shutdown.recv() => {
+            () = shutdown.recv() => {
                 info!("shutdown signal received");
                 Ok(())
             }
@@ -332,7 +332,7 @@ impl Server {
                     },
                 }
             },
-            _ = shutdown.recv() => {
+            () = shutdown.recv() => {
                 info!("shutdown signal received");
                 // Note that `Child::kill` sends SIGKILL which is not what we
                 // want. We instead send SIGTERM so that the child has a chance

--- a/lading/src/target_metrics/expvar.rs
+++ b/lading/src/target_metrics/expvar.rs
@@ -92,7 +92,7 @@ impl Expvar {
                 error!("server shutdown unexpectedly");
                  Err(Error::EarlyShutdown)
             }
-            _ = self.shutdown.recv() => {
+            () = self.shutdown.recv() => {
                 info!("shutdown signal received");
                  Ok(())
             }

--- a/lading/src/target_metrics/expvar.rs
+++ b/lading/src/target_metrics/expvar.rs
@@ -67,7 +67,12 @@ impl Expvar {
             loop {
                 tokio::time::sleep(Duration::from_secs(1)).await;
 
-                let Ok(resp) = client.get(&self.config.uri).timeout(Duration::from_secs(1)).send().await else {
+                let Ok(resp) = client
+                    .get(&self.config.uri)
+                    .timeout(Duration::from_secs(1))
+                    .send()
+                    .await
+                else {
                     info!("failed to get expvar uri");
                     continue;
                 };

--- a/lading/src/target_metrics/prometheus.rs
+++ b/lading/src/target_metrics/prometheus.rs
@@ -98,7 +98,12 @@ impl Prometheus {
             loop {
                 tokio::time::sleep(Duration::from_secs(1)).await;
 
-                let Ok(resp) = client.get(&self.config.uri).timeout(Duration::from_secs(1)).send().await else {
+                let Ok(resp) = client
+                    .get(&self.config.uri)
+                    .timeout(Duration::from_secs(1))
+                    .send()
+                    .await
+                else {
                     info!("failed to get Prometheus uri");
                     continue;
                 };

--- a/lading/src/target_metrics/prometheus.rs
+++ b/lading/src/target_metrics/prometheus.rs
@@ -217,7 +217,7 @@ impl Prometheus {
                 error!("server shutdown unexpectedly");
                  Err(Error::EarlyShutdown)
             }
-            _ = self.shutdown.recv() => {
+            () = self.shutdown.recv() => {
                 info!("shutdown signal received");
                  Ok(())
             }

--- a/lading_payload/src/block.rs
+++ b/lading_payload/src/block.rs
@@ -560,14 +560,14 @@ where
                 match snd.try_reserve() {
                     Ok(permit) => permit.send(block),
                     Err(err) => match err {
-                        mpsc::error::TrySendError::Full(_) => {
+                        mpsc::error::TrySendError::Full(()) => {
                             if accum_bytes < total_bytes {
                                 accum_bytes += u64::from(block.total_bytes.get());
                                 cache.push_back(block);
                                 break 'refill;
                             }
                         }
-                        mpsc::error::TrySendError::Closed(_) => return Ok(()),
+                        mpsc::error::TrySendError::Closed(()) => return Ok(()),
                     },
                 }
             }

--- a/lading_payload/src/dogstatsd/event.rs
+++ b/lading_payload/src/dogstatsd/event.rs
@@ -108,7 +108,7 @@ impl<'a> fmt::Display for Event<'a> {
             if !tags.is_empty() {
                 write!(f, "|#")?;
                 let mut commas_remaining = tags.len() - 1;
-                for tag in tags.iter() {
+                for tag in tags {
                     write!(f, "{tag}")?;
                     if commas_remaining != 0 {
                         write!(f, ",")?;

--- a/lading_payload/src/dogstatsd/service_check.rs
+++ b/lading_payload/src/dogstatsd/service_check.rs
@@ -74,7 +74,7 @@ impl<'a> fmt::Display for ServiceCheck<'a> {
             if !tags.is_empty() {
                 write!(f, "|#")?;
                 let mut commas_remaining = tags.len() - 1;
-                for tag in tags.iter() {
+                for tag in tags {
                     write!(f, "{tag}")?;
                     if commas_remaining != 0 {
                         write!(f, ",")?;

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.71.0"
-profile = "default"
+channel = "1.74.0"
+profile = "complete"


### PR DESCRIPTION
### What does this PR do?

This commit updates our rust toolchain to 1.74 and switches its profile from 'default' to 'complete', meaning rust-analyzer et al are installed now by default for every lading developer.

### Related issues

REF SMPTNG-94
