### PR TITLE
changelog: prep for 0.20.4 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
-## [0.20.4]
+## [0.20.4-rc1]
 ### Changed
 - Dogstatsd payload structs now have public fields.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
-## [0.20.4-rc1]
+## [0.20.4]
+### Added
+- `lading.running` gauge metric that submits a value of 1 as long as the main
+  `select!` of lading is executing.
+- `target.running` gauge metric that submits a value of 1 as long as the target
+  is running.
+
 ### Changed
 - Dogstatsd payload structs now have public fields.
+- Capture file descriptor is flushed as soon as current lines are written.
+- Renamed `Shutdown` data type to `Phase` so that this data type can be used as
+  a signal to control `lading` behavior over distinct stages of load generation
+  (e.g., warmup, shutdown).
+- Prometheus telemetry and Go expvar target metrics are no longer emitted during
+  `lading`'s warmup ("experimental") phase.
+
+### Fixed
+- Refactors the main `select!` in `lading/src/bin/lading.rs` to loop over the
+  select to address a potential early-termination bug when the set of generators
+  are empty.
 
 ## [0.20.3]
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## [0.20.4]
+### Changed
+- Dogstatsd payload structs now have public fields.
+
 ## [0.20.3]
 ### Added
 - ProcFs generator is now suitable for use.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1049,7 +1049,7 @@ dependencies = [
 
 [[package]]
 name = "lading"
-version = "0.20.3"
+version = "0.20.4-rc1"
 dependencies = [
  "async-pidfd",
  "byte-unit",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1049,7 +1049,7 @@ dependencies = [
 
 [[package]]
 name = "lading"
-version = "0.20.4-rc1"
+version = "0.20.4"
 dependencies = [
  "async-pidfd",
  "byte-unit",

--- a/lading/Cargo.toml
+++ b/lading/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lading"
-version = "0.20.4-rc1"
+version = "0.20.4"
 authors = ["Brian L. Troutwine <brian.troutwine@datadoghq.com>", "George Hahn <george.hahn@datadoghq.com"]
 edition = "2021"
 license = "MIT"

--- a/lading/Cargo.toml
+++ b/lading/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lading"
-version = "0.20.3"
+version = "0.20.4-rc1"
 authors = ["Brian L. Troutwine <brian.troutwine@datadoghq.com>", "George Hahn <george.hahn@datadoghq.com"]
 edition = "2021"
 license = "MIT"


### PR DESCRIPTION
### What does this PR do?

Before cutting a `lading` release, its changelog must be updated. This commit updates the changelog in preparation for a 0.20.4 release.

### Motivation

Release changes that should fix broken `idle` experiment in `datadog-agent`.

### Related issues

n/a

### Additional Notes

n/a