### PR TITLE
Switches back to including warmup data in the capture manager

### DIFF
--- a/lading/src/bin/lading.rs
+++ b/lading/src/bin/lading.rs
@@ -294,7 +294,7 @@ async fn inner_main(
                 capture_manager.add_global_label(k, v);
             }
             tokio::spawn(async {
-                capture_manager.start().await;
+                capture_manager.start();
             });
         }
     }
@@ -568,7 +568,7 @@ generator: []
         assert!(exit_code.is_ok());
 
         let contents = std::fs::read_to_string(capture_path).unwrap();
-        assert_eq!(contents.rmatches("lading.running").count(), 2);
+        assert_eq!(contents.rmatches("lading.running").count(), 7);
     }
 
     #[test]

--- a/lading/src/captures.rs
+++ b/lading/src/captures.rs
@@ -40,7 +40,7 @@ pub struct CaptureManager {
     capture_fp: BufWriter<std::fs::File>,
     capture_path: PathBuf,
     shutdown: Phase,
-    experiment_started: Phase,
+    _experiment_started: Phase,
     inner: Arc<Inner>,
     global_labels: FxHashMap<String, String>,
 }
@@ -60,7 +60,7 @@ impl CaptureManager {
             capture_fp: BufWriter::new(fp),
             capture_path,
             shutdown,
-            experiment_started,
+            _experiment_started: experiment_started,
             inner: Arc::new(Inner {
                 registry: Registry::atomic(),
             }),
@@ -160,12 +160,10 @@ impl CaptureManager {
     /// # Panics
     ///
     /// None known.
-    pub async fn start(mut self) {
-        info!("Capture manager running, waiting for warmup to complete");
-        self.experiment_started.recv().await; // block until experimental phase entered
-
-        // Defer installing the recorder until after the warmup period. This
-        // ensures that we don't get any metrics/errors from the warmup period.
+    pub fn start(mut self) {
+        // Installing the recorder immediately on startup.
+        // This does _not_ wait on experiment_started signal, so
+        // warmup data will be included in the capture.
         self.install();
         info!("Capture manager installed, recording to capture file.");
 


### PR DESCRIPTION
### What does this PR do?

Partially reverts #774 . The 'experimental' phase is still present, however the capture manager no longer waits for the experimental phase to be active before installing the metrics recorder.
This gives us warmup data in the capture files, which some later components rely on currently.

### Motivation

Some components rely on warmup data being present in the capture file.

### Related issues

#774 

### Additional Notes

