### PR TITLE
AMLII-1328: Adds an 'experimental' phase and removes warmup data from capture

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1080,6 +1080,7 @@ dependencies = [
  "serde_json",
  "serde_qs",
  "serde_yaml",
+ "tempfile",
  "thiserror",
  "tokio",
  "tokio-util",

--- a/lading/Cargo.toml
+++ b/lading/Cargo.toml
@@ -52,6 +52,8 @@ async-pidfd = "0.1"
 [dev-dependencies]
 proptest = "1.4"
 proptest-derive = "0.4.0"
+tempfile = "3.8.1"
+
 
 [features]
 default = []

--- a/lading/src/bin/lading.rs
+++ b/lading/src/bin/lading.rs
@@ -445,7 +445,7 @@ async fn inner_main(
         }
     };
     drop(shutdown);
-    return res;
+    res
 }
 
 fn run_process_tree(opts: ProcessTreeGen) {

--- a/lading/src/bin/lading.rs
+++ b/lading/src/bin/lading.rs
@@ -18,6 +18,7 @@ use lading::{
     target::{self, Behavior, Output},
     target_metrics,
 };
+use metrics::gauge;
 use metrics_exporter_prometheus::PrometheusBuilder;
 use rand::{rngs::StdRng, SeedableRng};
 use rustc_hash::FxHashMap;
@@ -25,10 +26,16 @@ use tokio::{
     runtime::Builder,
     signal,
     sync::broadcast,
-    time::{sleep, Duration},
+    time::{self, sleep, Duration},
 };
 use tracing::{debug, error, info, warn};
 use tracing_subscriber::{fmt::format::FmtSpan, util::SubscriberInitExt};
+
+#[derive(thiserror::Error, Debug)]
+enum Error {
+    #[error("Target related error: {0}")]
+    Target(target::Error),
+}
 
 fn default_config_path() -> String {
     "/etc/lading/lading.yaml".to_string()
@@ -160,8 +167,10 @@ struct ProcessTreeGen {
     config_content: Option<String>,
 }
 
-fn get_config(ops: &Opts) -> Config {
-    let contents = if let Ok(env_var_value) = env::var("LADING_CONFIG") {
+fn get_config(ops: &Opts, config: Option<String>) -> Config {
+    let contents = if let Some(config) = config {
+        config
+    } else if let Ok(env_var_value) = env::var("LADING_CONFIG") {
         debug!("Using config from env var 'LADING_CONFIG'");
         env_var_value
     } else {
@@ -181,7 +190,7 @@ fn get_config(ops: &Opts) -> Config {
         contents
     };
 
-    let mut config: Config = serde_yaml::from_str(&contents).unwrap();
+    let mut config: Config = serde_yaml::from_str(&contents).expect("invalid configuration file");
 
     if let Some(rss_bytes_limit) = ops.target_rss_bytes_limit {
         target::Meta::set_rss_bytes_limit(rss_bytes_limit).unwrap();
@@ -249,8 +258,9 @@ async fn inner_main(
     warmup_duration: Duration,
     disable_inspector: bool,
     config: Config,
-) {
-    let shutdown = Phase::new();
+) -> Result<(), Error> {
+    let mut shutdown = Phase::new();
+    let experiment_started = Phase::new();
 
     // Set up the telemetry sub-system.
     //
@@ -266,18 +276,26 @@ async fn inner_main(
             for (k, v) in global_labels {
                 builder = builder.add_global_label(k, v);
             }
-            builder.install().unwrap();
+            let mut prom_experiment_started = experiment_started.clone();
+            tokio::spawn(async move {
+                prom_experiment_started.recv().await; // block until experimental phase entered
+                builder
+                    .install()
+                    .expect("failed to install prometheus recorder");
+            });
         }
         Telemetry::Log {
             path,
             global_labels,
         } => {
-            let mut capture_manager = CaptureManager::new(path, shutdown.clone()).await;
-            capture_manager.install();
+            let mut capture_manager =
+                CaptureManager::new(path, shutdown.clone(), experiment_started.clone()).await;
             for (k, v) in global_labels {
                 capture_manager.add_global_label(k, v);
             }
-            capture_manager.start();
+            tokio::spawn(async {
+                capture_manager.start().await;
+            });
         }
     }
 
@@ -338,7 +356,8 @@ async fn inner_main(
     //
     if let Some(cfgs) = config.target_metrics {
         for cfg in cfgs {
-            let metrics_server = target_metrics::Server::new(cfg, shutdown.clone());
+            let metrics_server =
+                target_metrics::Server::new(cfg, shutdown.clone(), experiment_started.clone());
             tokio::spawn(async {
                 match metrics_server.run().await {
                     Ok(()) => debug!("target_metrics shut down successfully"),
@@ -348,11 +367,12 @@ async fn inner_main(
         }
     }
 
+    let mut tsrv_joinset = tokio::task::JoinSet::new();
     //
     // OBSERVER
     //
     // Observer is not used when there is no target.
-    let tsrv = if let Some(target) = config.target {
+    if let Some(target) = config.target {
         let obs_rcv = tgt_snd.subscribe();
         let observer_server = observer::Server::new(config.observer, shutdown.clone()).unwrap();
         let _osrv = tokio::spawn(observer_server.run(obs_rcv));
@@ -361,58 +381,71 @@ async fn inner_main(
         // TARGET
         //
         let target_server = target::Server::new(target, shutdown.clone());
-        let tsrv = tokio::spawn(target_server.run(tgt_snd));
-        futures::future::Either::Left(tsrv)
+        tsrv_joinset.spawn(target_server.run(tgt_snd));
     } else {
         // Many lading servers synchronize on target startup.
         tgt_snd
             .send(None)
             .expect("unable to transmit startup sync signal, catastrophic failure");
-        futures::future::Either::Right(futures::future::pending())
     };
 
-    let experiment_sleep = async move {
+    let experiment_completed_shutdown = shutdown.clone();
+    tokio::spawn(async move {
         info!("target is running, now sleeping for warmup");
         sleep(warmup_duration).await;
+        experiment_started.signal();
         info!("warmup completed, collecting samples");
         sleep(experiment_duration).await;
-    };
+        info!("experiment duration exceeded, signaling for shutdown");
+        experiment_completed_shutdown.signal();
+    });
 
-    tokio::select! {
-        _ = signal::ctrl_c() => {
-            info!("received ctrl-c");
-            shutdown.signal();
-        },
-        _ = experiment_sleep => {
-            info!("experiment duration exceeded, signaling for shutdown");
-            shutdown.signal();
-        }
-        res = gsrv_joinset.join_next() => {
-            match res {
-                Some(join_result) => match join_result {
+    let mut interval = time::interval(Duration::from_millis(400));
+    let res = loop {
+        tokio::select! {
+            _ = interval.tick() => {
+                gauge!("lading.running", 1.0);
+            },
+
+            _ = signal::ctrl_c() => {
+                info!("received ctrl-c");
+                shutdown.signal();
+            },
+            _ = shutdown.recv() => {
+                info!("shutdown signal received.");
+                break Ok(());
+            }
+            Some(res) = gsrv_joinset.join_next() => {
+                match res {
                     Ok(generator_result) => match generator_result {
                         Ok(()) => { /* Generator shut down successfully */ }
                         Err(err) => error!("Generator shut down unexpectedly: {}", err),
                     }
                     Err(err) => error!("Could not join the spawned generator task: {}", err),
-                },
-                None => { /* Indicates all spawned generators have resolved */ }
-            }
-        }
-        res = tsrv => {
-            match res {
-                Ok(Err(e)) => {
-                    error!("target shut down unexpectedly: {e}");
-                    std::process::exit(1);
                 }
-                Ok(Ok(())) | Err(_) => {
-                    // JoinError or a shutdown signal arrived
-                    shutdown.signal();
+            },
+            Some(target_result) = tsrv_joinset.join_next() => {
+                match target_result {
+                    // joined successfully, but how did the target server exit?
+                    Ok(target_result) => match target_result {
+                        Ok(_) => {
+                            debug!("Target shut down successfully");
+                            shutdown.signal();
+                            break Ok(());
+                        }
+                        Err(err) => {
+                            error!("Target shut down unexpectedly: {}", err);
+                            shutdown.signal();
+                            break Err(Error::Target(err));
+                        }
+                    }
+                    Err(err) => panic!("Could not join the spawned target task: {}", err),
                 }
-            }
+            },
         }
-    }
+    };
     drop(shutdown);
+    return res;
 }
 
 fn run_process_tree(opts: ProcessTreeGen) {
@@ -457,7 +490,7 @@ fn run_extra_cmds(cmds: ExtraCommands) {
     }
 }
 
-fn main() {
+fn main() -> Result<(), Error> {
     tracing_subscriber::fmt()
         .with_span_events(FmtSpan::FULL)
         .with_ansi(false)
@@ -470,10 +503,10 @@ fn main() {
     // handle extra commands
     if let Some(cmds) = opts.extracmds {
         run_extra_cmds(cmds);
-        return;
+        return Ok(());
     }
 
-    let config = get_config(&opts);
+    let config = get_config(&opts, None);
 
     let experiment_duration = Duration::from_secs(opts.experiment_duration_seconds.into());
     let warmup_duration = Duration::from_secs(opts.warmup_duration_seconds.into());
@@ -487,7 +520,7 @@ fn main() {
         .enable_time()
         .build()
         .unwrap();
-    runtime.block_on(inner_main(
+    let res = runtime.block_on(inner_main(
         experiment_duration,
         warmup_duration,
         disable_inspector,
@@ -504,11 +537,39 @@ fn main() {
     );
     runtime.shutdown_timeout(max_shutdown_delay);
     info!("Bye. :)");
+    res
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn inner_main_capture_has_data() {
+        let contents = r#"
+generator: []
+"#;
+
+        let tmp_dir = tempfile::tempdir().unwrap();
+        let capture_path = tmp_dir.path().join("capture");
+        let capture_arg = format!("--capture-path={}", capture_path.display());
+
+        let args = vec!["lading", "--no-target", capture_arg.as_str()];
+        let ops: &Opts = &Opts::parse_from(args);
+        let config = get_config(ops, Some(contents.to_string()));
+        let exit_code = inner_main(
+            Duration::from_millis(2500),
+            Duration::from_millis(5000),
+            false,
+            config,
+        )
+        .await;
+
+        assert!(exit_code.is_ok());
+
+        let contents = std::fs::read_to_string(capture_path).unwrap();
+        assert_eq!(contents.rmatches("lading.running").count(), 2);
+    }
 
     #[test]
     fn cli_key_values_deserializes_empty_string_to_empty_set() {

--- a/lading/src/target.rs
+++ b/lading/src/target.rs
@@ -265,7 +265,6 @@ impl Server {
         // does not give access to the exit code on early termination.
         #[cfg(not(target_os = "linux"))]
         let target_wait = async move {
-            use std::time::Duration;
             use tokio::time::sleep;
             loop {
                 let ret = kill(pid, None);
@@ -289,10 +288,9 @@ impl Server {
                     if let Some(code) = target_exit{
                         error!("target exited unexpectedly with code {}", code);
                         break Err(Error::TargetExited(Some(code)));
-                    } else {
-                        error!("target exited unexpectedly; exit code unavailable");
-                        break Err(Error::TargetExited(None));
                     }
+                    error!("target exited unexpectedly; exit code unavailable");
+                    break Err(Error::TargetExited(None));
                 },
                 () = shutdown.recv() => {
                     info!("shutdown signal received");

--- a/lading/src/target.rs
+++ b/lading/src/target.rs
@@ -21,6 +21,7 @@ use std::{
     path::PathBuf,
     process::{ExitStatus, Stdio},
     sync::atomic::{AtomicU64, Ordering},
+    time::Duration,
 };
 
 use metrics::gauge;
@@ -30,7 +31,7 @@ use nix::{
     unistd::Pid,
 };
 use rustc_hash::FxHashMap;
-use tokio::process::Command;
+use tokio::{process::Command, time};
 use tracing::{error, info};
 
 pub use crate::common::{Behavior, Output};
@@ -276,19 +277,27 @@ impl Server {
             Option::<ExitStatus>::None
         };
 
-        tokio::select! {
-            target_exit = target_wait => {
-                if let Some(code) = target_exit{
-                    error!("target exited unexpectedly with code {}", code);
-                    Err(Error::TargetExited(Some(code)))
-                } else {
-                    error!("target exited unexpectedly; exit code unavailable");
-                    Err(Error::TargetExited(None))
+        let mut interval = time::interval(Duration::from_millis(400));
+        tokio::pin!(target_wait);
+
+        loop {
+            tokio::select! {
+                _ = interval.tick() => {
+                    gauge!("target.running", 1.0);
+                },
+                target_exit = &mut target_wait => {
+                    if let Some(code) = target_exit{
+                        error!("target exited unexpectedly with code {}", code);
+                        break Err(Error::TargetExited(Some(code)));
+                    } else {
+                        error!("target exited unexpectedly; exit code unavailable");
+                        break Err(Error::TargetExited(None));
+                    }
+                },
+                () = shutdown.recv() => {
+                    info!("shutdown signal received");
+                    break Ok(());
                 }
-            },
-            () = shutdown.recv() => {
-                info!("shutdown signal received");
-                Ok(())
             }
         }
     }
@@ -319,28 +328,34 @@ impl Server {
             .expect("target server unable to transmit PID, catastrophic failure");
         drop(pid_snd);
 
-        tokio::select! {
-            res = target_child.wait() => {
-                match res {
-                    Ok(res) => {
-                        error!("target exited unexpectedly with code {}", res);
-                        Err(Error::TargetExited(Some(res)))
-                    },
-                    Err(e) => {
-                        error!("target exited unexpectedly; exit code unavailable ({})", e);
-                        Err(Error::TargetExited(None))
-                    },
+        let mut interval = time::interval(Duration::from_secs(400));
+        loop {
+            tokio::select! {
+                _ = interval.tick() => {
+                    gauge!("target.running", 1.0);
+                },
+                res = target_child.wait() => {
+                    match res {
+                        Ok(res) => {
+                            error!("target exited unexpectedly with code {}", res);
+                            break Err(Error::TargetExited(Some(res)))
+                        },
+                        Err(e) => {
+                            error!("target exited unexpectedly; exit code unavailable ({})", e);
+                            break Err(Error::TargetExited(None))
+                        },
+                    }
+                },
+                () = shutdown.recv() => {
+                    info!("shutdown signal received");
+                    // Note that `Child::kill` sends SIGKILL which is not what we
+                    // want. We instead send SIGTERM so that the child has a chance
+                    // to clean up.
+                    let pid: Pid = Pid::from_raw(target_id.try_into().unwrap());
+                    kill(pid, SIGTERM).map_err(Error::SigTerm)?;
+                    let res = target_child.wait().await.map_err(Error::TargetWait)?;
+                    break Ok(res)
                 }
-            },
-            () = shutdown.recv() => {
-                info!("shutdown signal received");
-                // Note that `Child::kill` sends SIGKILL which is not what we
-                // want. We instead send SIGTERM so that the child has a chance
-                // to clean up.
-                let pid: Pid = Pid::from_raw(target_id.try_into().unwrap());
-                kill(pid, SIGTERM).map_err(Error::SigTerm)?;
-                let res = target_child.wait().await.map_err(Error::TargetWait)?;
-                Ok(res)
             }
         }
     }

--- a/lading/src/target_metrics.rs
+++ b/lading/src/target_metrics.rs
@@ -47,12 +47,16 @@ impl Server {
     /// the target process.
     ///
     #[must_use]
-    pub fn new(config: Config, shutdown: Phase) -> Self {
+    pub fn new(config: Config, shutdown: Phase, experiment_started: Phase) -> Self {
         match config {
-            Config::Expvar(conf) => Self::Expvar(expvar::Expvar::new(conf, shutdown)),
-            Config::Prometheus(conf) => {
-                Self::Prometheus(prometheus::Prometheus::new(conf, shutdown))
+            Config::Expvar(conf) => {
+                Self::Expvar(expvar::Expvar::new(conf, shutdown, experiment_started))
             }
+            Config::Prometheus(conf) => Self::Prometheus(prometheus::Prometheus::new(
+                conf,
+                shutdown,
+                experiment_started,
+            )),
         }
     }
 


### PR DESCRIPTION
### What does this PR do?

This PR implements:
1. An 'experimental' phase that will be entered after the `warmup_duration` expires
2. Modifies the target scrapers and capture manager to not begin execution until the experimental phase has been entered.
    i. As part of this, a test for `inner_main` was added which asserts that the expected # of `lading.running` entries given 
        a 1 second capture record interval.
4. Refactors the main `select!` in `lading/src/bin/lading.rs` to loop over the `select` to address a potential early-termination bug when the set of `generator`s are empty.
    a. This bug was encountered in https://github.com/DataDog/datadog-agent/pull/21452
6. Adds 2 gauge metrics:
    a. `lading.running` -- submits a value of `1` as long as the main `select!` of lading is executing
    b. `target.running` -- submits a value of `1` as long as the target is running.
7. `flush`es the capture file descriptor as soon as current lines are written, I observed in my unit tests that without this I could miss data. Likely due to the test runtime not being torn down by the time the capture files are inspected, but figure this data is valuable enough to pay the small IO penalty.


### Motivation
Especially visible in `smp local-run`, the generators and target scrapers have errors during the warmup phase connecting to the target. This is expected and is the entire point of the warmup phase.

This PR's original goal was simply to implement this "experimental phase", however scope creep got the best of me, which I hopefully made up for with my new unit tests for `inner_main`

### Related issues


### Additional Notes

There are a few `sleep` based loops that use a 1s timer, both the target metrics scraper, the target process observer, and the capture manager. Future improvement here would be to consider using `interval` instead of `sleep` in order to consider the [`MissedTickBehavior`](https://docs.rs/tokio/latest/tokio/time/enum.MissedTickBehavior.html)

The new `gauge` metrics are useful to me in validating the resulting data in the capture file, however I can refactor to avoid these if desired.

