### PR TITLE
Correct SMPTNG-124

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## [0.20.6-rc0]
+### Fixed
+- Fixed a bug in CLI key/value parsing where values might be incorrectly parsed
+  as key/value pairs if they held lading's delimiter character.
+
 ## [0.20.5]
 ### Added
 - Adds a new config option to `lading_payload::dogstatsd::Config`,

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1049,7 +1049,7 @@ dependencies = [
 
 [[package]]
 name = "lading"
-version = "0.20.5"
+version = "0.20.6-rc0"
 dependencies = [
  "async-pidfd",
  "byte-unit",
@@ -1074,6 +1074,7 @@ dependencies = [
  "proptest",
  "proptest-derive",
  "rand",
+ "regex",
  "reqwest",
  "rustc-hash",
  "serde",
@@ -1218,9 +1219,9 @@ checksum = "b87248edafb776e59e6ee64a79086f65890d3510f2c656c000bf2a7e8a0aea40"
 
 [[package]]
 name = "memchr"
-version = "2.5.0"
+version = "2.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
+checksum = "f665ee40bc4a3c5590afb1e9677db74a508659dfd71e126420da8274909a0167"
 
 [[package]]
 name = "memoffset"
@@ -1880,14 +1881,14 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.9.1"
+version = "1.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2eae68fc220f7cf2532e4494aded17545fce192d59cd996e0fe7887f4ceb575"
+checksum = "380b951a9c5e80ddfd6136919eef32310721aa4aacd4889a8d39124b026ab343"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata 0.3.3",
- "regex-syntax 0.7.4",
+ "regex-automata 0.4.3",
+ "regex-syntax 0.8.2",
 ]
 
 [[package]]
@@ -1901,13 +1902,13 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.3.3"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39354c10dd07468c2e73926b23bb9c2caca74c5501e38a35da70406f1d923310"
+checksum = "5f804c7828047e88b2d32e2d7fe5a105da8ee3264f01902f796c8e067dc2483f"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax 0.7.4",
+ "regex-syntax 0.8.2",
 ]
 
 [[package]]
@@ -1915,12 +1916,6 @@ name = "regex-syntax"
 version = "0.6.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
-
-[[package]]
-name = "regex-syntax"
-version = "0.7.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5ea92a5b6195c6ef2a0295ea818b312502c6fc94dde986c5553242e18fd4ce2"
 
 [[package]]
 name = "regex-syntax"

--- a/lading/Cargo.toml
+++ b/lading/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lading"
-version = "0.20.5"
+version = "0.20.6-rc0"
 authors = ["Brian L. Troutwine <brian.troutwine@datadoghq.com>", "George Hahn <george.hahn@datadoghq.com"]
 edition = "2021"
 license = "MIT"
@@ -28,8 +28,9 @@ metrics-exporter-prometheus = { version = "0.12.1", default-features = false, fe
 metrics-util = { version = "0.15" }
 nix = { version = "0.27", default-features = false, features = ["process", "signal"] }
 num_cpus = { version = "1.16" }
-once_cell = "1.18"
+once_cell = { version = "1.18" }
 rand = { workspace = true, default-features = false, features = ["small_rng", "std", "std_rng" ]}
+regex = { version = "1.10" }
 reqwest = { version = "0.11", default-features = false, features = ["json"] }
 rustc-hash = { workspace = true }
 serde = { workspace = true }

--- a/lading/src/bin/lading.rs
+++ b/lading/src/bin/lading.rs
@@ -50,6 +50,12 @@ struct CliKeyValues {
     inner: FxHashMap<String, String>,
 }
 
+impl CliKeyValues {
+    fn get(&self, key: &str) -> Option<&str> {
+        self.inner.get(key).map(|s| s.as_str())
+    }
+}
+
 impl Display for CliKeyValues {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
         for (k, v) in self.inner.iter() {
@@ -595,5 +601,16 @@ generator: []
         let deser = CliKeyValues::from_str(val);
         let deser = deser.unwrap().to_string();
         assert_eq!(deser, "first=one,");
+    }
+
+    #[test]
+    fn cli_key_values_deserializes_kv_comma_separated_value() {
+        let val = "DD_API_KEY=00000001,DD_TELEMETRY_ENABLED=true,DD_TAGS=uqhwd:b2xiyw,hf9gy:uwcy04";
+        let deser = CliKeyValues::from_str(val);
+        let deser = deser.unwrap();
+
+        assert_eq!(deser.get("DD_API_KEY").unwrap(), "00000001");
+        assert_eq!(deser.get("DD_TELEMETRY_ENABLED").unwrap(), "true");
+        assert_eq!(deser.get("DD_TAGS").unwrap(), "uqhwd:b2xiyw,hf9gy:uwcy04");
     }
 }


### PR DESCRIPTION
### What does this PR do?

Correct tag parsing issue when passed tags use lading's splitting convention. 

### Motivation

We want users to be able to pass tags in Datadog Agent format without needing to make a backward incompatible update to lading. 

### Related issues

REF SMPTNG-124

