### PR TITLE
AMLII-1319: Unix Stream Dogstatsd Support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+- Fixes bug with retry logic in `unix-stream` generator that could result in
+  unexpected, extra unix stream connections.
+- Adds a new config option to `lading_payload::dogstatsd::Config`,
+  `length_prefix_framed`. If this option is on, each "block" emitted by the
+  dogstatsd generator will have a little-endian u32 prefix (4 bytes) containing
+  the length of the following block.
+
 ### Fixed
 - Total CPU calculation routine no longer panics in some scenarios
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1053,7 +1053,6 @@ version = "0.20.4"
 dependencies = [
  "async-pidfd",
  "byte-unit",
- "byteorder",
  "bytes",
  "clap 3.2.25",
  "flate2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -270,9 +270,9 @@ dependencies = [
 
 [[package]]
 name = "byteorder"
-version = "1.4.3"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
@@ -1053,6 +1053,7 @@ version = "0.20.4"
 dependencies = [
  "async-pidfd",
  "byte-unit",
+ "byteorder",
  "bytes",
  "clap 3.2.25",
  "flate2",

--- a/lading/Cargo.toml
+++ b/lading/Cargo.toml
@@ -44,6 +44,7 @@ tower = { version = "0.4", default-features = false, features = ["timeout", "lim
 tracing = { workspace = true }
 tracing-subscriber = { version = "0.3", features = ["std", "env-filter"] }
 uuid = { workspace = true }
+byteorder = "1.5.0"
 
 [target.'cfg(target_os = "linux")'.dependencies]
 procfs = { version = "0.15", default-features = false, features = [] }

--- a/lading/Cargo.toml
+++ b/lading/Cargo.toml
@@ -44,7 +44,6 @@ tower = { version = "0.4", default-features = false, features = ["timeout", "lim
 tracing = { workspace = true }
 tracing-subscriber = { version = "0.3", features = ["std", "env-filter"] }
 uuid = { workspace = true }
-byteorder = "1.5.0"
 
 [target.'cfg(target_os = "linux")'.dependencies]
 procfs = { version = "0.15", default-features = false, features = [] }

--- a/lading/src/generator/unix_stream.rs
+++ b/lading/src/generator/unix_stream.rs
@@ -242,8 +242,6 @@ impl UnixStream {
                                     counter!("request_failure", 1, &error_labels);
                                 }
                             }
-                        } else {
-                            warn!("socket is not writeable");
                         }
                     }
                 }

--- a/lading/src/generator/unix_stream.rs
+++ b/lading/src/generator/unix_stream.rs
@@ -266,8 +266,9 @@ impl UnixStream {
                                 Ok(bytes) => {
                                     // We close the current frame if we wrote all the bytes we desired to write
                                     // Otherwise the frame stays open.
-                                    if let Some(ref frame) = current_frame {
-                                        if bytes == frame.bytes_in_frame {
+                                    if let Some(ref mut frame) = current_frame {
+                                        frame.bytes_in_frame -= bytes;
+                                        if frame.bytes_in_frame == 0 {
                                             current_frame = None;
                                         }
                                     }

--- a/lading_payload/src/block.rs
+++ b/lading_payload/src/block.rs
@@ -239,6 +239,7 @@ impl Cache {
                     metric_weights,
                     value,
                     service_check_names,
+                    length_prefix_framed,
                 },
             ) => {
                 if !conf.valid() {
@@ -258,6 +259,7 @@ impl Cache {
                     *kind_weights,
                     *metric_weights,
                     *value,
+                    *length_prefix_framed,
                     &mut rng,
                 )?;
 
@@ -457,6 +459,7 @@ fn stream_inner(
                 kind_weights,
                 metric_weights,
                 value,
+                length_prefix_framed,
             },
         ) => {
             if !conf.valid() {
@@ -476,6 +479,7 @@ fn stream_inner(
                 *kind_weights,
                 *metric_weights,
                 *value,
+                *length_prefix_framed,
                 &mut rng,
             )?;
 


### PR DESCRIPTION
### What does this PR do?

See changelog for detailed list, but broadly this branch fixes some bugs in the `unix-stream` generator and adds support for length-prefixed frames in the `dogstatsd` payload generator.

### Motivation

Improve lading to be able to test the new dogstatsd unix-stream support.

### Related issues



### Additional Notes

