### PR TITLE
Fix cargo-deny advisories

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2706,9 +2706,9 @@ dependencies = [
 
 [[package]]
 name = "unsafe-libyaml"
-version = "0.2.9"
+version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f28467d3e1d3c6586d8f25fa243f544f5800fec42d97032474e17222c2b75cfa"
+checksum = "ab4c90930b95a82d00dc9e9ac071b4991924390d46cbd0dfe566148667605e4b"
 
 [[package]]
 name = "url"

--- a/deny.toml
+++ b/deny.toml
@@ -18,7 +18,6 @@ copyleft = "deny"
 default = "deny"
 
 [sources]
-allow-git = ["https://github.com/open-telemetry/opentelemetry-rust/"]
 unknown-git = "deny"
 
 [advisories]


### PR DESCRIPTION
### What does this PR do?

- Updates unsafe-libyaml from 0.2.9 -> 0.2.10 per RUSTSEC-2023-0075"
- Removes un-used git allowed source

### Motivation

Cargo-deny is blocking my release PR #780 

### Related issues


### Additional Notes

