### PR TITLE
Implements a version of tag generation where a common set of tags are repeatedly sampled

### DIFF
--- a/lading_payload/src/dogstatsd.rs
+++ b/lading_payload/src/dogstatsd.rs
@@ -444,9 +444,12 @@ impl MemberGenerator {
         let pool = Rc::new(strings::Pool::with_size(&mut rng, 8_000_000));
 
         let num_contexts = contexts.sample(rng);
+        // TODO propogate this up the chain so its configurable
+        let common_tag_pool_size = ConfRange::Constant(100);
 
         let mut tags_generator = tags::Generator::new(
             rng.gen(),
+            common_tag_pool_size,
             tags_per_msg,
             tag_key_length,
             tag_value_length,

--- a/lading_payload/src/dogstatsd/common/tags.rs
+++ b/lading_payload/src/dogstatsd/common/tags.rs
@@ -3,7 +3,12 @@ use std::{
     rc::Rc,
 };
 
-use rand::{rngs::SmallRng, SeedableRng};
+use rand::{
+    distributions::{Distribution, OpenClosed01},
+    rngs::SmallRng,
+    seq::SliceRandom,
+    SeedableRng,
+};
 
 use crate::{common::strings, dogstatsd::ConfRange};
 
@@ -11,7 +16,7 @@ use crate::{common::strings, dogstatsd::ConfRange};
 // dogstatsd message.
 pub(crate) type Tagset = Vec<String>;
 
-/// Generator for tags
+/// Generator for tagsets
 ///
 /// This is an unusual generator. Unlike our others this maintains its own RNG
 /// and will reseed it when counter reaches `num_tagsets`. The goal is to
@@ -23,24 +28,48 @@ pub(crate) struct Generator {
     internal_rng: RefCell<SmallRng>,
     tagsets_produced: Cell<usize>,
     num_tagsets: usize,
+    common_tag_pool: Vec<String>,
     tags_per_msg: ConfRange<u8>,
     tag_key_length: ConfRange<u8>,
     tag_value_length: ConfRange<u8>,
     str_pool: Rc<strings::Pool>,
 }
 
+fn generate_single_tag(
+    rng: &mut SmallRng,
+    tag_key_length: ConfRange<u8>,
+    tag_value_length: ConfRange<u8>,
+    str_pool: &strings::Pool,
+) -> String {
+    let key_sz = tag_key_length.sample(&mut *rng) as usize;
+    let key = str_pool.of_size(&mut *rng, key_sz).unwrap_or_default();
+    let value_sz = tag_value_length.sample(&mut *rng) as usize;
+    let value = str_pool.of_size(&mut *rng, value_sz).unwrap_or_default();
+    format!("{}:{}", key, value)
+}
+
 impl Generator {
     pub(crate) fn new(
         seed: u64,
+        common_tag_pool_size: ConfRange<u8>,
         tags_per_msg: ConfRange<u8>,
         tag_key_length: ConfRange<u8>,
         tag_value_length: ConfRange<u8>,
         str_pool: Rc<strings::Pool>,
         num_tagsets: usize,
     ) -> Self {
+        let internal_rng = RefCell::new(SmallRng::seed_from_u64(seed));
+        let mut rng = internal_rng.borrow_mut();
+        let num_common_tags = common_tag_pool_size.sample(&mut *rng);
+        let common_tag_pool = (0..num_common_tags)
+            .map(|_| generate_single_tag(&mut *rng, tag_key_length, tag_value_length, &str_pool))
+            .collect();
+
+        drop(rng);
         Generator {
             seed: Cell::new(seed),
-            internal_rng: RefCell::new(SmallRng::seed_from_u64(seed)),
+            internal_rng,
+            common_tag_pool,
             tags_per_msg,
             tag_key_length,
             tag_value_length,
@@ -59,7 +88,7 @@ impl<'a> crate::Generator<'a> for Generator {
     where
         R: rand::Rng + ?Sized,
     {
-        let mut tagset = Vec::new();
+        let mut tagset: Vec<String> = Vec::new();
 
         let tags_count = self
             .tags_per_msg
@@ -73,16 +102,22 @@ impl<'a> crate::Generator<'a> for Generator {
             }
 
             let mut rng = self.internal_rng.borrow_mut();
-            let key_sz = self.tag_key_length.sample(&mut *rng) as usize;
-            let key = self.str_pool.of_size(&mut *rng, key_sz).unwrap_or_default();
-            let value_sz = self.tag_value_length.sample(&mut *rng) as usize;
-            let value = self
-                .str_pool
-                .of_size(&mut *rng, value_sz)
-                .unwrap_or_default();
+            let prob: f32 = OpenClosed01.sample(&mut *rng);
+            let tag = if prob < 0.1 {
+                self.common_tag_pool
+                    .choose(&mut *rng)
+                    .expect("empty pool")
+                    .to_string()
+            } else {
+                generate_single_tag(
+                    &mut *rng,
+                    self.tag_key_length,
+                    self.tag_value_length,
+                    &self.str_pool,
+                )
+            };
 
-            self.tagsets_produced.set(self.tagsets_produced.get() + 1);
-            tagset.push(format!("{key}:{value}"));
+            tagset.push(tag);
         }
 
         tagset
@@ -108,6 +143,7 @@ mod test {
             let tags_per_msg_max = 255;
             let generator = tags::Generator::new(
                 seed,
+                ConfRange::Inclusive{min: 1, max: 20},
                 ConfRange::Inclusive{min: 0, max: tags_per_msg_max},
                 ConfRange::Inclusive{min: 1, max: 64},
                 ConfRange::Inclusive{min: 1, max: 64},


### PR DESCRIPTION
### What does this PR do?
When generating dogstatsd contexts, the current approach simply generates completely random tags until the number of desired contexts is reached, which works, but doesn't reflect real-world usage of dogstatsd.

In the real world, tags are repeated amongst messages frequently and its usually the unique combinations that create cardinality.

### Motivation

String interner experiments

### Related issues

This currently under-generates cardinality dramatically. If I request 100k contexts, I only get 1268 contexts. This is due to the way the common pool is sampled.

This algorithm needs some work, but posting this early as a draft in case anyone has feedback/ideas.


### Additional Notes

Anything else we should know when reviewing?
