### PR TITLE
Waits on generator's execution in order to print out any errors

### DIFF
--- a/lading/src/bin/lading.rs
+++ b/lading/src/bin/lading.rs
@@ -295,6 +295,7 @@ async fn inner_main(
 
     let (tgt_snd, _tgt_rcv) = broadcast::channel(1);
 
+    let mut gsrv_handles: Vec<tokio::task::JoinHandle<Result<(), generator::Error>>> = Vec::new();
     //
     // GENERATOR
     //
@@ -302,7 +303,11 @@ async fn inner_main(
         let tgt_rcv = tgt_snd.subscribe();
         let generator_server = generator::Server::new(cfg, shutdown.clone()).unwrap();
         let _gsrv = tokio::spawn(generator_server.run(tgt_rcv));
+        gsrv_handles.push(_gsrv);
     }
+    // select_all will yield the first resolved future in the given iterator
+    // It will continue to yield new futures as they resolve.
+    let gsrv_waitable = futures::future::select_all(gsrv_handles);
 
     //
     // INSPECTOR
@@ -384,6 +389,13 @@ async fn inner_main(
         _ = experiment_sleep => {
             info!("experiment duration exceeded, signaling for shutdown");
             shutdown.signal().unwrap();
+        }
+        (item_resolved, ready_future_index, _remaining_futures) = gsrv_waitable => {
+            match item_resolved {
+                Ok(Ok(())) => debug!("generator {ready_future_index} shut down successfully"),
+                Ok(Err(err)) => error!("generator failed with err:\n{}", err),
+                Err(join_err) => error!("generator failed with unknown join err:\n{}", join_err),
+            }
         }
         res = tsrv => {
             match res {


### PR DESCRIPTION
### What does this PR do?
Adds logic in the main `select` loop of `lading` to wait for the result of the generators that were spawned.

### Motivation
While there is good error handling inside the generators that give feedback when an invalid condition is hit, that result was not being read anywhere.


### Related issues


### Additional Notes

