### PR TITLE
Increment, not reset block offsets

### DIFF
--- a/lading/src/generator/unix_datagram.rs
+++ b/lading/src/generator/unix_datagram.rs
@@ -263,7 +263,7 @@ impl Child {
                             Ok(bytes) => {
                                 bytes_written.increment(bytes as u64);
                                 packets_sent.increment(1);
-                                blk_offset = bytes;
+                                blk_offset += bytes;
                             }
                             Err(err) => {
                                 debug!("write failed: {}", err);

--- a/lading/src/generator/unix_stream.rs
+++ b/lading/src/generator/unix_stream.rs
@@ -220,7 +220,7 @@ impl UnixStream {
                                 Ok(bytes) => {
                                     bytes_written.increment(bytes as u64);
                                     packets_sent.increment(1);
-                                    blk_offset = bytes;
+                                    blk_offset += bytes;
                                 }
                                 Err(ref e) if e.kind() == tokio::io::ErrorKind::WouldBlock => {
                                     // If the read side has hung up we will never


### PR DESCRIPTION
### What does this PR do?

Discovered by @tobz we were previously setting the block offset in unix datagram and stream to the bytes written, not incrementing as we should have been. This PR corrects that mistake.
