### PR TITLE
Expose dogstatsd structures publicly

### DIFF
--- a/lading_payload/src/dogstatsd.rs
+++ b/lading_payload/src/dogstatsd.rs
@@ -20,9 +20,9 @@ use self::{
 use super::Generator;
 
 mod common;
-mod event;
+pub mod event;
 pub mod metric;
-mod service_check;
+pub mod service_check;
 
 /// Error for [`MemberGenerator`]
 #[derive(Debug, thiserror::Error, Clone, Copy)]

--- a/lading_payload/src/dogstatsd.rs
+++ b/lading_payload/src/dogstatsd.rs
@@ -21,7 +21,7 @@ use super::Generator;
 
 mod common;
 mod event;
-mod metric;
+pub mod metric;
 mod service_check;
 
 /// Error for [`MemberGenerator`]

--- a/lading_payload/src/dogstatsd/common.rs
+++ b/lading_payload/src/dogstatsd/common.rs
@@ -12,8 +12,8 @@ use super::{ConfRange, ValueConf};
 
 pub(crate) mod tags;
 
-#[derive(Clone, Debug)]
-pub(crate) enum NumValue {
+#[derive(Clone, Debug, Copy)]
+pub enum NumValue {
     Int(i64),
     Float(f64),
 }
@@ -95,13 +95,13 @@ impl fmt::Display for NumValue {
 }
 
 #[derive(Clone, Copy, Debug)]
-pub(crate) enum ZeroToOne {
+pub enum ZeroToOne {
     One,
     Frac(u32),
 }
 
 #[derive(Debug, Clone, Copy)]
-pub(crate) enum ZeroToOneError {
+pub enum ZeroToOneError {
     OutOfRange,
 }
 

--- a/lading_payload/src/dogstatsd/event.rs
+++ b/lading_payload/src/dogstatsd/event.rs
@@ -62,17 +62,17 @@ impl<'a> Generator<'a> for EventGenerator {
 /// An event, like a syslog kind of.
 #[derive(Debug)]
 pub struct Event<'a> {
-    title: &'a str,
-    text: &'a str,
-    title_utf8_length: usize,
-    text_utf8_length: usize,
-    timestamp_second: Option<u32>,
-    hostname: Option<&'a str>,
-    aggregation_key: Option<&'a str>,
-    priority: Option<Priority>,
-    source_type_name: Option<&'a str>,
-    alert_type: Option<Alert>,
-    tags: Option<common::tags::Tagset>,
+    pub title: &'a str,
+    pub text: &'a str,
+    pub title_utf8_length: usize,
+    pub text_utf8_length: usize,
+    pub timestamp_second: Option<u32>,
+    pub hostname: Option<&'a str>,
+    pub aggregation_key: Option<&'a str>,
+    pub priority: Option<Priority>,
+    pub source_type_name: Option<&'a str>,
+    pub alert_type: Option<Alert>,
+    pub tags: Option<common::tags::Tagset>,
 }
 
 impl<'a> fmt::Display for Event<'a> {
@@ -122,7 +122,7 @@ impl<'a> fmt::Display for Event<'a> {
 }
 
 #[derive(Clone, Copy, Debug)]
-enum Priority {
+pub enum Priority {
     Normal,
     Low,
 }
@@ -150,7 +150,7 @@ impl fmt::Display for Priority {
 }
 
 #[derive(Clone, Copy, Debug)]
-enum Alert {
+pub enum Alert {
     Error,
     Warning,
     Info,

--- a/lading_payload/src/dogstatsd/event.rs
+++ b/lading_payload/src/dogstatsd/event.rs
@@ -1,3 +1,4 @@
+//! `DogStatsD` event.
 use std::{fmt, ops::Range, rc::Rc};
 
 use rand::{distributions::Standard, prelude::Distribution, Rng};
@@ -62,16 +63,27 @@ impl<'a> Generator<'a> for EventGenerator {
 /// An event, like a syslog kind of.
 #[derive(Debug)]
 pub struct Event<'a> {
+    /// Title of the event.
     pub title: &'a str,
+    /// Text of the event.
     pub text: &'a str,
+    /// Length of the title in UTF-8 bytes.
     pub title_utf8_length: usize,
+    /// Length of the text in UTF-8 bytes.
     pub text_utf8_length: usize,
+    /// Timestamp of the event (in seconds from unix epoch)
     pub timestamp_second: Option<u32>,
+    /// Hostname of the event.
     pub hostname: Option<&'a str>,
+    /// Aggregation key of the event.
     pub aggregation_key: Option<&'a str>,
+    /// Priority of the event.
     pub priority: Option<Priority>,
+    /// Source type name of the event.
     pub source_type_name: Option<&'a str>,
+    /// Alert type of the event.
     pub alert_type: Option<Alert>,
+    /// Tags of the event.
     pub tags: Option<common::tags::Tagset>,
 }
 
@@ -121,9 +133,12 @@ impl<'a> fmt::Display for Event<'a> {
     }
 }
 
+/// Priority of an event.
 #[derive(Clone, Copy, Debug)]
 pub enum Priority {
+    /// Normal priority. (default)
     Normal,
+    /// Low priority.
     Low,
 }
 
@@ -149,11 +164,16 @@ impl fmt::Display for Priority {
     }
 }
 
+/// Alert Type associated with an event
 #[derive(Clone, Copy, Debug)]
 pub enum Alert {
+    /// Error alert type.
     Error,
+    /// Warning alert type.
     Warning,
+    /// Info alert type.
     Info,
+    /// Success alert type.
     Success,
 }
 

--- a/lading_payload/src/dogstatsd/metric.rs
+++ b/lading_payload/src/dogstatsd/metric.rs
@@ -197,11 +197,11 @@ impl<'a> std::fmt::Debug for Metric<'a> {
 #[derive(Clone, Debug)]
 /// The count type in `DogStatsD` metric format. Monotonically increasing value.
 pub struct Count<'a> {
-    name: &'a str,
-    values: Vec<common::NumValue>,
-    sample_rate: Option<common::ZeroToOne>,
-    tags: &'a common::tags::Tagset,
-    container_id: Option<&'a str>,
+    pub name: &'a str,
+    pub values: Vec<common::NumValue>,
+    pub sample_rate: Option<common::ZeroToOne>,
+    pub tags: &'a common::tags::Tagset,
+    pub container_id: Option<&'a str>,
 }
 
 impl<'a> fmt::Display for Count<'a> {
@@ -238,10 +238,10 @@ impl<'a> fmt::Display for Count<'a> {
 #[derive(Clone, Debug)]
 /// The gauge type in `DogStatsD` format.
 pub struct Gauge<'a> {
-    name: &'a str,
-    values: Vec<common::NumValue>,
-    tags: &'a common::tags::Tagset,
-    container_id: Option<&'a str>,
+    pub name: &'a str,
+    pub values: Vec<common::NumValue>,
+    pub tags: &'a common::tags::Tagset,
+    pub container_id: Option<&'a str>,
 }
 
 impl<'a> fmt::Display for Gauge<'a> {
@@ -275,11 +275,11 @@ impl<'a> fmt::Display for Gauge<'a> {
 #[derive(Clone, Debug)]
 /// The timer type in `DogStatsD` format.
 pub struct Timer<'a> {
-    name: &'a str,
-    values: Vec<common::NumValue>,
-    sample_rate: Option<common::ZeroToOne>,
-    tags: &'a common::tags::Tagset,
-    container_id: Option<&'a str>,
+    pub name: &'a str,
+    pub values: Vec<common::NumValue>,
+    pub sample_rate: Option<common::ZeroToOne>,
+    pub tags: &'a common::tags::Tagset,
+    pub container_id: Option<&'a str>,
 }
 
 impl<'a> fmt::Display for Timer<'a> {
@@ -316,11 +316,11 @@ impl<'a> fmt::Display for Timer<'a> {
 #[derive(Clone, Debug)]
 /// The distribution type in `DogStatsD` format.
 pub struct Dist<'a> {
-    name: &'a str,
-    values: Vec<common::NumValue>,
-    sample_rate: Option<common::ZeroToOne>,
-    tags: &'a common::tags::Tagset,
-    container_id: Option<&'a str>,
+    pub name: &'a str,
+    pub values: Vec<common::NumValue>,
+    pub sample_rate: Option<common::ZeroToOne>,
+    pub tags: &'a common::tags::Tagset,
+    pub container_id: Option<&'a str>,
 }
 
 impl<'a> fmt::Display for Dist<'a> {
@@ -357,10 +357,10 @@ impl<'a> fmt::Display for Dist<'a> {
 #[derive(Clone, Debug)]
 /// The set type in `DogStatsD` format.
 pub struct Set<'a> {
-    name: &'a str,
-    value: common::NumValue,
-    tags: &'a common::tags::Tagset,
-    container_id: Option<&'a str>,
+    pub name: &'a str,
+    pub value: common::NumValue,
+    pub tags: &'a common::tags::Tagset,
+    pub container_id: Option<&'a str>,
 }
 
 impl<'a> fmt::Display for Set<'a> {
@@ -390,11 +390,11 @@ impl<'a> fmt::Display for Set<'a> {
 #[derive(Clone, Debug)]
 /// The histogram type in `DogStatsD` format.
 pub struct Histogram<'a> {
-    name: &'a str,
-    values: Vec<common::NumValue>,
-    sample_rate: Option<common::ZeroToOne>,
-    tags: &'a common::tags::Tagset,
-    container_id: Option<&'a str>,
+    pub name: &'a str,
+    pub values: Vec<common::NumValue>,
+    pub sample_rate: Option<common::ZeroToOne>,
+    pub tags: &'a common::tags::Tagset,
+    pub container_id: Option<&'a str>,
 }
 
 impl<'a> fmt::Display for Histogram<'a> {

--- a/lading_payload/src/dogstatsd/metric.rs
+++ b/lading_payload/src/dogstatsd/metric.rs
@@ -1,5 +1,4 @@
 //! `DogStatsD` metric.
-#[allow(missing_docs)]
 use std::fmt;
 
 use rand::{
@@ -160,13 +159,20 @@ impl<'a> Generator<'a> for MetricGenerator {
     }
 }
 
+/// Representation of a dogstatsd Metric
 #[derive(Clone)]
 pub enum Metric<'a> {
+    /// Dogstatsd 'count' metric type.
     Count(Count<'a>),
+    /// Dogstatsd 'gauge' metric type.
     Gauge(Gauge<'a>),
+    /// Dogstatsd 'timer' metric type.
     Timer(Timer<'a>),
+    /// Dogstatsd 'histogram' metric type.
     Histogram(Histogram<'a>),
+    /// Dogstatsd 'set' metric type.
     Set(Set<'a>),
+    /// Dogstatsd 'distribution' metric type.
     Distribution(Dist<'a>),
 }
 
@@ -199,10 +205,15 @@ impl<'a> std::fmt::Debug for Metric<'a> {
 #[derive(Clone, Debug)]
 /// The count type in `DogStatsD` metric format. Monotonically increasing value.
 pub struct Count<'a> {
+    /// Name of the metric.
     pub name: &'a str,
+    /// Values of the metric.
     pub values: Vec<common::NumValue>,
+    /// Sample rate of the metric.
     pub sample_rate: Option<common::ZeroToOne>,
+    /// Tags of the metric.
     pub tags: &'a common::tags::Tagset,
+    /// Container ID of the metric.
     pub container_id: Option<&'a str>,
 }
 
@@ -240,9 +251,13 @@ impl<'a> fmt::Display for Count<'a> {
 #[derive(Clone, Debug)]
 /// The gauge type in `DogStatsD` format.
 pub struct Gauge<'a> {
+    /// Name of the metric.
     pub name: &'a str,
+    /// Values of the metric.
     pub values: Vec<common::NumValue>,
+    /// Tags of the metric.
     pub tags: &'a common::tags::Tagset,
+    /// Container ID of the metric.
     pub container_id: Option<&'a str>,
 }
 
@@ -277,10 +292,15 @@ impl<'a> fmt::Display for Gauge<'a> {
 #[derive(Clone, Debug)]
 /// The timer type in `DogStatsD` format.
 pub struct Timer<'a> {
+    /// Name of the metric.
     pub name: &'a str,
+    /// Values of the metric.
     pub values: Vec<common::NumValue>,
+    /// Sample rate of the metric.
     pub sample_rate: Option<common::ZeroToOne>,
+    /// Tags of the metric.
     pub tags: &'a common::tags::Tagset,
+    /// Container ID of the metric.
     pub container_id: Option<&'a str>,
 }
 
@@ -318,10 +338,15 @@ impl<'a> fmt::Display for Timer<'a> {
 #[derive(Clone, Debug)]
 /// The distribution type in `DogStatsD` format.
 pub struct Dist<'a> {
+    /// Name of the metric.
     pub name: &'a str,
+    /// Values of the metric.
     pub values: Vec<common::NumValue>,
+    /// Sample rate of the metric.
     pub sample_rate: Option<common::ZeroToOne>,
+    /// Tags of the metric.
     pub tags: &'a common::tags::Tagset,
+    /// Container ID of the metric.
     pub container_id: Option<&'a str>,
 }
 
@@ -359,9 +384,13 @@ impl<'a> fmt::Display for Dist<'a> {
 #[derive(Clone, Debug)]
 /// The set type in `DogStatsD` format.
 pub struct Set<'a> {
+    /// Name of the metric.
     pub name: &'a str,
+    /// Value of the metric.
     pub value: common::NumValue,
+    /// Tags of the metric.
     pub tags: &'a common::tags::Tagset,
+    /// Container ID of the metric.
     pub container_id: Option<&'a str>,
 }
 
@@ -392,10 +421,15 @@ impl<'a> fmt::Display for Set<'a> {
 #[derive(Clone, Debug)]
 /// The histogram type in `DogStatsD` format.
 pub struct Histogram<'a> {
+    /// Name of the metric.
     pub name: &'a str,
+    /// Values of the metric.
     pub values: Vec<common::NumValue>,
+    /// Sample rate of the metric.
     pub sample_rate: Option<common::ZeroToOne>,
+    /// Tags of the metric.
     pub tags: &'a common::tags::Tagset,
+    /// Container ID of the metric.
     pub container_id: Option<&'a str>,
 }
 

--- a/lading_payload/src/dogstatsd/metric.rs
+++ b/lading_payload/src/dogstatsd/metric.rs
@@ -1,3 +1,5 @@
+//! `DogStatsD` metric.
+#[allow(missing_docs)]
 use std::fmt;
 
 use rand::{

--- a/lading_payload/src/dogstatsd/service_check.rs
+++ b/lading_payload/src/dogstatsd/service_check.rs
@@ -1,3 +1,4 @@
+//! `DogStatsD` service check.
 use std::fmt;
 
 use rand::{distributions::Standard, prelude::Distribution, seq::SliceRandom, Rng};
@@ -47,11 +48,17 @@ impl<'a> Generator<'a> for ServiceCheckGenerator {
 /// Check of a service.
 #[derive(Debug)]
 pub struct ServiceCheck<'a> {
+    /// Name of the service check.
     pub name: &'a str,
+    /// Status of the service check.
     pub status: Status,
+    /// Timestamp of the service check.
     pub timestamp_second: Option<u32>,
+    /// Hostname of the service check.
     pub hostname: Option<&'a str>,
+    /// Tags of the service check.
     pub tags: Option<Tagset>,
+    /// Message of the service check.
     pub message: Option<&'a str>,
 }
 
@@ -90,11 +97,16 @@ impl<'a> fmt::Display for ServiceCheck<'a> {
     }
 }
 
+/// Status of a service check.
 #[derive(Clone, Copy, Debug)]
 pub enum Status {
+    /// 'OK' status. Corresponds to 0
     Ok,
+    /// 'Warning' status. Corresponds to 1
     Warning,
+    /// 'Critical' status. Corresponds to 2
     Critical,
+    /// 'Unknown' status. Corresponds to 3
     Unknown,
 }
 

--- a/lading_payload/src/dogstatsd/service_check.rs
+++ b/lading_payload/src/dogstatsd/service_check.rs
@@ -47,12 +47,12 @@ impl<'a> Generator<'a> for ServiceCheckGenerator {
 /// Check of a service.
 #[derive(Debug)]
 pub struct ServiceCheck<'a> {
-    name: &'a str,
-    status: Status,
-    timestamp_second: Option<u32>,
-    hostname: Option<&'a str>,
-    tags: Option<Tagset>,
-    message: Option<&'a str>,
+    pub name: &'a str,
+    pub status: Status,
+    pub timestamp_second: Option<u32>,
+    pub hostname: Option<&'a str>,
+    pub tags: Option<Tagset>,
+    pub message: Option<&'a str>,
 }
 
 impl<'a> fmt::Display for ServiceCheck<'a> {
@@ -91,7 +91,7 @@ impl<'a> fmt::Display for ServiceCheck<'a> {
 }
 
 #[derive(Clone, Copy, Debug)]
-enum Status {
+pub enum Status {
     Ok,
     Warning,
     Critical,

--- a/lading_payload/src/lib.rs
+++ b/lading_payload/src/lib.rs
@@ -13,7 +13,7 @@
 #![deny(unused_assignments)]
 #![deny(unused_comparisons)]
 #![deny(unreachable_pub)]
-#![allow(missing_docs)]
+#![deny(missing_docs)]
 #![deny(missing_copy_implementations)]
 #![deny(missing_debug_implementations)]
 #![allow(clippy::cast_precision_loss)]

--- a/lading_payload/src/lib.rs
+++ b/lading_payload/src/lib.rs
@@ -13,7 +13,7 @@
 #![deny(unused_assignments)]
 #![deny(unused_comparisons)]
 #![deny(unreachable_pub)]
-#![deny(missing_docs)]
+#![allow(missing_docs)]
 #![deny(missing_copy_implementations)]
 #![deny(missing_debug_implementations)]
 #![allow(clippy::cast_precision_loss)]


### PR DESCRIPTION
### What does this PR do?
This exposes types and fields from dogstatsd message related structs publicly and adds doc-comments as needed.

### Motivation
Motivating example: https://github.com/scottopell/dogstatsd-utils/pull/6

But more generally these could be helpful and don't hurt to expose.

### Related issues

A list of issues either fixed, containing architectural discussions, otherwise relevant
for this Pull Request.

### Additional Notes

Anything else we should know when reviewing?
