### PR TITLE
Abort on panic

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,3 +26,7 @@ rustc-hash = { version = "1.1.0" }
 lto = true        # Optimize our binary at link stage.
 codegen-units = 1 # Increases compile time but improves optmization alternatives.
 opt-level = 3     # Optimize with 'all' optimization flipped on. May produce larger binaries than 's' or 'z'.
+panic = "abort"
+
+[profile.dev]
+panic = "abort"


### PR DESCRIPTION
### What does this PR do?

Make lading abort on panic rather than unwinding. This is an optional change.

The motivation for this change is to exit lading when any panic occurs. We recently observed a case where an async task panicked and tokio gobbled it up and allowed the process to continue blindly. That particular case will be addressed separately, but that's not generally a failure mode we want.

Ref SMPTNG-103