### PR TITLE
Move capture manager to background blocking thread

### DIFF
--- a/lading/src/bin/lading.rs
+++ b/lading/src/bin/lading.rs
@@ -277,7 +277,7 @@ async fn inner_main(
             for (k, v) in global_labels {
                 capture_manager.add_global_label(k, v);
             }
-            let _capmgr = tokio::spawn(capture_manager.run());
+            capture_manager.start();
         }
     }
 

--- a/lading/src/signals.rs
+++ b/lading/src/signals.rs
@@ -46,9 +46,6 @@ impl Shutdown {
     /// Receive the shutdown notice. This function will block if a notice has
     /// not already been sent.
     pub async fn recv(&mut self) {
-        // NOTE if we ever need a sync version of this function the interior of
-        // this function but with `try_acquire` will work just fine.
-
         // If the shutdown signal has already been received, then return
         // immediately.
         if self.shutdown {


### PR DESCRIPTION
### What does this PR do?

Move the capture manager to its own thread. This makes explicit what tokio was already doing and avoids tokio's panic handler.

The IO routine is adjusted to not panic if serialization or writes fail. This changes the `captures` file contract: each line is now written on a best-effort basis and failure to write one line will not stop ongoing recording. This means we may have invalid lines within a captures file where we previously would have only had them at the end. I believe our capture readers all handle this gracefully today and will ignore the invalid lines.

### Related issues

https://datadoghq.atlassian.net/browse/SMPTNG-105
