### PR TITLE
Revert "Use generational storage in the CaptureManager"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1073,7 +1073,6 @@ dependencies = [
  "procfs",
  "proptest",
  "proptest-derive",
- "quanta",
  "rand",
  "reqwest",
  "rustc-hash",

--- a/lading/Cargo.toml
+++ b/lading/Cargo.toml
@@ -29,7 +29,6 @@ metrics-util = { version = "0.15" }
 nix = { version = "0.27", default-features = false, features = ["process", "signal"] }
 num_cpus = { version = "1.16" }
 once_cell = "1.18"
-quanta = { version = "0.11", default-features = false, features = [] }
 rand = { workspace = true, default-features = false, features = ["small_rng", "std", "std_rng" ]}
 reqwest = { version = "0.11", default-features = false, features = ["json"] }
 rustc-hash = { workspace = true }

--- a/lading/src/captures.rs
+++ b/lading/src/captures.rs
@@ -17,10 +17,7 @@ use std::{
 };
 
 use lading_capture::json;
-use metrics_util::{
-    registry::{GenerationalAtomicStorage, Recency, Registry},
-    MetricKindMask,
-};
+use metrics_util::registry::{AtomicStorage, Registry};
 use rustc_hash::FxHashMap;
 use tokio::{
     fs::File,
@@ -33,8 +30,7 @@ use uuid::Uuid;
 use crate::signals::Shutdown;
 
 struct Inner {
-    recency: Recency<metrics::Key>,
-    registry: Registry<metrics::Key, GenerationalAtomicStorage>,
+    registry: Registry<metrics::Key, AtomicStorage>,
 }
 
 #[allow(missing_debug_implementations)]
@@ -68,12 +64,7 @@ impl CaptureManager {
             capture_path,
             shutdown,
             inner: Arc::new(Inner {
-                recency: Recency::new(
-                    quanta::Clock::new(),
-                    MetricKindMask::COUNTER | MetricKindMask::GAUGE,
-                    Some(Duration::from_secs(10)),
-                ),
-                registry: Registry::new(GenerationalAtomicStorage::atomic()),
+                registry: Registry::atomic(),
             }),
             global_labels: FxHashMap::default(),
         }
@@ -109,55 +100,41 @@ impl CaptureManager {
         self.inner
             .registry
             .visit_counters(|key: &metrics::Key, counter| {
-                let gen = counter.get_generation();
-                if self
-                    .inner
-                    .recency
-                    .should_store_counter(key, gen, &self.inner.registry)
-                {
-                    let mut labels = self.global_labels.clone();
-                    for lbl in key.labels() {
-                        // TODO we're allocating the same small strings over and over most likely
-                        labels.insert(lbl.key().into(), lbl.value().into());
-                    }
-                    let line = json::Line {
-                        run_id: Cow::Borrowed(&self.run_id),
-                        time: now_ms,
-                        fetch_index: self.fetch_index,
-                        metric_name: key.name().into(),
-                        metric_kind: json::MetricKind::Counter,
-                        value: json::LineValue::Int(counter.get_inner().load(Ordering::Relaxed)),
-                        labels,
-                    };
-                    lines.push(line);
+                let mut labels = self.global_labels.clone();
+                for lbl in key.labels() {
+                    // TODO we're allocating the same small strings over and over most likely
+                    labels.insert(lbl.key().into(), lbl.value().into());
                 }
+                let line = json::Line {
+                    run_id: Cow::Borrowed(&self.run_id),
+                    time: now_ms,
+                    fetch_index: self.fetch_index,
+                    metric_name: key.name().into(),
+                    metric_kind: json::MetricKind::Counter,
+                    value: json::LineValue::Int(counter.load(Ordering::Relaxed)),
+                    labels,
+                };
+                lines.push(line);
             });
         self.inner
             .registry
             .visit_gauges(|key: &metrics::Key, gauge| {
-                let gen = gauge.get_generation();
-                if self
-                    .inner
-                    .recency
-                    .should_store_gauge(key, gen, &self.inner.registry)
-                {
-                    let mut labels = self.global_labels.clone();
-                    for lbl in key.labels() {
-                        // TODO we're allocating the same small strings over and over most likely
-                        labels.insert(lbl.key().into(), lbl.value().into());
-                    }
-                    let value: f64 = f64::from_bits(gauge.get_inner().load(Ordering::Relaxed));
-                    let line = json::Line {
-                        run_id: Cow::Borrowed(&self.run_id),
-                        time: now_ms,
-                        fetch_index: self.fetch_index,
-                        metric_name: key.name().into(),
-                        metric_kind: json::MetricKind::Gauge,
-                        value: json::LineValue::Float(value),
-                        labels,
-                    };
-                    lines.push(line);
+                let mut labels = self.global_labels.clone();
+                for lbl in key.labels() {
+                    // TODO we're allocating the same small strings over and over most likely
+                    labels.insert(lbl.key().into(), lbl.value().into());
                 }
+                let value: f64 = f64::from_bits(gauge.load(Ordering::Relaxed));
+                let line = json::Line {
+                    run_id: Cow::Borrowed(&self.run_id),
+                    time: now_ms,
+                    fetch_index: self.fetch_index,
+                    metric_name: key.name().into(),
+                    metric_kind: json::MetricKind::Gauge,
+                    value: json::LineValue::Float(value),
+                    labels,
+                };
+                lines.push(line);
             });
         debug!(
             "Recording {} captures to {}",


### PR DESCRIPTION
Reverts DataDog/lading#748

We have discovered that in lading 0.20.0 this causes a runtime lock. Per our debugging the whole of lading becomes contended on a RWLock and cannot make forward progress. We have not determined the root cause. Because we introduced generational storage to address an edge condition we revert the change for now. 

REF SMPTNG-94