### PR TITLE
Don't panic from tallying resources after process exit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Fixed
+- Total CPU calculation routine no longer panics in some scenarios
 
 ## [0.20.4]
 ### Added

--- a/lading/src/observer/linux.rs
+++ b/lading/src/observer/linux.rs
@@ -313,9 +313,10 @@ struct CpuPercentage {
 #[inline]
 fn calculate_cpu_percentage(sample: &Sample, previous: &Sample, num_cores: usize) -> CpuPercentage {
     let uptime_diff = sample.uptime - previous.uptime; // CPU-ticks
-    let stime_diff: u64 = sample.stime - previous.stime; // CPU-ticks
-    let utime_diff: u64 = sample.utime - previous.utime; // CPU-ticks
-    let time_diff: u64 = (sample.stime + sample.utime) - (previous.stime + previous.utime); // CPU-ticks
+    let stime_diff: u64 = sample.stime.saturating_sub(previous.stime); // CPU-ticks
+    let utime_diff: u64 = sample.utime.saturating_sub(previous.utime); // CPU-ticks
+    let time_diff: u64 =
+        (sample.stime + sample.utime).saturating_sub(previous.stime + previous.utime); // CPU-ticks
 
     let user_percentage = percentage(utime_diff as f64, uptime_diff as f64, num_cores as f64);
     let kernel_percentage = percentage(stime_diff as f64, uptime_diff as f64, num_cores as f64);


### PR DESCRIPTION
### What does this PR do?

Fix a panic that we've observed in a small number of cases. This switches it from a stability issue into a data-correctness issue. It's expected that the correctness issue will require switching these totals over to cgroup values instead of doing the tally in lading.

### Related issues

https://datadoghq.atlassian.net/browse/SMPTNG-109

