### PR TITLE
Replace all Unwraps with Expect

### DIFF
--- a/integration/ducks/src/main.rs
+++ b/integration/ducks/src/main.rs
@@ -80,12 +80,12 @@ impl From<&HttpCounters> for HttpMetrics {
             median_entropy: val
                 .entropy
                 .quantile(0.5)
-                .expect("Error: quantile is outside of the valid range")
+                .expect("quantile is outside of the valid range")
                 .unwrap_or_default(),
             median_size: val
                 .body_size
                 .quantile(0.5)
-                .expect("Error: quantile is outside of the valid range")
+                .expect("quantile is outside of the valid range")
                 .unwrap_or_default(),
         }
     }
@@ -118,7 +118,7 @@ impl From<&SocketCounters> for SocketMetrics {
             median_entropy: val
                 .entropy
                 .quantile(0.5)
-                .expect("Error: quantile is outside of the valid range")
+                .expect("quantile is outside of the valid range")
                 .unwrap_or_default(),
         }
     }
@@ -130,9 +130,7 @@ async fn http_req_handler(req: Request<Body>) -> Result<hyper::Response<Body>, h
     let body = body::to_bytes(body).await?;
 
     {
-        let metric = HTTP_COUNTERS
-            .get()
-            .expect("Error: HTTP_COUNTERS not initialized");
+        let metric = HTTP_COUNTERS.get().expect("HTTP_COUNTERS not initialized");
         let mut m = metric.lock().await;
         m.request_count += 1;
 
@@ -289,9 +287,7 @@ impl DucksTarget {
             socket.read_buf(&mut buffer).await?;
 
             {
-                let metric = TCP_COUNTERS
-                    .get()
-                    .expect("Error: TCP_COUNTERS not initialized");
+                let metric = TCP_COUNTERS.get().expect("TCP_COUNTERS not initialized");
                 let mut m = metric.lock().await;
                 m.read_count += 1;
                 m.total_bytes += buffer.len() as u64;
@@ -323,9 +319,7 @@ impl DucksTarget {
             trace!("Got {} B from {}", count, _remote);
 
             {
-                let metric = UDP_COUNTERS
-                    .get()
-                    .expect("Error: UDP_COUNTERS not initialized");
+                let metric = UDP_COUNTERS.get().expect("UDP_COUNTERS not initialized");
                 let mut m = metric.lock().await;
                 m.read_count += 1;
                 m.total_bytes += count as u64;
@@ -343,7 +337,7 @@ async fn main() -> Result<(), anyhow::Error> {
     // Every ducks-sheepdog pair is connected by a unique socket file
     let ducks_comm_file = std::env::args()
         .nth(1)
-        .expect("Error: The length of env args is less than 2");
+        .expect("ducks socket file argument missing");
     let ducks_comm =
         UnixListener::bind(&ducks_comm_file).context("ducks failed to bind to RPC socket")?;
     let ducks_comm = UnixListenerStream::new(ducks_comm);

--- a/integration/ducks/src/main.rs
+++ b/integration/ducks/src/main.rs
@@ -80,12 +80,12 @@ impl From<&HttpCounters> for HttpMetrics {
             median_entropy: val
                 .entropy
                 .quantile(0.5)
-                .expect("quantile is outside of the valid range")
+                .expect("quantile argument must be between 0.0 and 1.0 inclusive")
                 .unwrap_or_default(),
             median_size: val
                 .body_size
                 .quantile(0.5)
-                .expect("quantile is outside of the valid range")
+                .expect("quantile argument must be between 0.0 and 1.0 inclusive")
                 .unwrap_or_default(),
         }
     }
@@ -118,7 +118,7 @@ impl From<&SocketCounters> for SocketMetrics {
             median_entropy: val
                 .entropy
                 .quantile(0.5)
-                .expect("quantile is outside of the valid range")
+                .expect("quantile argument must be between 0.0 and 1.0 inclusive")
                 .unwrap_or_default(),
         }
     }

--- a/integration/shared/src/lib.rs
+++ b/integration/shared/src/lib.rs
@@ -55,13 +55,14 @@ pub struct DucksConfig {
 impl IntoRequest<TestConfig> for DucksConfig {
     fn into_request(self) -> tonic::Request<TestConfig> {
         Request::new(TestConfig {
-            json_blob: serde_json::to_string(&self).unwrap(),
+            json_blob: serde_json::to_string(&self)
+                .expect("Error: Failed to convert config to JSON"),
         })
     }
 }
 
 impl From<TestConfig> for DucksConfig {
     fn from(val: TestConfig) -> Self {
-        serde_json::from_str(&val.json_blob).unwrap()
+        serde_json::from_str(&val.json_blob).expect("Error: Failed to convert to JSON")
     }
 }

--- a/integration/shared/src/lib.rs
+++ b/integration/shared/src/lib.rs
@@ -55,14 +55,13 @@ pub struct DucksConfig {
 impl IntoRequest<TestConfig> for DucksConfig {
     fn into_request(self) -> tonic::Request<TestConfig> {
         Request::new(TestConfig {
-            json_blob: serde_json::to_string(&self)
-                .expect("Error: Failed to convert config to JSON"),
+            json_blob: serde_json::to_string(&self).expect("Failed to convert config to JSON"),
         })
     }
 }
 
 impl From<TestConfig> for DucksConfig {
     fn from(val: TestConfig) -> Self {
-        serde_json::from_str(&val.json_blob).expect("Error: Failed to convert to JSON")
+        serde_json::from_str(&val.json_blob).expect("Failed to convert to JSON")
     }
 }

--- a/integration/sheepdog/src/lib.rs
+++ b/integration/sheepdog/src/lib.rs
@@ -111,7 +111,11 @@ impl IntegrationTest {
         let ducks_process = Command::new(ducks_binary)
             .stdout(Stdio::piped())
             .env("RUST_LOG", "ducks=debug,info")
-            .arg(ducks_comm_file.to_str().unwrap())
+            .arg(
+                ducks_comm_file
+                    .to_str()
+                    .expect("Error: Path is invalid unicode"),
+            )
             .spawn()
             .context("launch ducks")?;
 
@@ -148,17 +152,30 @@ impl IntegrationTest {
             .stdout(Stdio::piped())
             .env("RUST_LOG", "lading=debug,info")
             .arg("--target-pid")
-            .arg(ducks_process.id().unwrap().to_string())
+            .arg(
+                ducks_process
+                    .id()
+                    .expect("Error: process is already done")
+                    .to_string(),
+            )
             .arg("--config-path")
-            .arg(lading_config_file.to_str().unwrap())
+            .arg(
+                lading_config_file
+                    .to_str()
+                    .expect("Error: path is invalid unicode"),
+            )
             .arg("--experiment-duration-seconds")
             .arg(self.experiment_duration.as_secs().to_string())
             .arg("--warmup-duration-seconds")
             .arg(self.experiment_warmup.as_secs().to_string())
             .arg("--capture-path")
-            .arg(captures_file.to_str().unwrap())
+            .arg(
+                captures_file
+                    .to_str()
+                    .expect("Error: path is invalid unicode"),
+            )
             .spawn()
-            .unwrap();
+            .expect("Error: lading binary failed to spawn");
 
         // wait for lading to push some load. It will exit on its own.
         debug!("lading is running");

--- a/integration/sheepdog/src/lib.rs
+++ b/integration/sheepdog/src/lib.rs
@@ -111,11 +111,7 @@ impl IntegrationTest {
         let ducks_process = Command::new(ducks_binary)
             .stdout(Stdio::piped())
             .env("RUST_LOG", "ducks=debug,info")
-            .arg(
-                ducks_comm_file
-                    .to_str()
-                    .expect("Error: Path is invalid unicode"),
-            )
+            .arg(ducks_comm_file.to_str().expect("Path is invalid unicode"))
             .spawn()
             .context("launch ducks")?;
 
@@ -155,27 +151,23 @@ impl IntegrationTest {
             .arg(
                 ducks_process
                     .id()
-                    .expect("Error: process is already done")
+                    .expect("process is already done")
                     .to_string(),
             )
             .arg("--config-path")
             .arg(
                 lading_config_file
                     .to_str()
-                    .expect("Error: path is invalid unicode"),
+                    .expect("path is invalid unicode"),
             )
             .arg("--experiment-duration-seconds")
             .arg(self.experiment_duration.as_secs().to_string())
             .arg("--warmup-duration-seconds")
             .arg(self.experiment_warmup.as_secs().to_string())
             .arg("--capture-path")
-            .arg(
-                captures_file
-                    .to_str()
-                    .expect("Error: path is invalid unicode"),
-            )
+            .arg(captures_file.to_str().expect("path is invalid unicode"))
             .spawn()
-            .expect("Error: lading binary failed to spawn");
+            .expect("lading binary failed to spawn");
 
         // wait for lading to push some load. It will exit on its own.
         debug!("lading is running");

--- a/lading/src/bin/lading.rs
+++ b/lading/src/bin/lading.rs
@@ -80,13 +80,18 @@ impl FromStr for CliKeyValues {
         //
         // The approach taken here is to use the key notion as delimiter and
         // then tidy up afterward to find values.
-        static RE: Lazy<Regex> = Lazy::new(|| Regex::new(r"([[:alpha:]_]+)=").unwrap());
+        static RE: Lazy<Regex> = Lazy::new(|| {
+            Regex::new(r"([[:alpha:]_]+)=").expect("Error: Invalid regex pattern provided")
+        });
 
         let mut labels = FxHashMap::default();
 
         for cap in RE.captures_iter(input) {
             let key = cap[1].to_string();
-            let start = cap.get(0).unwrap().end();
+            let start = cap
+                .get(0)
+                .expect("Error: value 0 not found in Captures")
+                .end();
 
             // Find the next key or run into the end of the input.
             let end = RE.find_at(input, start).map_or(input.len(), |m| m.start());
@@ -208,7 +213,8 @@ fn get_config(ops: &Opts, config: Option<String>) -> Config {
                 panic!("Could not open configuration file at: {}", &ops.config_path)
             });
         let mut contents = String::new();
-        file.read_to_string(&mut contents).unwrap();
+        file.read_to_string(&mut contents)
+            .expect("Error: Data in contents is not valid utf-8");
 
         contents
     };
@@ -216,7 +222,8 @@ fn get_config(ops: &Opts, config: Option<String>) -> Config {
     let mut config: Config = serde_yaml::from_str(&contents).expect("invalid configuration file");
 
     if let Some(rss_bytes_limit) = ops.target_rss_bytes_limit {
-        target::Meta::set_rss_bytes_limit(rss_bytes_limit).unwrap();
+        target::Meta::set_rss_bytes_limit(rss_bytes_limit)
+            .expect("Error: rss_bytes_limit is greater than u64::MAX");
     }
     let target = if ops.no_target {
         None
@@ -245,12 +252,16 @@ fn get_config(ops: &Opts, config: Option<String>) -> Config {
     let options_global_labels = ops.global_labels.clone().unwrap_or_default();
     if let Some(ref prom_addr) = ops.prometheus_addr {
         config.telemetry = Telemetry::Prometheus {
-            prometheus_addr: prom_addr.parse().unwrap(),
+            prometheus_addr: prom_addr
+                .parse()
+                .expect("Error: Not possible to parse to SocketAddr"),
             global_labels: options_global_labels.inner,
         };
     } else if let Some(ref capture_path) = ops.capture_path {
         config.telemetry = Telemetry::Log {
-            path: capture_path.parse().unwrap(),
+            path: capture_path
+                .parse()
+                .expect("Error: Not possible to parse to PathBuf"),
             global_labels: options_global_labels.inner,
         };
     } else {
@@ -343,7 +354,8 @@ async fn inner_main(
     //
     for cfg in config.generator {
         let tgt_rcv = tgt_snd.subscribe();
-        let generator_server = generator::Server::new(cfg, shutdown.clone()).unwrap();
+        let generator_server = generator::Server::new(cfg, shutdown.clone())
+            .expect("Error: Underlying sub-server creation signals erro");
         gsrv_joinset.spawn(generator_server.run(tgt_rcv));
     }
 
@@ -353,8 +365,8 @@ async fn inner_main(
     if let Some(inspector_conf) = config.inspector {
         if !disable_inspector {
             let tgt_rcv = tgt_snd.subscribe();
-            let inspector_server =
-                inspector::Server::new(inspector_conf, shutdown.clone()).unwrap();
+            let inspector_server = inspector::Server::new(inspector_conf, shutdown.clone())
+                .expect("Error: Path is invalid or path is not executable by this program");
             let _isrv = tokio::spawn(inspector_server.run(tgt_rcv));
         }
     }
@@ -364,7 +376,8 @@ async fn inner_main(
     //
     if let Some(cfgs) = config.blackhole {
         for cfg in cfgs {
-            let blackhole_server = blackhole::Server::new(cfg, shutdown.clone()).unwrap();
+            let blackhole_server = blackhole::Server::new(cfg, shutdown.clone())
+                .expect("Error: Underlying sub-server creation signals error");
             let _bsrv = tokio::spawn(async {
                 match blackhole_server.run().await {
                     Ok(()) => debug!("blackhole shut down successfully"),
@@ -397,7 +410,8 @@ async fn inner_main(
     // Observer is not used when there is no target.
     if let Some(target) = config.target {
         let obs_rcv = tgt_snd.subscribe();
-        let observer_server = observer::Server::new(config.observer, shutdown.clone()).unwrap();
+        let observer_server = observer::Server::new(config.observer, shutdown.clone())
+            .expect("Error: Path is invalid or path is not executable by this program");
         let _osrv = tokio::spawn(observer_server.run(obs_rcv));
 
         //
@@ -484,7 +498,8 @@ fn run_process_tree(opts: ProcessTreeGen) {
             .open(&path)
             .unwrap_or_else(|_| panic!("Could not open configuration file at: {}", path.display()));
 
-        file.read_to_string(&mut contents).unwrap();
+        file.read_to_string(&mut contents)
+            .expect("Error: Data in contents is not valid utf-8");
     } else if let Some(str) = &opts.config_content {
         contents = str.to_string()
     } else {
@@ -542,7 +557,7 @@ fn main() -> Result<(), Error> {
         .enable_io()
         .enable_time()
         .build()
-        .unwrap();
+        .expect("Error: Failed to create runtime");
     let res = runtime.block_on(inner_main(
         experiment_duration,
         warmup_duration,
@@ -573,7 +588,7 @@ mod tests {
 generator: []
 "#;
 
-        let tmp_dir = tempfile::tempdir().unwrap();
+        let tmp_dir = tempfile::tempdir().expect("Error: directory could not be created");
         let capture_path = tmp_dir.path().join("capture");
         let capture_arg = format!("--capture-path={}", capture_path.display());
 
@@ -590,7 +605,8 @@ generator: []
 
         assert!(exit_code.is_ok());
 
-        let contents = std::fs::read_to_string(capture_path).unwrap();
+        let contents = std::fs::read_to_string(capture_path)
+            .expect("Error: File path does not already exist or does not contain valid utf-8");
         assert_eq!(contents.rmatches("lading.running").count(), 7);
     }
 
@@ -598,39 +614,67 @@ generator: []
     fn cli_key_values_deserializes_empty_string_to_empty_set() {
         let val = "";
         let deser = CliKeyValues::from_str(val);
-        let deser = deser.unwrap().to_string();
+        let deser = deser
+            .expect("Error: String could not be converted into valid CliKeyValues")
+            .to_string();
         assert_eq!("", deser);
     }
 
     #[test]
     fn cli_key_values_deserializes_kv_list() {
         let val = "first=one,second=two";
-        let deser = CliKeyValues::from_str(val);
-        let deser = deser.unwrap();
+        let deser = CliKeyValues::from_str(val)
+            .expect("Error: String cannot be converted into CliKeyValues");
 
-        assert_eq!(deser.get("first").unwrap(), "one");
-        assert_eq!(deser.get("second").unwrap(), "two");
+        assert_eq!(
+            deser.get("first").expect("Deser does not have key first"),
+            "one"
+        );
+        assert_eq!(
+            deser.get("second").expect("Deser does not have key second"),
+            "two"
+        );
     }
 
     #[test]
     fn cli_key_values_deserializes_trailing_comma_kv_list() {
         let val = "first=one,";
-        let deser = CliKeyValues::from_str(val);
-        let deser = deser.unwrap();
+        let deser = CliKeyValues::from_str(val)
+            .expect("Error: String cannot be converted into CliKeyValues");
 
-        assert_eq!(deser.get("first").unwrap(), "one");
+        assert_eq!(
+            deser
+                .get("first")
+                .expect("Error: Deser does not have key first"),
+            "one"
+        );
     }
 
     #[test]
     fn cli_key_values_deserializes_separated_value_kv_comma() {
         let val = "DD_API_KEY=00000001,DD_TELEMETRY_ENABLED=true,DD_TAGS=uqhwd:b2xiyw,hf9gy:uwcy04";
         let deser = CliKeyValues::from_str(val);
-        let deser = deser.unwrap();
+        let deser = deser.expect("Error: String cannot be converted into CliKeyValues");
 
         println!("RESULT: {deser}");
 
-        assert_eq!(deser.get("DD_API_KEY").unwrap(), "00000001");
-        assert_eq!(deser.get("DD_TELEMETRY_ENABLED").unwrap(), "true");
-        assert_eq!(deser.get("DD_TAGS").unwrap(), "uqhwd:b2xiyw,hf9gy:uwcy04");
+        assert_eq!(
+            deser
+                .get("DD_API_KEY")
+                .expect("Error: DD_API_KEY is not a valid key for the map"),
+            "00000001"
+        );
+        assert_eq!(
+            deser
+                .get("DD_TELEMETRY_ENABLED")
+                .expect("Error: DD_TELEMETRY_ENABLED is not a valid key for the map"),
+            "true"
+        );
+        assert_eq!(
+            deser
+                .get("DD_TAGS")
+                .expect("Error: DD_TAGS is not a valid key for the map"),
+            "uqhwd:b2xiyw,hf9gy:uwcy04"
+        );
     }
 }

--- a/lading/src/blackhole/http.rs
+++ b/lading/src/blackhole/http.rs
@@ -71,7 +71,7 @@ fn default_headers() -> HeaderMap {
         header::CONTENT_TYPE,
         "application/json"
             .parse()
-            .expect("Error: Not possible to parse into HeaderMap"),
+            .expect("Not possible to parse into HeaderMap"),
     );
     map
 }
@@ -188,7 +188,7 @@ impl Http {
                         record_id: "foobar".to_string(),
                     }],
                 };
-                serde_json::to_vec(&response).expect("Error: Unable to serialize response")
+                serde_json::to_vec(&response).expect("Unable to serialize response")
             }
             BodyVariant::Nothing => vec![],
             BodyVariant::RawBytes => config.raw_bytes.clone(),
@@ -276,14 +276,14 @@ mod tests {
 binding_addr: "127.0.0.1:1000"
 body_variant: "nothing"
 "#;
-        let config: Config = serde_yaml::from_str(contents)
-            .expect("Error: Contents do not match the structure expected");
+        let config: Config =
+            serde_yaml::from_str(contents).expect("Contents do not match the structure expected");
         assert_eq!(
             config,
             Config {
                 concurrent_requests_max: default_concurrent_requests_max(),
                 binding_addr: SocketAddr::from_str("127.0.0.1:1000")
-                    .expect("Error: Not possible to parse into SocketAddr"),
+                    .expect("Not possible to parse into SocketAddr"),
                 body_variant: BodyVariant::Nothing,
                 headers: default_headers(),
                 status: default_status_code(),
@@ -299,14 +299,14 @@ binding_addr: "127.0.0.1:1000"
 body_variant: "raw_bytes"
 raw_bytes: [0x01, 0x02, 0x10]
 "#;
-        let config: Config = serde_yaml::from_str(contents)
-            .expect("Error: Contents do not match the structure expected");
+        let config: Config =
+            serde_yaml::from_str(contents).expect("Contents do not match the structure expected");
         assert_eq!(
             config,
             Config {
                 concurrent_requests_max: default_concurrent_requests_max(),
                 binding_addr: SocketAddr::from_str("127.0.0.1:1000")
-                    .expect("Error: Not possible to parse into SocketAddr"),
+                    .expect("Not possible to parse into SocketAddr"),
                 body_variant: BodyVariant::RawBytes,
                 headers: default_headers(),
                 status: default_status_code(),

--- a/lading/src/blackhole/http.rs
+++ b/lading/src/blackhole/http.rs
@@ -67,7 +67,12 @@ fn default_status_code() -> u16 {
 
 fn default_headers() -> HeaderMap {
     let mut map = HeaderMap::new();
-    map.insert(header::CONTENT_TYPE, "application/json".parse().unwrap());
+    map.insert(
+        header::CONTENT_TYPE,
+        "application/json"
+            .parse()
+            .expect("Error: Not possible to parse into HeaderMap"),
+    );
     map
 }
 
@@ -183,7 +188,7 @@ impl Http {
                         record_id: "foobar".to_string(),
                     }],
                 };
-                serde_json::to_vec(&response).unwrap()
+                serde_json::to_vec(&response).expect("Error: Unable to serialize response")
             }
             BodyVariant::Nothing => vec![],
             BodyVariant::RawBytes => config.raw_bytes.clone(),
@@ -271,12 +276,14 @@ mod tests {
 binding_addr: "127.0.0.1:1000"
 body_variant: "nothing"
 "#;
-        let config: Config = serde_yaml::from_str(contents).unwrap();
+        let config: Config = serde_yaml::from_str(contents)
+            .expect("Error: Contents do not match the structure expected");
         assert_eq!(
             config,
             Config {
                 concurrent_requests_max: default_concurrent_requests_max(),
-                binding_addr: SocketAddr::from_str("127.0.0.1:1000").unwrap(),
+                binding_addr: SocketAddr::from_str("127.0.0.1:1000")
+                    .expect("Error: Not possible to parse into SocketAddr"),
                 body_variant: BodyVariant::Nothing,
                 headers: default_headers(),
                 status: default_status_code(),
@@ -292,12 +299,14 @@ binding_addr: "127.0.0.1:1000"
 body_variant: "raw_bytes"
 raw_bytes: [0x01, 0x02, 0x10]
 "#;
-        let config: Config = serde_yaml::from_str(contents).unwrap();
+        let config: Config = serde_yaml::from_str(contents)
+            .expect("Error: Contents do not match the structure expected");
         assert_eq!(
             config,
             Config {
                 concurrent_requests_max: default_concurrent_requests_max(),
-                binding_addr: SocketAddr::from_str("127.0.0.1:1000").unwrap(),
+                binding_addr: SocketAddr::from_str("127.0.0.1:1000")
+                    .expect("Error: Not possible to parse into SocketAddr"),
                 body_variant: BodyVariant::RawBytes,
                 headers: default_headers(),
                 status: default_status_code(),

--- a/lading/src/blackhole/splunk_hec.rs
+++ b/lading/src/blackhole/splunk_hec.rs
@@ -120,7 +120,7 @@ async fn srv(
                         code: 0,
                         ack_id,
                     })
-                    .expect("Error: Failed to serialize HecResponse");
+                    .expect("Failed to serialize HecResponse");
                     *okay.body_mut() = Body::from(body_bytes);
                 }
                 // Path for querying indexer acknowledgements
@@ -128,7 +128,7 @@ async fn srv(
                     match serde_json::from_slice::<HecAckRequest>(&body) {
                         Ok(ack_request) => {
                             let body_bytes = serde_json::to_vec(&HecAckResponse::from(ack_request))
-                                .expect("Error: Failed to serialize HecAckResponse");
+                                .expect("Failed to serialize HecAckResponse");
                             *okay.body_mut() = Body::from(body_bytes);
                         }
                         Err(_) => {

--- a/lading/src/blackhole/splunk_hec.rs
+++ b/lading/src/blackhole/splunk_hec.rs
@@ -120,15 +120,15 @@ async fn srv(
                         code: 0,
                         ack_id,
                     })
-                    .unwrap();
+                    .expect("Error: Failed to serialize HecResponse");
                     *okay.body_mut() = Body::from(body_bytes);
                 }
                 // Path for querying indexer acknowledgements
                 (Method::POST, "/services/collector/ack") => {
                     match serde_json::from_slice::<HecAckRequest>(&body) {
                         Ok(ack_request) => {
-                            let body_bytes =
-                                serde_json::to_vec(&HecAckResponse::from(ack_request)).unwrap();
+                            let body_bytes = serde_json::to_vec(&HecAckResponse::from(ack_request))
+                                .expect("Error: Failed to serialize HecAckResponse");
                             *okay.body_mut() = Body::from(body_bytes);
                         }
                         Err(_) => {

--- a/lading/src/blackhole/sqs.rs
+++ b/lading/src/blackhole/sqs.rs
@@ -258,21 +258,22 @@ async fn srv(
             .status(StatusCode::OK)
             .header("content-type", "text/html")
             .body(Body::from(generate_delete_message_response()))
-            .unwrap()),
+            .expect("Error: status, head, or body failed to parse for Delete Message")),
         "DeleteMessageBatch" => {
-            let action: DeleteMessageBatch = serde_qs::from_bytes(&bytes).unwrap();
+            let action: DeleteMessageBatch = serde_qs::from_bytes(&bytes)
+                .expect("Error: Failed to deserialize DeleteMessageBatch from bytes");
             Ok(Response::builder()
                 .status(StatusCode::OK)
                 .header("content-type", "text/html")
                 .body(Body::from(action.generate_response()))
-                .unwrap())
+                .expect("Error: status, head, or body failed to parse for Delete Message Batch"))
         }
         action => {
             debug!("Unknown action: {action:?}");
             Ok(Response::builder()
                 .status(StatusCode::NOT_IMPLEMENTED)
                 .body(Body::from(vec![]))
-                .unwrap())
+                .expect("Error: status or body failed to parse"))
         }
     }
 }

--- a/lading/src/blackhole/sqs.rs
+++ b/lading/src/blackhole/sqs.rs
@@ -113,7 +113,7 @@ impl Sqs {
                 addr.set_keepalive(Some(Duration::from_secs(60)));
                 addr
             })
-            .unwrap();
+            .expect("Error: Unable to bind to socket address provided");
         let server = Server::builder(addr).serve(svc);
         tokio::select! {
             res = server => {
@@ -241,17 +241,18 @@ async fn srv(
     let bytes = body::to_bytes(req).await?;
     bytes_received.increment(bytes.len() as u64);
 
-    let action: Action = serde_qs::from_bytes(&bytes).unwrap();
+    let action: Action = serde_qs::from_bytes(&bytes).expect("Error: Failed to deserialize Action");
 
     match action.action.as_str() {
         "ReceiveMessage" => {
-            let action: ReceiveMessage = serde_qs::from_bytes(&bytes).unwrap();
+            let action: ReceiveMessage =
+                serde_qs::from_bytes(&bytes).expect("Error: Failed to deserialize ReceiveMessage");
             let num_messages = action.max_number_of_messages;
             Ok(Response::builder()
                 .status(StatusCode::OK)
                 .header("content-type", "text/html")
                 .body(Body::from(generate_receive_message_response(num_messages)))
-                .unwrap())
+                .expect("Error: Failed to build response body"))
         }
         "DeleteMessage" => Ok(Response::builder()
             .status(StatusCode::OK)

--- a/lading/src/blackhole/sqs.rs
+++ b/lading/src/blackhole/sqs.rs
@@ -113,7 +113,7 @@ impl Sqs {
                 addr.set_keepalive(Some(Duration::from_secs(60)));
                 addr
             })
-            .expect("Error: Unable to bind to socket address provided");
+            .expect("Unable to bind to socket address provided");
         let server = Server::builder(addr).serve(svc);
         tokio::select! {
             res = server => {
@@ -241,39 +241,39 @@ async fn srv(
     let bytes = body::to_bytes(req).await?;
     bytes_received.increment(bytes.len() as u64);
 
-    let action: Action = serde_qs::from_bytes(&bytes).expect("Error: Failed to deserialize Action");
+    let action: Action = serde_qs::from_bytes(&bytes).expect("Failed to deserialize Action");
 
     match action.action.as_str() {
         "ReceiveMessage" => {
             let action: ReceiveMessage =
-                serde_qs::from_bytes(&bytes).expect("Error: Failed to deserialize ReceiveMessage");
+                serde_qs::from_bytes(&bytes).expect("Failed to deserialize ReceiveMessage");
             let num_messages = action.max_number_of_messages;
             Ok(Response::builder()
                 .status(StatusCode::OK)
                 .header("content-type", "text/html")
                 .body(Body::from(generate_receive_message_response(num_messages)))
-                .expect("Error: Failed to build response body"))
+                .expect("Failed to build response body"))
         }
         "DeleteMessage" => Ok(Response::builder()
             .status(StatusCode::OK)
             .header("content-type", "text/html")
             .body(Body::from(generate_delete_message_response()))
-            .expect("Error: status, head, or body failed to parse for Delete Message")),
+            .expect("status, head, or body failed to parse for Delete Message")),
         "DeleteMessageBatch" => {
             let action: DeleteMessageBatch = serde_qs::from_bytes(&bytes)
-                .expect("Error: Failed to deserialize DeleteMessageBatch from bytes");
+                .expect("Failed to deserialize DeleteMessageBatch from bytes");
             Ok(Response::builder()
                 .status(StatusCode::OK)
                 .header("content-type", "text/html")
                 .body(Body::from(action.generate_response()))
-                .expect("Error: status, head, or body failed to parse for Delete Message Batch"))
+                .expect("status, head, or body failed to parse for Delete Message Batch"))
         }
         action => {
             debug!("Unknown action: {action:?}");
             Ok(Response::builder()
                 .status(StatusCode::NOT_IMPLEMENTED)
                 .body(Body::from(vec![]))
-                .expect("Error: status or body failed to parse"))
+                .expect("status or body failed to parse"))
         }
     }
 }

--- a/lading/src/captures.rs
+++ b/lading/src/captures.rs
@@ -52,7 +52,9 @@ impl CaptureManager {
     ///
     /// Function will panic if the underlying capture file cannot be opened.
     pub async fn new(capture_path: PathBuf, shutdown: Phase, experiment_started: Phase) -> Self {
-        let fp = tokio::fs::File::create(&capture_path).await.unwrap();
+        let fp = tokio::fs::File::create(&capture_path)
+            .await
+            .expect("Error: create either called from outside tokio or create errored");
         let fp = fp.into_std().await;
         Self {
             run_id: Uuid::new_v4(),
@@ -77,7 +79,7 @@ impl CaptureManager {
         let recorder = CaptureRecorder {
             inner: Arc::clone(&self.inner),
         };
-        metrics::set_boxed_recorder(Box::new(recorder)).unwrap();
+        metrics::set_boxed_recorder(Box::new(recorder)).expect("Error: recorder already set");
     }
 
     /// Add a global label to all metrics managed by [`CaptureManager`].
@@ -92,7 +94,7 @@ impl CaptureManager {
     fn record_captures(&mut self) -> Result<(), io::Error> {
         let now_ms: u128 = SystemTime::now()
             .duration_since(UNIX_EPOCH)
-            .unwrap()
+            .expect("Error: UNIX_EPOCH is earlier than the provided time")
             .as_millis();
         let mut lines = Vec::new();
         self.inner
@@ -140,7 +142,7 @@ impl CaptureManager {
             self.capture_path
                 .file_name()
                 .and_then(OsStr::to_str)
-                .unwrap()
+                .expect("Error: capture path is not a valid file name")
         );
         for line in lines.drain(..) {
             let pyld = serde_json::to_string(&line)?;

--- a/lading/src/captures.rs
+++ b/lading/src/captures.rs
@@ -54,7 +54,7 @@ impl CaptureManager {
     pub async fn new(capture_path: PathBuf, shutdown: Phase, experiment_started: Phase) -> Self {
         let fp = tokio::fs::File::create(&capture_path)
             .await
-            .expect("Error: create either called from outside tokio or create errored");
+            .expect("create either called from outside tokio or create errored");
         let fp = fp.into_std().await;
         Self {
             run_id: Uuid::new_v4(),
@@ -79,7 +79,7 @@ impl CaptureManager {
         let recorder = CaptureRecorder {
             inner: Arc::clone(&self.inner),
         };
-        metrics::set_boxed_recorder(Box::new(recorder)).expect("Error: recorder already set");
+        metrics::set_boxed_recorder(Box::new(recorder)).expect("recorder already set");
     }
 
     /// Add a global label to all metrics managed by [`CaptureManager`].
@@ -94,7 +94,7 @@ impl CaptureManager {
     fn record_captures(&mut self) -> Result<(), io::Error> {
         let now_ms: u128 = SystemTime::now()
             .duration_since(UNIX_EPOCH)
-            .expect("Error: UNIX_EPOCH is earlier than the provided time")
+            .expect("UNIX_EPOCH is earlier than the provided time")
             .as_millis();
         let mut lines = Vec::new();
         self.inner
@@ -142,7 +142,7 @@ impl CaptureManager {
             self.capture_path
                 .file_name()
                 .and_then(OsStr::to_str)
-                .expect("Error: capture path is not a valid file name")
+                .expect("capture path is not a valid file name")
         );
         for line in lines.drain(..) {
             let pyld = serde_json::to_string(&line)?;

--- a/lading/src/common.rs
+++ b/lading/src/common.rs
@@ -56,7 +56,7 @@ pub(crate) fn stdio(behavior: &Behavior) -> Stdio {
     match behavior {
         Behavior::Quiet => Stdio::null(),
         Behavior::Log(path) => {
-            let fp = fs::File::create(path).expect("Error: Full directory path does not exist");
+            let fp = fs::File::create(path).expect("Full directory path does not exist");
             Stdio::from(fp)
         }
     }

--- a/lading/src/common.rs
+++ b/lading/src/common.rs
@@ -56,7 +56,7 @@ pub(crate) fn stdio(behavior: &Behavior) -> Stdio {
     match behavior {
         Behavior::Quiet => Stdio::null(),
         Behavior::Log(path) => {
-            let fp = fs::File::create(path).unwrap();
+            let fp = fs::File::create(path).expect("Error: Full directory path does not exist");
             Stdio::from(fp)
         }
     }

--- a/lading/src/config.rs
+++ b/lading/src/config.rs
@@ -64,7 +64,9 @@ pub enum Telemetry {
 impl Default for Telemetry {
     fn default() -> Self {
         Self::Prometheus {
-            prometheus_addr: "0.0.0.0:9000".parse().unwrap(),
+            prometheus_addr: "0.0.0.0:9000"
+                .parse()
+                .expect("Error: Not possible to parse to SocketAddr"),
             global_labels: FxHashMap::default(),
         }
     }
@@ -102,7 +104,8 @@ blackhole:
   - tcp:
       binding_addr: "127.0.0.1:1001"
 "#;
-        let config: Config = serde_yaml::from_str(contents).unwrap();
+        let config: Config = serde_yaml::from_str(contents)
+            .expect("Error: Contents do not match the structure expected");
         assert_eq!(
             config,
             Config {
@@ -112,14 +115,16 @@ blackhole:
                     },
                     inner: generator::Inner::Http(generator::http::Config {
                         seed: Default::default(),
-                        target_uri: "http://localhost:1000/".try_into().unwrap(),
+                        target_uri: "http://localhost:1000/"
+                            .try_into()
+                            .expect("Error: Failed to convert to to valid URI"),
                         method: generator::http::Method::Post {
                             variant: lading_payload::Config::Fluent,
                             maximum_prebuild_cache_size_bytes: byte_unit::Byte::from_unit(
                                 8_f64,
                                 byte_unit::ByteUnit::MB
                             )
-                            .unwrap(),
+                            .expect("Error: Value provided is negative"),
                             block_cache_method: block::CacheMethod::Fixed,
                         },
                         headers: HeaderMap::default(),
@@ -127,7 +132,7 @@ blackhole:
                             100_f64,
                             byte_unit::ByteUnit::MB
                         )
-                        .unwrap(),
+                        .expect("Error: Value provided is negative"),
                         block_sizes: Option::default(),
                         parallel_connections: 5,
                         throttle: lading_throttle::Config::default(),
@@ -139,13 +144,15 @@ blackhole:
                             id: Some(String::from("Data in"))
                         },
                         inner: blackhole::Inner::Tcp(blackhole::tcp::Config {
-                            binding_addr: SocketAddr::from_str("127.0.0.1:1000").unwrap(),
+                            binding_addr: SocketAddr::from_str("127.0.0.1:1000")
+                                .expect("Error: Failed to convert to valid SocketAddr"),
                         })
                     },
                     blackhole::Config {
                         general: blackhole::General { id: None },
                         inner: blackhole::Inner::Tcp(blackhole::tcp::Config {
-                            binding_addr: SocketAddr::from_str("127.0.0.1:1001").unwrap(),
+                            binding_addr: SocketAddr::from_str("127.0.0.1:1001")
+                                .expect("Error: Failed to convert to valid SocketAddr"),
                         })
                     },
                 ]),

--- a/lading/src/config.rs
+++ b/lading/src/config.rs
@@ -66,7 +66,7 @@ impl Default for Telemetry {
         Self::Prometheus {
             prometheus_addr: "0.0.0.0:9000"
                 .parse()
-                .expect("Error: Not possible to parse to SocketAddr"),
+                .expect("Not possible to parse to SocketAddr"),
             global_labels: FxHashMap::default(),
         }
     }
@@ -104,8 +104,8 @@ blackhole:
   - tcp:
       binding_addr: "127.0.0.1:1001"
 "#;
-        let config: Config = serde_yaml::from_str(contents)
-            .expect("Error: Contents do not match the structure expected");
+        let config: Config =
+            serde_yaml::from_str(contents).expect("Contents do not match the structure expected");
         assert_eq!(
             config,
             Config {
@@ -117,14 +117,14 @@ blackhole:
                         seed: Default::default(),
                         target_uri: "http://localhost:1000/"
                             .try_into()
-                            .expect("Error: Failed to convert to to valid URI"),
+                            .expect("Failed to convert to to valid URI"),
                         method: generator::http::Method::Post {
                             variant: lading_payload::Config::Fluent,
                             maximum_prebuild_cache_size_bytes: byte_unit::Byte::from_unit(
                                 8_f64,
                                 byte_unit::ByteUnit::MB
                             )
-                            .expect("Error: Value provided is negative"),
+                            .expect("Value provided is negative"),
                             block_cache_method: block::CacheMethod::Fixed,
                         },
                         headers: HeaderMap::default(),
@@ -132,7 +132,7 @@ blackhole:
                             100_f64,
                             byte_unit::ByteUnit::MB
                         )
-                        .expect("Error: Value provided is negative"),
+                        .expect("Value provided is negative"),
                         block_sizes: Option::default(),
                         parallel_connections: 5,
                         throttle: lading_throttle::Config::default(),
@@ -145,14 +145,14 @@ blackhole:
                         },
                         inner: blackhole::Inner::Tcp(blackhole::tcp::Config {
                             binding_addr: SocketAddr::from_str("127.0.0.1:1000")
-                                .expect("Error: Failed to convert to valid SocketAddr"),
+                                .expect("Failed to convert to valid SocketAddr"),
                         })
                     },
                     blackhole::Config {
                         general: blackhole::General { id: None },
                         inner: blackhole::Inner::Tcp(blackhole::tcp::Config {
                             binding_addr: SocketAddr::from_str("127.0.0.1:1001")
-                                .expect("Error: Failed to convert to valid SocketAddr"),
+                                .expect("Failed to convert to valid SocketAddr"),
                         })
                     },
                 ]),

--- a/lading/src/generator/file_gen/logrotate.rs
+++ b/lading/src/generator/file_gen/logrotate.rs
@@ -115,18 +115,12 @@ impl Server {
             .block_sizes
             .unwrap_or_else(|| {
                 vec![
-                    Byte::from_unit(1_f64, ByteUnit::MB)
-                        .expect("Error: Bytes must not be negative"),
-                    Byte::from_unit(2_f64, ByteUnit::MB)
-                        .expect("Error: Bytes must not be negative"),
-                    Byte::from_unit(4_f64, ByteUnit::MB)
-                        .expect("Error: Bytes must not be negative"),
-                    Byte::from_unit(8_f64, ByteUnit::MB)
-                        .expect("Error: Bytes must not be negative"),
-                    Byte::from_unit(16_f64, ByteUnit::MB)
-                        .expect("Error: Bytes must not be negative"),
-                    Byte::from_unit(32_f64, ByteUnit::MB)
-                        .expect("Error: Bytes must not be negative"),
+                    Byte::from_unit(1_f64, ByteUnit::MB).expect("Bytes must not be negative"),
+                    Byte::from_unit(2_f64, ByteUnit::MB).expect("Bytes must not be negative"),
+                    Byte::from_unit(4_f64, ByteUnit::MB).expect("Bytes must not be negative"),
+                    Byte::from_unit(8_f64, ByteUnit::MB).expect("Bytes must not be negative"),
+                    Byte::from_unit(16_f64, ByteUnit::MB).expect("Bytes must not be negative"),
+                    Byte::from_unit(32_f64, ByteUnit::MB).expect("Bytes must not be negative"),
                 ]
             })
             .iter()
@@ -150,7 +144,7 @@ impl Server {
 
         let maximum_bytes_per_file =
             NonZeroU32::new(config.maximum_bytes_per_log.get_bytes() as u32)
-                .expect("Error: Maximumm bytes per log must be non-zero");
+                .expect("Maximumm bytes per log must be non-zero");
 
         let mut handles = Vec::new();
 
@@ -276,10 +270,10 @@ impl Child {
         let last_name = &self
             .names
             .last()
-            .expect("Error: there is no last element in names");
+            .expect("there is no last element in names");
 
         // SAFETY: By construction the name is guaranteed to have a parent.
-        fs::create_dir_all(&self.names[0].parent().expect("Error: names has no parent")).await?;
+        fs::create_dir_all(&self.names[0].parent().expect("names has no parent")).await?;
         let mut fp = BufWriter::with_capacity(
             bytes_per_second,
             fs::OpenOptions::new()
@@ -301,12 +295,12 @@ impl Child {
         loop {
             // SAFETY: By construction the block cache will never be empty
             // except in the event of a catastrophic failure.
-            let blk = rcv.peek().await.expect("Error: block cache is empty");
+            let blk = rcv.peek().await.expect("block cache is empty");
             let total_bytes = blk.total_bytes;
 
             tokio::select! {
                 _ = self.throttle.wait_for(total_bytes) => {
-                    let blk = rcv.next().await.expect("Error: failed to advance through blocks"); // actually advance through the blocks
+                    let blk = rcv.next().await.expect("failed to advance through blocks"); // actually advance through the blocks
                     let total_bytes = u64::from(total_bytes.get());
 
                     {

--- a/lading/src/generator/file_gen/logrotate.rs
+++ b/lading/src/generator/file_gen/logrotate.rs
@@ -115,12 +115,18 @@ impl Server {
             .block_sizes
             .unwrap_or_else(|| {
                 vec![
-                    Byte::from_unit(1_f64, ByteUnit::MB).unwrap(),
-                    Byte::from_unit(2_f64, ByteUnit::MB).unwrap(),
-                    Byte::from_unit(4_f64, ByteUnit::MB).unwrap(),
-                    Byte::from_unit(8_f64, ByteUnit::MB).unwrap(),
-                    Byte::from_unit(16_f64, ByteUnit::MB).unwrap(),
-                    Byte::from_unit(32_f64, ByteUnit::MB).unwrap(),
+                    Byte::from_unit(1_f64, ByteUnit::MB)
+                        .expect("Error: Bytes must not be negative"),
+                    Byte::from_unit(2_f64, ByteUnit::MB)
+                        .expect("Error: Bytes must not be negative"),
+                    Byte::from_unit(4_f64, ByteUnit::MB)
+                        .expect("Error: Bytes must not be negative"),
+                    Byte::from_unit(8_f64, ByteUnit::MB)
+                        .expect("Error: Bytes must not be negative"),
+                    Byte::from_unit(16_f64, ByteUnit::MB)
+                        .expect("Error: Bytes must not be negative"),
+                    Byte::from_unit(32_f64, ByteUnit::MB)
+                        .expect("Error: Bytes must not be negative"),
                 ]
             })
             .iter()
@@ -134,7 +140,8 @@ impl Server {
             labels.push(("id".to_string(), id));
         }
 
-        let bytes_per_second = NonZeroU32::new(config.bytes_per_second.get_bytes() as u32).unwrap();
+        let bytes_per_second = NonZeroU32::new(config.bytes_per_second.get_bytes() as u32)
+            .expect("Expect: config bytes per second must be non-zero");
         gauge!(
             "bytes_per_second",
             f64::from(bytes_per_second.get()),
@@ -142,7 +149,8 @@ impl Server {
         );
 
         let maximum_bytes_per_file =
-            NonZeroU32::new(config.maximum_bytes_per_log.get_bytes() as u32).unwrap();
+            NonZeroU32::new(config.maximum_bytes_per_log.get_bytes() as u32)
+                .expect("Error: Maximumm bytes per log must be non-zero");
 
         let mut handles = Vec::new();
 
@@ -265,10 +273,13 @@ impl Child {
 
         let total_names = self.names.len();
         // SAFETY: By construction there is guaranteed to be at least one name.
-        let last_name = &self.names.last().unwrap();
+        let last_name = &self
+            .names
+            .last()
+            .expect("Error: there is no last element in names");
 
         // SAFETY: By construction the name is guaranteed to have a parent.
-        fs::create_dir_all(&self.names[0].parent().unwrap()).await?;
+        fs::create_dir_all(&self.names[0].parent().expect("Error: names has no parent")).await?;
         let mut fp = BufWriter::with_capacity(
             bytes_per_second,
             fs::OpenOptions::new()
@@ -290,12 +301,12 @@ impl Child {
         loop {
             // SAFETY: By construction the block cache will never be empty
             // except in the event of a catastrophic failure.
-            let blk = rcv.peek().await.unwrap();
+            let blk = rcv.peek().await.expect("Error: block cache is empty");
             let total_bytes = blk.total_bytes;
 
             tokio::select! {
                 _ = self.throttle.wait_for(total_bytes) => {
-                    let blk = rcv.next().await.unwrap(); // actually advance through the blocks
+                    let blk = rcv.next().await.expect("Error: failed to advance through blocks"); // actually advance through the blocks
                     let total_bytes = u64::from(total_bytes.get());
 
                     {

--- a/lading/src/generator/file_gen/traditional.rs
+++ b/lading/src/generator/file_gen/traditional.rs
@@ -135,12 +135,18 @@ impl Server {
             .block_sizes
             .unwrap_or_else(|| {
                 vec![
-                    Byte::from_unit(1_f64, ByteUnit::MB).unwrap(),
-                    Byte::from_unit(2_f64, ByteUnit::MB).unwrap(),
-                    Byte::from_unit(4_f64, ByteUnit::MB).unwrap(),
-                    Byte::from_unit(8_f64, ByteUnit::MB).unwrap(),
-                    Byte::from_unit(16_f64, ByteUnit::MB).unwrap(),
-                    Byte::from_unit(32_f64, ByteUnit::MB).unwrap(),
+                    Byte::from_unit(1_f64, ByteUnit::MB)
+                        .expect("Error: Bytes must not be negative"),
+                    Byte::from_unit(2_f64, ByteUnit::MB)
+                        .expect("Error: Bytes must not be negative"),
+                    Byte::from_unit(4_f64, ByteUnit::MB)
+                        .expect("Error: Bytes must not be negative"),
+                    Byte::from_unit(8_f64, ByteUnit::MB)
+                        .expect("Error: Bytes must not be negative"),
+                    Byte::from_unit(16_f64, ByteUnit::MB)
+                        .expect("Error: Bytes must not be negative"),
+                    Byte::from_unit(32_f64, ByteUnit::MB)
+                        .expect("Error: Bytes must not be negative"),
                 ]
             })
             .iter()
@@ -154,7 +160,8 @@ impl Server {
             labels.push(("id".to_string(), id));
         }
 
-        let bytes_per_second = NonZeroU32::new(config.bytes_per_second.get_bytes() as u32).unwrap();
+        let bytes_per_second = NonZeroU32::new(config.bytes_per_second.get_bytes() as u32)
+            .expect("Error: config bytes must be non-zero");
         gauge!(
             "bytes_per_second",
             f64::from(bytes_per_second.get()),
@@ -162,7 +169,8 @@ impl Server {
         );
 
         let maximum_bytes_per_file =
-            NonZeroU32::new(config.maximum_bytes_per_file.get_bytes() as u32).unwrap();
+            NonZeroU32::new(config.maximum_bytes_per_file.get_bytes() as u32)
+                .expect("Error: config maximum bytes per file must be non-zero");
 
         let mut handles = Vec::new();
         let file_index = Arc::new(AtomicU32::new(0));
@@ -267,12 +275,12 @@ impl Child {
         let bytes_written = register_counter!("bytes_written");
 
         loop {
-            let blk = rcv.peek().await.unwrap();
+            let blk = rcv.peek().await.expect("Error: block cache is empty");
             let total_bytes = blk.total_bytes;
 
             tokio::select! {
                 _ = self.throttle.wait_for(total_bytes) => {
-                    let blk = rcv.next().await.unwrap(); // actually advance through the blocks
+                    let blk = rcv.next().await.expect("Error: failed to advance through the blocks"); // actually advance through the blocks
                     let total_bytes = u64::from(total_bytes.get());
 
                     {

--- a/lading/src/generator/file_gen/traditional.rs
+++ b/lading/src/generator/file_gen/traditional.rs
@@ -135,18 +135,12 @@ impl Server {
             .block_sizes
             .unwrap_or_else(|| {
                 vec![
-                    Byte::from_unit(1_f64, ByteUnit::MB)
-                        .expect("Error: Bytes must not be negative"),
-                    Byte::from_unit(2_f64, ByteUnit::MB)
-                        .expect("Error: Bytes must not be negative"),
-                    Byte::from_unit(4_f64, ByteUnit::MB)
-                        .expect("Error: Bytes must not be negative"),
-                    Byte::from_unit(8_f64, ByteUnit::MB)
-                        .expect("Error: Bytes must not be negative"),
-                    Byte::from_unit(16_f64, ByteUnit::MB)
-                        .expect("Error: Bytes must not be negative"),
-                    Byte::from_unit(32_f64, ByteUnit::MB)
-                        .expect("Error: Bytes must not be negative"),
+                    Byte::from_unit(1_f64, ByteUnit::MB).expect("Bytes must not be negative"),
+                    Byte::from_unit(2_f64, ByteUnit::MB).expect("Bytes must not be negative"),
+                    Byte::from_unit(4_f64, ByteUnit::MB).expect("Bytes must not be negative"),
+                    Byte::from_unit(8_f64, ByteUnit::MB).expect("Bytes must not be negative"),
+                    Byte::from_unit(16_f64, ByteUnit::MB).expect("Bytes must not be negative"),
+                    Byte::from_unit(32_f64, ByteUnit::MB).expect("Bytes must not be negative"),
                 ]
             })
             .iter()
@@ -161,7 +155,7 @@ impl Server {
         }
 
         let bytes_per_second = NonZeroU32::new(config.bytes_per_second.get_bytes() as u32)
-            .expect("Error: config bytes must be non-zero");
+            .expect("config bytes must be non-zero");
         gauge!(
             "bytes_per_second",
             f64::from(bytes_per_second.get()),
@@ -170,7 +164,7 @@ impl Server {
 
         let maximum_bytes_per_file =
             NonZeroU32::new(config.maximum_bytes_per_file.get_bytes() as u32)
-                .expect("Error: config maximum bytes per file must be non-zero");
+                .expect("config maximum bytes per file must be non-zero");
 
         let mut handles = Vec::new();
         let file_index = Arc::new(AtomicU32::new(0));
@@ -275,12 +269,12 @@ impl Child {
         let bytes_written = register_counter!("bytes_written");
 
         loop {
-            let blk = rcv.peek().await.expect("Error: block cache is empty");
+            let blk = rcv.peek().await.expect("block cache is empty");
             let total_bytes = blk.total_bytes;
 
             tokio::select! {
                 _ = self.throttle.wait_for(total_bytes) => {
-                    let blk = rcv.next().await.expect("Error: failed to advance through the blocks"); // actually advance through the blocks
+                    let blk = rcv.next().await.expect("failed to advance through the blocks"); // actually advance through the blocks
                     let total_bytes = u64::from(total_bytes.get());
 
                     {

--- a/lading/src/generator/file_tree.rs
+++ b/lading/src/generator/file_tree.rs
@@ -48,31 +48,31 @@ impl From<::std::io::Error> for Error {
 }
 
 fn default_max_depth() -> NonZeroUsize {
-    NonZeroUsize::new(10).expect("Error: default max depth given was 0")
+    NonZeroUsize::new(10).expect("default max depth given was 0")
 }
 
 fn default_max_sub_folders() -> NonZeroU32 {
-    NonZeroU32::new(5).expect("Error: default max sub folders given was 0")
+    NonZeroU32::new(5).expect("default max sub folders given was 0")
 }
 
 fn default_max_files() -> NonZeroU32 {
-    NonZeroU32::new(5).expect("Error: default max files given was 0")
+    NonZeroU32::new(5).expect("default max files given was 0")
 }
 
 fn default_max_nodes() -> NonZeroUsize {
-    NonZeroUsize::new(100).expect("Error: default max nodes given was 0")
+    NonZeroUsize::new(100).expect("default max nodes given was 0")
 }
 
 fn default_name_len() -> NonZeroUsize {
-    NonZeroUsize::new(8).expect("Error: default name len given was 0")
+    NonZeroUsize::new(8).expect("default name len given was 0")
 }
 
 fn default_open_per_second() -> NonZeroU32 {
-    NonZeroU32::new(8).expect("Error: default open per second given was 0")
+    NonZeroU32::new(8).expect("default open per second given was 0")
 }
 
 fn default_rename_per_name() -> NonZeroU32 {
-    NonZeroU32::new(1).expect("Error: default rename per second given was 0")
+    NonZeroU32::new(1).expect("default rename per second given was 0")
 }
 
 #[derive(Debug, Deserialize, PartialEq, Clone)]
@@ -173,7 +173,7 @@ impl FileTree {
         loop {
             tokio::select! {
                 _ = self.open_throttle.wait() => {
-                    let node = iter.next().expect("Error: next failed, node path already finished");
+                    let node = iter.next().expect("next failed, node path already finished");
                     if node.exists() {
                         File::open(node.as_path()).await?;
                     } else {
@@ -224,7 +224,7 @@ fn generate_tree(rng: &mut StdRng, config: &Config) -> (VecDeque<PathBuf>, usize
 
                 let curr_depth = node
                     .to_str()
-                    .expect("Error: node is invalid unicode and could not convert to str")
+                    .expect("node is invalid unicode and could not convert to str")
                     .matches(path::MAIN_SEPARATOR)
                     .count()
                     - root_depth;
@@ -250,7 +250,7 @@ fn generate_tree(rng: &mut StdRng, config: &Config) -> (VecDeque<PathBuf>, usize
 
 #[inline]
 async fn rename_folder(rng: &mut StdRng, folder: &Path, len: usize) -> Result<(), Error> {
-    let parent = PathBuf::from(folder.parent().expect("Error: folder has no parent"));
+    let parent = PathBuf::from(folder.parent().expect("folder has no parent"));
     let dir = rnd_node_name(rng, &parent, len);
 
     // rename twice to keep the original folder name so that future file access

--- a/lading/src/generator/file_tree.rs
+++ b/lading/src/generator/file_tree.rs
@@ -48,31 +48,31 @@ impl From<::std::io::Error> for Error {
 }
 
 fn default_max_depth() -> NonZeroUsize {
-    NonZeroUsize::new(10).unwrap()
+    NonZeroUsize::new(10).expect("Error: default max depth given was 0")
 }
 
 fn default_max_sub_folders() -> NonZeroU32 {
-    NonZeroU32::new(5).unwrap()
+    NonZeroU32::new(5).expect("Error: default max sub folders given was 0")
 }
 
 fn default_max_files() -> NonZeroU32 {
-    NonZeroU32::new(5).unwrap()
+    NonZeroU32::new(5).expect("Error: default max files given was 0")
 }
 
 fn default_max_nodes() -> NonZeroUsize {
-    NonZeroUsize::new(100).unwrap()
+    NonZeroUsize::new(100).expect("Error: default max nodes given was 0")
 }
 
 fn default_name_len() -> NonZeroUsize {
-    NonZeroUsize::new(8).unwrap()
+    NonZeroUsize::new(8).expect("Error: default name len given was 0")
 }
 
 fn default_open_per_second() -> NonZeroU32 {
-    NonZeroU32::new(8).unwrap()
+    NonZeroU32::new(8).expect("Error: default open per second given was 0")
 }
 
 fn default_rename_per_name() -> NonZeroU32 {
-    NonZeroU32::new(1).unwrap()
+    NonZeroU32::new(1).expect("Error: default rename per second given was 0")
 }
 
 #[derive(Debug, Deserialize, PartialEq, Clone)]
@@ -173,7 +173,7 @@ impl FileTree {
         loop {
             tokio::select! {
                 _ = self.open_throttle.wait() => {
-                    let node = iter.next().unwrap();
+                    let node = iter.next().expect("Error: next failed, node path already finished");
                     if node.exists() {
                         File::open(node.as_path()).await?;
                     } else {
@@ -222,8 +222,12 @@ fn generate_tree(rng: &mut StdRng, config: &Config) -> (VecDeque<PathBuf>, usize
                     }
                 }
 
-                let curr_depth =
-                    node.to_str().unwrap().matches(path::MAIN_SEPARATOR).count() - root_depth;
+                let curr_depth = node
+                    .to_str()
+                    .expect("Error: node is invalid unicode and could not convert to str")
+                    .matches(path::MAIN_SEPARATOR)
+                    .count()
+                    - root_depth;
 
                 // generate sub folders
                 if curr_depth < config.max_depth.get() {
@@ -246,7 +250,7 @@ fn generate_tree(rng: &mut StdRng, config: &Config) -> (VecDeque<PathBuf>, usize
 
 #[inline]
 async fn rename_folder(rng: &mut StdRng, folder: &Path, len: usize) -> Result<(), Error> {
-    let parent = PathBuf::from(folder.parent().unwrap());
+    let parent = PathBuf::from(folder.parent().expect("Error: folder has no parent"));
     let dir = rnd_node_name(rng, &parent, len);
 
     // rename twice to keep the original folder name so that future file access

--- a/lading/src/generator/grpc.rs
+++ b/lading/src/generator/grpc.rs
@@ -160,22 +160,14 @@ impl Grpc {
             .clone()
             .unwrap_or_else(|| {
                 vec![
-                    Byte::from_unit(1.0 / 32.0, ByteUnit::MB)
-                        .expect("Error: bytes must not be negative"),
-                    Byte::from_unit(1.0 / 16.0, ByteUnit::MB)
-                        .expect("Error: bytes must not be negative"),
-                    Byte::from_unit(1.0 / 8.0, ByteUnit::MB)
-                        .expect("Error: bytes must not be negative"),
-                    Byte::from_unit(1.0 / 4.0, ByteUnit::MB)
-                        .expect("Error: bytes must not be negative"),
-                    Byte::from_unit(1.0 / 2.0, ByteUnit::MB)
-                        .expect("Error: bytes must not be negative"),
-                    Byte::from_unit(1_f64, ByteUnit::MB)
-                        .expect("Error: bytes must not be negative"),
-                    Byte::from_unit(2_f64, ByteUnit::MB)
-                        .expect("Error: bytes must not be negative"),
-                    Byte::from_unit(4_f64, ByteUnit::MB)
-                        .expect("Error: bytes must not be negative"),
+                    Byte::from_unit(1.0 / 32.0, ByteUnit::MB).expect("bytes must not be negative"),
+                    Byte::from_unit(1.0 / 16.0, ByteUnit::MB).expect("bytes must not be negative"),
+                    Byte::from_unit(1.0 / 8.0, ByteUnit::MB).expect("bytes must not be negative"),
+                    Byte::from_unit(1.0 / 4.0, ByteUnit::MB).expect("bytes must not be negative"),
+                    Byte::from_unit(1.0 / 2.0, ByteUnit::MB).expect("bytes must not be negative"),
+                    Byte::from_unit(1_f64, ByteUnit::MB).expect("bytes must not be negative"),
+                    Byte::from_unit(2_f64, ByteUnit::MB).expect("bytes must not be negative"),
+                    Byte::from_unit(4_f64, ByteUnit::MB).expect("bytes must not be negative"),
                 ]
             })
             .iter()
@@ -190,7 +182,7 @@ impl Grpc {
         }
 
         let bytes_per_second = NonZeroU32::new(config.bytes_per_second.get_bytes() as u32)
-            .expect("Error: configu bytes per second must be non-zero");
+            .expect("configu bytes per second must be non-zero");
         gauge!(
             "bytes_per_second",
             f64::from(bytes_per_second.get()),
@@ -235,7 +227,7 @@ impl Grpc {
     async fn connect(&self) -> Result<tonic::client::Grpc<tonic::transport::Channel>, Error> {
         let mut parts = self.target_uri.clone().into_parts();
         parts.path_and_query = Some(PathAndQuery::from_static(""));
-        let uri = Uri::from_parts(parts).expect("Error: failed to convert parts into uri");
+        let uri = Uri::from_parts(parts).expect("failed to convert parts into uri");
 
         let endpoint = tonic::transport::Endpoint::new(uri)?;
         let endpoint = endpoint.concurrency_limit(self.config.parallel_connections as usize);
@@ -298,17 +290,14 @@ impl Grpc {
         let response_bytes = register_counter!("response_bytes", &self.metric_labels);
 
         loop {
-            let blk = rcv
-                .peek()
-                .await
-                .expect("Error: block cache should never be empty");
+            let blk = rcv.peek().await.expect("block cache should never be empty");
             let total_bytes = blk.total_bytes;
 
             tokio::select! {
                 _ = self.throttle.wait_for(total_bytes) => {
                     let block_length = blk.bytes.len();
                     requests_sent.increment(1);
-                    let blk = rcv.next().await.expect("Error: there is no next block in rcv"); // actually advance through the blocks
+                    let blk = rcv.next().await.expect("there is no next block in rcv"); // actually advance through the blocks
                     let res = Self::req(
                         &mut client,
                         rpc_path.clone(),

--- a/lading/src/generator/grpc.rs
+++ b/lading/src/generator/grpc.rs
@@ -161,18 +161,21 @@ impl Grpc {
             .unwrap_or_else(|| {
                 vec![
                     Byte::from_unit(1.0 / 32.0, ByteUnit::MB)
-                        .expect("Error: bytes must be non-zero"),
+                        .expect("Error: bytes must not be negative"),
                     Byte::from_unit(1.0 / 16.0, ByteUnit::MB)
-                        .expect("Error: bytes must be non-zero"),
+                        .expect("Error: bytes must not be negative"),
                     Byte::from_unit(1.0 / 8.0, ByteUnit::MB)
-                        .expect("Error: bytes must be non-zero"),
+                        .expect("Error: bytes must not be negative"),
                     Byte::from_unit(1.0 / 4.0, ByteUnit::MB)
-                        .expect("Error: bytes must be non-zero"),
+                        .expect("Error: bytes must not be negative"),
                     Byte::from_unit(1.0 / 2.0, ByteUnit::MB)
-                        .expect("Error: bytes must be non-zero"),
-                    Byte::from_unit(1_f64, ByteUnit::MB).expect("Error: bytes must be non-zero"),
-                    Byte::from_unit(2_f64, ByteUnit::MB).expect("Error: bytes must be non-zero"),
-                    Byte::from_unit(4_f64, ByteUnit::MB).expect("Error: bytes must be non-zero"),
+                        .expect("Error: bytes must not be negative"),
+                    Byte::from_unit(1_f64, ByteUnit::MB)
+                        .expect("Error: bytes must not be negative"),
+                    Byte::from_unit(2_f64, ByteUnit::MB)
+                        .expect("Error: bytes must not be negative"),
+                    Byte::from_unit(4_f64, ByteUnit::MB)
+                        .expect("Error: bytes must not be negative"),
                 ]
             })
             .iter()

--- a/lading/src/generator/http.rs
+++ b/lading/src/generator/http.rs
@@ -127,12 +127,18 @@ impl Http {
             .block_sizes
             .unwrap_or_else(|| {
                 vec![
-                    Byte::from_unit(1.0 / 8.0, ByteUnit::MB).unwrap(),
-                    Byte::from_unit(1.0 / 4.0, ByteUnit::MB).unwrap(),
-                    Byte::from_unit(1.0 / 2.0, ByteUnit::MB).unwrap(),
-                    Byte::from_unit(1_f64, ByteUnit::MB).unwrap(),
-                    Byte::from_unit(2_f64, ByteUnit::MB).unwrap(),
-                    Byte::from_unit(4_f64, ByteUnit::MB).unwrap(),
+                    Byte::from_unit(1.0 / 8.0, ByteUnit::MB)
+                        .expect("Error: Bytes must not be negative"),
+                    Byte::from_unit(1.0 / 4.0, ByteUnit::MB)
+                        .expect("Error: Bytes must not be negative"),
+                    Byte::from_unit(1.0 / 2.0, ByteUnit::MB)
+                        .expect("Error: Bytes must not be negative"),
+                    Byte::from_unit(1_f64, ByteUnit::MB)
+                        .expect("Error: Bytes must not be negative"),
+                    Byte::from_unit(2_f64, ByteUnit::MB)
+                        .expect("Error: Bytes must not be negative"),
+                    Byte::from_unit(4_f64, ByteUnit::MB)
+                        .expect("Error: Bytes must not be negative"),
                 ]
             })
             .iter()
@@ -146,7 +152,8 @@ impl Http {
             labels.push(("id".to_string(), id));
         }
 
-        let bytes_per_second = NonZeroU32::new(config.bytes_per_second.get_bytes() as u32).unwrap();
+        let bytes_per_second = NonZeroU32::new(config.bytes_per_second.get_bytes() as u32)
+            .expect("Error: config bytes per second must be non-zero");
         gauge!(
             "bytes_per_second",
             f64::from(bytes_per_second.get()),
@@ -176,7 +183,7 @@ impl Http {
 
                 CONNECTION_SEMAPHORE
                     .set(Semaphore::new(config.parallel_connections as usize))
-                    .unwrap();
+                    .expect("Error: failed to set semaphore");
 
                 Ok(Self {
                     parallel_connections: config.parallel_connections,
@@ -220,7 +227,7 @@ impl Http {
         thread::Builder::new().spawn(|| block_cache.spin(snd))?;
 
         loop {
-            let blk = rcv.next().await.unwrap();
+            let blk = rcv.next().await.expect("Error: block cache closed");
             let total_bytes = blk.total_bytes;
 
             let body = Body::from(blk.bytes.clone());
@@ -231,7 +238,7 @@ impl Http {
                 .uri(&uri)
                 .header(CONTENT_LENGTH, block_length)
                 .body(body)
-                .unwrap();
+                .expect("Error: failed to build request");
             let headers = request.headers_mut();
             for (k, v) in self.headers.clone().drain() {
                 if let Some(k) = k {
@@ -244,7 +251,7 @@ impl Http {
                     let client = client.clone();
                     let labels = labels.clone();
 
-                    let permit = CONNECTION_SEMAPHORE.get().unwrap().acquire().await.unwrap();
+                    let permit = CONNECTION_SEMAPHORE.get().expect("Error: Connection Semaphore is being initialized or cell is empty").acquire().await.expect("Error: Connection Semaphore has already closed");
                     tokio::spawn(async move {
                         counter!("requests_sent", 1, &labels);
                         match client.request(request).await {
@@ -269,7 +276,7 @@ impl Http {
                     info!("shutdown signal received");
                     // Acquire all available connections, meaning that we have
                     // no outstanding tasks in flight.
-                    let _semaphore = CONNECTION_SEMAPHORE.get().unwrap().acquire_many(u32::from(self.parallel_connections)).await.unwrap();
+                    let _semaphore = CONNECTION_SEMAPHORE.get().expect("Error: Connection Semaphore is being initialized or cell is empty").acquire_many(u32::from(self.parallel_connections)).await.expect("Error: Connection Semaphore has already closed");
                     return Ok(());
                 },
             }

--- a/lading/src/generator/process_tree.rs
+++ b/lading/src/generator/process_tree.rs
@@ -83,36 +83,36 @@ pub enum Error {
 }
 
 fn default_max_depth() -> NonZeroU32 {
-    NonZeroU32::new(10).expect("Error: default max depth given was 0")
+    NonZeroU32::new(10).expect("default max depth given was 0")
 }
 
 fn default_max_tree_per_second() -> NonZeroU32 {
-    NonZeroU32::new(5).expect("Error: default max tree per second given was 0")
+    NonZeroU32::new(5).expect("default max tree per second given was 0")
 }
 
 // default to 100ms
 fn default_process_sleep_ns() -> NonZeroU32 {
-    NonZeroU32::new(100_000_000).expect("Error: default process sleep ns given was 0")
+    NonZeroU32::new(100_000_000).expect("default process sleep ns given was 0")
 }
 
 fn default_max_children() -> NonZeroU32 {
-    NonZeroU32::new(10).expect("Error: default max children given was 0")
+    NonZeroU32::new(10).expect("default max children given was 0")
 }
 
 fn default_args_len() -> NonZeroUsize {
-    NonZeroUsize::new(10).expect("Error: default args len given was 0")
+    NonZeroUsize::new(10).expect("default args len given was 0")
 }
 
 fn default_args_count() -> NonZeroU32 {
-    NonZeroU32::new(16).expect("Error: default args count given was 0")
+    NonZeroU32::new(16).expect("default args count given was 0")
 }
 
 fn default_envs_len() -> NonZeroUsize {
-    NonZeroUsize::new(16).expect("Error: default envs len given was 0")
+    NonZeroUsize::new(16).expect("default envs len given was 0")
 }
 
 fn default_envs_count() -> NonZeroU32 {
-    NonZeroU32::new(10).expect("Error: default envs count given was 0")
+    NonZeroU32::new(10).expect("default envs count given was 0")
 }
 
 #[derive(Debug, Serialize, Deserialize, PartialEq, Clone)]
@@ -305,10 +305,7 @@ impl ProcessTree {
     /// Panic if the lading path can't determine.
     ///
     pub async fn spin(mut self) -> Result<(), Error> {
-        let lading_path = self
-            .lading_path
-            .to_str()
-            .expect("Error: lading path is not utf8");
+        let lading_path = self.lading_path.to_str().expect("lading path is not utf8");
 
         loop {
             tokio::select! {
@@ -320,12 +317,12 @@ impl ProcessTree {
                         .arg("--config-content")
                         .arg(&self.config_content)
                         .stdin(Stdio::null())
-                        .output().await.expect("Error: process tree generator failed to spawn");
+                        .output().await.expect("process tree generator failed to spawn");
 
                     if !output.status.success() {
                         error!("process tree generator execution error");
                         return Err(Error::from(ExecutionError {
-                            stderr: str::from_utf8(&output.stderr).expect("Error: The slice is not utf-8").to_string()
+                            stderr: str::from_utf8(&output.stderr).expect("The slice is not utf-8").to_string()
                         }));
                     }
                 },
@@ -381,7 +378,7 @@ impl Exec {
         let exec = config
             .executables
             .choose(rng)
-            .expect("Error: the rng slice is empty");
+            .expect("the rng slice is empty");
 
         let args = match &exec.args {
             Args::Static(params) => params.values.clone(),
@@ -397,7 +394,7 @@ impl Exec {
             executable: exec
                 .executable
                 .to_str()
-                .expect("Error: exec executable could not be converted to str")
+                .expect("exec executable could not be converted to str")
                 .to_string(),
             args,
             envs,
@@ -450,7 +447,7 @@ pub fn spawn_tree(nodes: &VecDeque<Process>, sleep_ns: u32) {
 
         let process = iter
             .next()
-            .expect("Error: next failed, iteration has already finished");
+            .expect("next failed, iteration has already finished");
 
         if let Some(exec) = &process.exec {
             let status = std::process::Command::new(&exec.executable)
@@ -459,8 +456,8 @@ pub fn spawn_tree(nodes: &VecDeque<Process>, sleep_ns: u32) {
                 .stdout(Stdio::null())
                 .stderr(Stdio::null())
                 .status()
-                .expect("Error: failed to execute process");
-            exit(status.code().expect("Error: failed to get exit code"));
+                .expect("failed to execute process");
+            exit(status.code().expect("failed to get exit code"));
         }
 
         match unsafe { fork() } {

--- a/lading/src/generator/process_tree.rs
+++ b/lading/src/generator/process_tree.rs
@@ -459,7 +459,6 @@ pub fn spawn_tree(nodes: &VecDeque<Process>, sleep_ns: u32) {
                 .stdout(Stdio::null())
                 .stderr(Stdio::null())
                 .status()
-                .ok()
                 .expect("Error: failed to execute process");
             exit(status.code().expect("Error: failed to get exit code"));
         }

--- a/lading/src/generator/procfs.rs
+++ b/lading/src/generator/procfs.rs
@@ -32,8 +32,9 @@ pub enum Error {
 
 fn default_copy_from_host() -> Vec<PathBuf> {
     vec![
-        PathBuf::from_str("/proc/uptime").unwrap(),
-        PathBuf::from_str("/proc/stat").unwrap(),
+        PathBuf::from_str("/proc/uptime")
+            .expect("Error: failed to convert /proc/uptime to PathBuf"),
+        PathBuf::from_str("/proc/stat").expect("Error: failed to convert /proc/stat to PathBuf"),
     ]
 }
 
@@ -140,7 +141,7 @@ impl ProcFs {
         }
 
         // SAFETY: By construction this pathbuf cannot fail to be created.
-        let prefix = PathBuf::from_str("/proc").unwrap();
+        let prefix = PathBuf::from_str("/proc").expect("Error: failed to convert /proc to PathBuf");
 
         for path in &config.copy_from_host {
             let base = path.strip_prefix(&prefix)?;

--- a/lading/src/generator/procfs.rs
+++ b/lading/src/generator/procfs.rs
@@ -32,9 +32,8 @@ pub enum Error {
 
 fn default_copy_from_host() -> Vec<PathBuf> {
     vec![
-        PathBuf::from_str("/proc/uptime")
-            .expect("Error: failed to convert /proc/uptime to PathBuf"),
-        PathBuf::from_str("/proc/stat").expect("Error: failed to convert /proc/stat to PathBuf"),
+        PathBuf::from_str("/proc/uptime").expect("failed to convert /proc/uptime to PathBuf"),
+        PathBuf::from_str("/proc/stat").expect("failed to convert /proc/stat to PathBuf"),
     ]
 }
 
@@ -141,7 +140,7 @@ impl ProcFs {
         }
 
         // SAFETY: By construction this pathbuf cannot fail to be created.
-        let prefix = PathBuf::from_str("/proc").expect("Error: failed to convert /proc to PathBuf");
+        let prefix = PathBuf::from_str("/proc").expect("failed to convert /proc to PathBuf");
 
         for path in &config.copy_from_host {
             let base = path.strip_prefix(&prefix)?;

--- a/lading/src/generator/splunk_hec.rs
+++ b/lading/src/generator/splunk_hec.rs
@@ -131,11 +131,16 @@ fn get_uri_by_format(base_uri: &Uri, format: lading_payload::splunk_hec::Encodin
     };
 
     Uri::builder()
-        .authority(base_uri.authority().unwrap().to_string())
+        .authority(
+            base_uri
+                .authority()
+                .expect("Error: base uri authority is empty")
+                .to_string(),
+        )
         .scheme("http")
         .path_and_query(path)
         .build()
-        .unwrap()
+        .expect("Error: unable to build URI")
 }
 
 impl SplunkHec {
@@ -156,12 +161,18 @@ impl SplunkHec {
             .block_sizes
             .unwrap_or_else(|| {
                 vec![
-                    Byte::from_unit(1.0 / 8.0, ByteUnit::MB).unwrap(),
-                    Byte::from_unit(1.0 / 4.0, ByteUnit::MB).unwrap(),
-                    Byte::from_unit(1.0 / 2.0, ByteUnit::MB).unwrap(),
-                    Byte::from_unit(1_f64, ByteUnit::MB).unwrap(),
-                    Byte::from_unit(2_f64, ByteUnit::MB).unwrap(),
-                    Byte::from_unit(4_f64, ByteUnit::MB).unwrap(),
+                    Byte::from_unit(1.0 / 8.0, ByteUnit::MB)
+                        .expect("Error: Bytes must not be negative"),
+                    Byte::from_unit(1.0 / 4.0, ByteUnit::MB)
+                        .expect("Error: Bytes must not be negative"),
+                    Byte::from_unit(1.0 / 2.0, ByteUnit::MB)
+                        .expect("Error: Bytes must not be negative"),
+                    Byte::from_unit(1_f64, ByteUnit::MB)
+                        .expect("Error: Bytes must not be negative"),
+                    Byte::from_unit(2_f64, ByteUnit::MB)
+                        .expect("Error: Bytes must not be negative"),
+                    Byte::from_unit(4_f64, ByteUnit::MB)
+                        .expect("Error: Bytes must not be negative"),
                 ]
             })
             .iter()

--- a/lading/src/generator/splunk_hec.rs
+++ b/lading/src/generator/splunk_hec.rs
@@ -134,13 +134,13 @@ fn get_uri_by_format(base_uri: &Uri, format: lading_payload::splunk_hec::Encodin
         .authority(
             base_uri
                 .authority()
-                .expect("Error: base uri authority is empty")
+                .expect("base uri authority is empty")
                 .to_string(),
         )
         .scheme("http")
         .path_and_query(path)
         .build()
-        .expect("Error: unable to build URI")
+        .expect("unable to build URI")
 }
 
 impl SplunkHec {
@@ -161,18 +161,12 @@ impl SplunkHec {
             .block_sizes
             .unwrap_or_else(|| {
                 vec![
-                    Byte::from_unit(1.0 / 8.0, ByteUnit::MB)
-                        .expect("Error: Bytes must not be negative"),
-                    Byte::from_unit(1.0 / 4.0, ByteUnit::MB)
-                        .expect("Error: Bytes must not be negative"),
-                    Byte::from_unit(1.0 / 2.0, ByteUnit::MB)
-                        .expect("Error: Bytes must not be negative"),
-                    Byte::from_unit(1_f64, ByteUnit::MB)
-                        .expect("Error: Bytes must not be negative"),
-                    Byte::from_unit(2_f64, ByteUnit::MB)
-                        .expect("Error: Bytes must not be negative"),
-                    Byte::from_unit(4_f64, ByteUnit::MB)
-                        .expect("Error: Bytes must not be negative"),
+                    Byte::from_unit(1.0 / 8.0, ByteUnit::MB).expect("Bytes must not be negative"),
+                    Byte::from_unit(1.0 / 4.0, ByteUnit::MB).expect("Bytes must not be negative"),
+                    Byte::from_unit(1.0 / 2.0, ByteUnit::MB).expect("Bytes must not be negative"),
+                    Byte::from_unit(1_f64, ByteUnit::MB).expect("Bytes must not be negative"),
+                    Byte::from_unit(2_f64, ByteUnit::MB).expect("Bytes must not be negative"),
+                    Byte::from_unit(4_f64, ByteUnit::MB).expect("Bytes must not be negative"),
                 ]
             })
             .iter()
@@ -187,7 +181,7 @@ impl SplunkHec {
         }
 
         let bytes_per_second = NonZeroU32::new(config.bytes_per_second.get_bytes() as u32)
-            .expect("Error: config bytes per second should not be zero");
+            .expect("config bytes per second should not be zero");
         gauge!(
             "bytes_per_second",
             f64::from(bytes_per_second.get()),
@@ -214,21 +208,17 @@ impl SplunkHec {
         let mut channels = Channels::new(config.parallel_connections);
         if let Some(ack_settings) = config.acknowledgements {
             let ack_uri = Uri::builder()
-                .authority(
-                    uri.authority()
-                        .expect("Error: Uri authority is empty")
-                        .to_string(),
-                )
+                .authority(uri.authority().expect("Uri authority is empty").to_string())
                 .scheme("http")
                 .path_and_query(SPLUNK_HEC_ACKNOWLEDGEMENTS_PATH)
                 .build()
-                .expect("Error: unable to build ack URI");
+                .expect("unable to build ack URI");
             channels.enable_acknowledgements(ack_uri, config.token.clone(), ack_settings);
         }
 
         CONNECTION_SEMAPHORE
             .set(Semaphore::new(config.parallel_connections as usize))
-            .expect("Error: semaphore already set");
+            .expect("semaphore already set");
 
         Ok(Self {
             channels,
@@ -279,12 +269,12 @@ impl SplunkHec {
         loop {
             let channel: Channel = channels
                 .next()
-                .expect("Error: channel iteration already finished")
+                .expect("channel iteration already finished")
                 .clone();
             let blk = rcv
                 .peek()
                 .await
-                .expect("Error: block cache does not have any blocks");
+                .expect("block cache does not have any blocks");
             let total_bytes = blk.total_bytes;
 
             tokio::select! {
@@ -293,7 +283,7 @@ impl SplunkHec {
                     let labels = labels.clone();
                     let uri = uri.clone();
 
-                    let blk = rcv.next().await.expect("Error: block cache failed to find next value"); // actually advance through the blocks
+                    let blk = rcv.next().await.expect("block cache failed to find next value"); // actually advance through the blocks
                     let body = Body::from(blk.bytes.clone());
                     let block_length = blk.bytes.len();
 
@@ -304,14 +294,14 @@ impl SplunkHec {
                         .header(CONTENT_LENGTH, block_length)
                         .header(SPLUNK_HEC_CHANNEL_HEADER, channel.id())
                         .body(body)
-                        .expect("Error: unable to build request");
+                        .expect("unable to build request");
 
                     // NOTE once JoinSet is in tokio stable we can make this
                     // much, much tidier by spawning requests in the JoinSet. I
                     // think we could also possibly have the send request return
                     // the AckID, meaning we could just keep the channel logic
                     // in this main loop here and avoid the AckService entirely.
-                    let permit = CONNECTION_SEMAPHORE.get().expect("Error: Connecton Semaphore is empty or being initialized").acquire().await.expect("Error: Semaphore has already been closed");
+                    let permit = CONNECTION_SEMAPHORE.get().expect("Connecton Semaphore is empty or being initialized").acquire().await.expect("Semaphore has already been closed");
                     tokio::spawn(send_hec_request(permit, block_length, labels, channel, client, request, self.shutdown.clone()));
                 }
                 () = self.shutdown.recv() => {
@@ -354,9 +344,9 @@ async fn send_hec_request(
                         counter!("request_ok", 1, &status_labels);
                         channel
                             .send(async {
-                                let body_bytes = hyper::body::to_bytes(body).await.expect("Error: unable to convert response body to bytes");
+                                let body_bytes = hyper::body::to_bytes(body).await.expect("unable to convert response body to bytes");
                                 let hec_ack_response =
-                                    serde_json::from_slice::<HecAckResponse>(&body_bytes).expect("Error: unable to parse response body");
+                                    serde_json::from_slice::<HecAckResponse>(&body_bytes).expect("unable to parse response body");
                                 hec_ack_response.ack_id
                             })
                             .await;

--- a/lading/src/generator/splunk_hec/acknowledgements.rs
+++ b/lading/src/generator/splunk_hec/acknowledgements.rs
@@ -165,7 +165,7 @@ impl AckService {
                             .header(AUTHORIZATION, format!("Splunk {}", self.token))
                             .header(SPLUNK_HEC_CHANNEL_HEADER, channel_id.clone())
                             .body(body)
-                            .unwrap();
+                            .expect("Error: failed to build ack request");
                         let work = ack_request(self.client.clone(), request, channel_id.clone(), &mut ack_ids);
 
                         if let Err(_err) = timeout(Duration::from_secs(1), work).await {
@@ -191,8 +191,11 @@ async fn ack_request(
             let status = parts.status;
             counter!("ack_status_request_ok", 1, "channel_id" => channel_id.clone(), "status" => status.to_string());
             if status == StatusCode::OK {
-                let body = hyper::body::to_bytes(body).await.unwrap();
-                let ack_status = serde_json::from_slice::<HecAckStatusResponse>(&body).unwrap();
+                let body = hyper::body::to_bytes(body)
+                    .await
+                    .expect("Error: failed to convert response body to bytes");
+                let ack_status = serde_json::from_slice::<HecAckStatusResponse>(&body)
+                    .expect("Error: failed to deserialize ack status response");
 
                 let mut ack_ids_acked: u32 = 0;
                 // Remove successfully acked ack ids

--- a/lading/src/generator/splunk_hec/acknowledgements.rs
+++ b/lading/src/generator/splunk_hec/acknowledgements.rs
@@ -165,7 +165,7 @@ impl AckService {
                             .header(AUTHORIZATION, format!("Splunk {}", self.token))
                             .header(SPLUNK_HEC_CHANNEL_HEADER, channel_id.clone())
                             .body(body)
-                            .expect("Error: failed to build ack request");
+                            .expect("failed to build ack request");
                         let work = ack_request(self.client.clone(), request, channel_id.clone(), &mut ack_ids);
 
                         if let Err(_err) = timeout(Duration::from_secs(1), work).await {
@@ -193,9 +193,9 @@ async fn ack_request(
             if status == StatusCode::OK {
                 let body = hyper::body::to_bytes(body)
                     .await
-                    .expect("Error: failed to convert response body to bytes");
+                    .expect("failed to convert response body to bytes");
                 let ack_status = serde_json::from_slice::<HecAckStatusResponse>(&body)
-                    .expect("Error: failed to deserialize ack status response");
+                    .expect("failed to deserialize ack status response");
 
                 let mut ack_ids_acked: u32 = 0;
                 // Remove successfully acked ack ids

--- a/lading/src/generator/tcp.rs
+++ b/lading/src/generator/tcp.rs
@@ -93,14 +93,22 @@ impl Tcp {
             .clone()
             .unwrap_or_else(|| {
                 vec![
-                    Byte::from_unit(1.0 / 32.0, ByteUnit::MB).unwrap(),
-                    Byte::from_unit(1.0 / 16.0, ByteUnit::MB).unwrap(),
-                    Byte::from_unit(1.0 / 8.0, ByteUnit::MB).unwrap(),
-                    Byte::from_unit(1.0 / 4.0, ByteUnit::MB).unwrap(),
-                    Byte::from_unit(1.0 / 2.0, ByteUnit::MB).unwrap(),
-                    Byte::from_unit(1_f64, ByteUnit::MB).unwrap(),
-                    Byte::from_unit(2_f64, ByteUnit::MB).unwrap(),
-                    Byte::from_unit(4_f64, ByteUnit::MB).unwrap(),
+                    Byte::from_unit(1.0 / 32.0, ByteUnit::MB)
+                        .expect("Error: Bytes must not be negative"),
+                    Byte::from_unit(1.0 / 16.0, ByteUnit::MB)
+                        .expect("Error: Bytes must not be negative"),
+                    Byte::from_unit(1.0 / 8.0, ByteUnit::MB)
+                        .expect("Error: Bytes must not be negative"),
+                    Byte::from_unit(1.0 / 4.0, ByteUnit::MB)
+                        .expect("Error: Bytes must not be negative"),
+                    Byte::from_unit(1.0 / 2.0, ByteUnit::MB)
+                        .expect("Error: Bytes must not be negative"),
+                    Byte::from_unit(1_f64, ByteUnit::MB)
+                        .expect("Error: Bytes must not be negative"),
+                    Byte::from_unit(2_f64, ByteUnit::MB)
+                        .expect("Error: Bytes must not be negative"),
+                    Byte::from_unit(4_f64, ByteUnit::MB)
+                        .expect("Error: Bytes must not be negative"),
                 ]
             })
             .iter()

--- a/lading/src/generator/tcp.rs
+++ b/lading/src/generator/tcp.rs
@@ -93,28 +93,18 @@ impl Tcp {
             .clone()
             .unwrap_or_else(|| {
                 vec![
-                    Byte::from_unit(1.0 / 32.0, ByteUnit::MB)
-                        .expect("Error: Bytes must not be negative"),
-                    Byte::from_unit(1.0 / 16.0, ByteUnit::MB)
-                        .expect("Error: Bytes must not be negative"),
-                    Byte::from_unit(1.0 / 8.0, ByteUnit::MB)
-                        .expect("Error: Bytes must not be negative"),
-                    Byte::from_unit(1.0 / 4.0, ByteUnit::MB)
-                        .expect("Error: Bytes must not be negative"),
-                    Byte::from_unit(1.0 / 2.0, ByteUnit::MB)
-                        .expect("Error: Bytes must not be negative"),
-                    Byte::from_unit(1_f64, ByteUnit::MB)
-                        .expect("Error: Bytes must not be negative"),
-                    Byte::from_unit(2_f64, ByteUnit::MB)
-                        .expect("Error: Bytes must not be negative"),
-                    Byte::from_unit(4_f64, ByteUnit::MB)
-                        .expect("Error: Bytes must not be negative"),
+                    Byte::from_unit(1.0 / 32.0, ByteUnit::MB).expect("Bytes must not be negative"),
+                    Byte::from_unit(1.0 / 16.0, ByteUnit::MB).expect("Bytes must not be negative"),
+                    Byte::from_unit(1.0 / 8.0, ByteUnit::MB).expect("Bytes must not be negative"),
+                    Byte::from_unit(1.0 / 4.0, ByteUnit::MB).expect("Bytes must not be negative"),
+                    Byte::from_unit(1.0 / 2.0, ByteUnit::MB).expect("Bytes must not be negative"),
+                    Byte::from_unit(1_f64, ByteUnit::MB).expect("Bytes must not be negative"),
+                    Byte::from_unit(2_f64, ByteUnit::MB).expect("Bytes must not be negative"),
+                    Byte::from_unit(4_f64, ByteUnit::MB).expect("Bytes must not be negative"),
                 ]
             })
             .iter()
-            .map(|sz| {
-                NonZeroU32::new(sz.get_bytes() as u32).expect("Error: bytes must be non-zero")
-            })
+            .map(|sz| NonZeroU32::new(sz.get_bytes() as u32).expect("bytes must be non-zero"))
             .collect();
         let mut labels = vec![
             ("component".to_string(), "generator".to_string()),
@@ -125,7 +115,7 @@ impl Tcp {
         }
 
         let bytes_per_second = NonZeroU32::new(config.bytes_per_second.get_bytes() as u32)
-            .expect("Error: config bytes per second must be non-zero");
+            .expect("config bytes per second must be non-zero");
         gauge!(
             "bytes_per_second",
             f64::from(bytes_per_second.get()),
@@ -143,9 +133,9 @@ impl Tcp {
         let addr = config
             .addr
             .to_socket_addrs()
-            .expect("Error: could not convert to socket")
+            .expect("could not convert to socket")
             .next()
-            .expect("Error: iterator was already finished");
+            .expect("iterator was already finished");
         Ok(Self {
             addr,
             block_cache,
@@ -194,12 +184,12 @@ impl Tcp {
                 continue;
             };
 
-            let blk = rcv.peek().await.expect("Error: block cache is empty");
+            let blk = rcv.peek().await.expect("block cache is empty");
             let total_bytes = blk.total_bytes;
 
             tokio::select! {
                 _ = self.throttle.wait_for(total_bytes) => {
-                    let blk = rcv.next().await.expect("Error: block cache has no next value"); // actually advance through the blocks
+                    let blk = rcv.next().await.expect("block cache has no next value"); // actually advance through the blocks
                     match connection.write_all(&blk.bytes).await {
                         Ok(()) => {
                             bytes_written.increment(u64::from(blk.total_bytes.get()));

--- a/lading/src/generator/tcp.rs
+++ b/lading/src/generator/tcp.rs
@@ -112,7 +112,9 @@ impl Tcp {
                 ]
             })
             .iter()
-            .map(|sz| NonZeroU32::new(sz.get_bytes() as u32).expect("bytes must be non-zero"))
+            .map(|sz| {
+                NonZeroU32::new(sz.get_bytes() as u32).expect("Error: bytes must be non-zero")
+            })
             .collect();
         let mut labels = vec![
             ("component".to_string(), "generator".to_string()),
@@ -122,7 +124,8 @@ impl Tcp {
             labels.push(("id".to_string(), id));
         }
 
-        let bytes_per_second = NonZeroU32::new(config.bytes_per_second.get_bytes() as u32).unwrap();
+        let bytes_per_second = NonZeroU32::new(config.bytes_per_second.get_bytes() as u32)
+            .expect("Error: config bytes per second must be non-zero");
         gauge!(
             "bytes_per_second",
             f64::from(bytes_per_second.get()),
@@ -140,9 +143,9 @@ impl Tcp {
         let addr = config
             .addr
             .to_socket_addrs()
-            .expect("could not convert to socket")
+            .expect("Error: could not convert to socket")
             .next()
-            .unwrap();
+            .expect("Error: iterator was already finished");
         Ok(Self {
             addr,
             block_cache,
@@ -191,12 +194,12 @@ impl Tcp {
                 continue;
             };
 
-            let blk = rcv.peek().await.unwrap();
+            let blk = rcv.peek().await.expect("Error: block cache is empty");
             let total_bytes = blk.total_bytes;
 
             tokio::select! {
                 _ = self.throttle.wait_for(total_bytes) => {
-                    let blk = rcv.next().await.unwrap(); // actually advance through the blocks
+                    let blk = rcv.next().await.expect("Error: block cache has no next value"); // actually advance through the blocks
                     match connection.write_all(&blk.bytes).await {
                         Ok(()) => {
                             bytes_written.increment(u64::from(blk.total_bytes.get()));

--- a/lading/src/generator/udp.rs
+++ b/lading/src/generator/udp.rs
@@ -123,7 +123,8 @@ impl Udp {
             labels.push(("id".to_string(), id));
         }
 
-        let bytes_per_second = NonZeroU32::new(config.bytes_per_second.get_bytes() as u32).unwrap();
+        let bytes_per_second = NonZeroU32::new(config.bytes_per_second.get_bytes() as u32)
+            .expect("Error: bytes must be non-zero");
         gauge!(
             "bytes_per_second",
             f64::from(bytes_per_second.get()),
@@ -143,7 +144,7 @@ impl Udp {
             .to_socket_addrs()
             .expect("could not convert to socket")
             .next()
-            .unwrap();
+            .expect("Error: iterator already finished");
 
         Ok(Self {
             addr,
@@ -178,7 +179,10 @@ impl Udp {
         let packets_sent = register_counter!("packets_sent", &self.metric_labels);
 
         loop {
-            let blk = rcv.peek().await.unwrap();
+            let blk = rcv
+                .peek()
+                .await
+                .expect("Error: block cache has no next block");
             let total_bytes = blk.total_bytes;
             assert!(
                 total_bytes.get() <= 65507,
@@ -203,8 +207,8 @@ impl Udp {
                     }
                 }
                 _ = self.throttle.wait_for(total_bytes), if connection.is_some() => {
-                    let sock = connection.unwrap();
-                    let blk = rcv.next().await.unwrap(); // actually advance through the blocks
+                    let sock = connection.expect("Error: connection failed");
+                    let blk = rcv.next().await.expect("Error: failed to advance through blocks"); // actually advance through the blocks
                     match sock.send_to(&blk.bytes, self.addr).await {
                         Ok(bytes) => {
                             bytes_written.increment(bytes as u64);

--- a/lading/src/generator/udp.rs
+++ b/lading/src/generator/udp.rs
@@ -94,14 +94,22 @@ impl Udp {
             .clone()
             .unwrap_or_else(|| {
                 vec![
-                    Byte::from_unit(1.0 / 32.0, ByteUnit::MB).unwrap(),
-                    Byte::from_unit(1.0 / 16.0, ByteUnit::MB).unwrap(),
-                    Byte::from_unit(1.0 / 8.0, ByteUnit::MB).unwrap(),
-                    Byte::from_unit(1.0 / 4.0, ByteUnit::MB).unwrap(),
-                    Byte::from_unit(1.0 / 2.0, ByteUnit::MB).unwrap(),
-                    Byte::from_unit(1_f64, ByteUnit::MB).unwrap(),
-                    Byte::from_unit(2_f64, ByteUnit::MB).unwrap(),
-                    Byte::from_unit(4_f64, ByteUnit::MB).unwrap(),
+                    Byte::from_unit(1.0 / 32.0, ByteUnit::MB)
+                        .expect("Error: Bytes must not be negative"),
+                    Byte::from_unit(1.0 / 16.0, ByteUnit::MB)
+                        .expect("Error: Bytes must not be negative"),
+                    Byte::from_unit(1.0 / 8.0, ByteUnit::MB)
+                        .expect("Error: Bytes must not be negative"),
+                    Byte::from_unit(1.0 / 4.0, ByteUnit::MB)
+                        .expect("Error: Bytes must not be negative"),
+                    Byte::from_unit(1.0 / 2.0, ByteUnit::MB)
+                        .expect("Error: Bytes must not be negative"),
+                    Byte::from_unit(1_f64, ByteUnit::MB)
+                        .expect("Error: Bytes must not be negative"),
+                    Byte::from_unit(2_f64, ByteUnit::MB)
+                        .expect("Error: Bytes must not be negative"),
+                    Byte::from_unit(4_f64, ByteUnit::MB)
+                        .expect("Error: Bytes must not be negative"),
                 ]
             })
             .iter()

--- a/lading/src/generator/udp.rs
+++ b/lading/src/generator/udp.rs
@@ -94,22 +94,14 @@ impl Udp {
             .clone()
             .unwrap_or_else(|| {
                 vec![
-                    Byte::from_unit(1.0 / 32.0, ByteUnit::MB)
-                        .expect("Error: Bytes must not be negative"),
-                    Byte::from_unit(1.0 / 16.0, ByteUnit::MB)
-                        .expect("Error: Bytes must not be negative"),
-                    Byte::from_unit(1.0 / 8.0, ByteUnit::MB)
-                        .expect("Error: Bytes must not be negative"),
-                    Byte::from_unit(1.0 / 4.0, ByteUnit::MB)
-                        .expect("Error: Bytes must not be negative"),
-                    Byte::from_unit(1.0 / 2.0, ByteUnit::MB)
-                        .expect("Error: Bytes must not be negative"),
-                    Byte::from_unit(1_f64, ByteUnit::MB)
-                        .expect("Error: Bytes must not be negative"),
-                    Byte::from_unit(2_f64, ByteUnit::MB)
-                        .expect("Error: Bytes must not be negative"),
-                    Byte::from_unit(4_f64, ByteUnit::MB)
-                        .expect("Error: Bytes must not be negative"),
+                    Byte::from_unit(1.0 / 32.0, ByteUnit::MB).expect("Bytes must not be negative"),
+                    Byte::from_unit(1.0 / 16.0, ByteUnit::MB).expect("Bytes must not be negative"),
+                    Byte::from_unit(1.0 / 8.0, ByteUnit::MB).expect("Bytes must not be negative"),
+                    Byte::from_unit(1.0 / 4.0, ByteUnit::MB).expect("Bytes must not be negative"),
+                    Byte::from_unit(1.0 / 2.0, ByteUnit::MB).expect("Bytes must not be negative"),
+                    Byte::from_unit(1_f64, ByteUnit::MB).expect("Bytes must not be negative"),
+                    Byte::from_unit(2_f64, ByteUnit::MB).expect("Bytes must not be negative"),
+                    Byte::from_unit(4_f64, ByteUnit::MB).expect("Bytes must not be negative"),
                 ]
             })
             .iter()
@@ -124,7 +116,7 @@ impl Udp {
         }
 
         let bytes_per_second = NonZeroU32::new(config.bytes_per_second.get_bytes() as u32)
-            .expect("Error: bytes must be non-zero");
+            .expect("bytes must be non-zero");
         gauge!(
             "bytes_per_second",
             f64::from(bytes_per_second.get()),
@@ -144,7 +136,7 @@ impl Udp {
             .to_socket_addrs()
             .expect("could not convert to socket")
             .next()
-            .expect("Error: iterator already finished");
+            .expect("iterator already finished");
 
         Ok(Self {
             addr,
@@ -179,10 +171,7 @@ impl Udp {
         let packets_sent = register_counter!("packets_sent", &self.metric_labels);
 
         loop {
-            let blk = rcv
-                .peek()
-                .await
-                .expect("Error: block cache has no next block");
+            let blk = rcv.peek().await.expect("block cache has no next block");
             let total_bytes = blk.total_bytes;
             assert!(
                 total_bytes.get() <= 65507,
@@ -207,8 +196,8 @@ impl Udp {
                     }
                 }
                 _ = self.throttle.wait_for(total_bytes), if connection.is_some() => {
-                    let sock = connection.expect("Error: connection failed");
-                    let blk = rcv.next().await.expect("Error: failed to advance through blocks"); // actually advance through the blocks
+                    let sock = connection.expect("connection failed");
+                    let blk = rcv.next().await.expect("failed to advance through blocks"); // actually advance through the blocks
                     match sock.send_to(&blk.bytes, self.addr).await {
                         Ok(bytes) => {
                             bytes_written.increment(bytes as u64);

--- a/lading/src/generator/unix_datagram.rs
+++ b/lading/src/generator/unix_datagram.rs
@@ -142,7 +142,8 @@ impl UnixDatagram {
             labels.push(("id".to_string(), id));
         }
 
-        let bytes_per_second = NonZeroU32::new(config.bytes_per_second.get_bytes() as u32).unwrap();
+        let bytes_per_second = NonZeroU32::new(config.bytes_per_second.get_bytes() as u32)
+            .expect("Error: config bytes per second must be non-zero");
         gauge!(
             "bytes_per_second",
             f64::from(bytes_per_second.get()),
@@ -254,7 +255,7 @@ impl Child {
         let packets_sent = register_counter!("packets_sent", &self.metric_labels);
 
         loop {
-            let blk = rcv.peek().await.unwrap();
+            let blk = rcv.peek().await.expect("Error: block cache is empty");
             let total_bytes = blk.total_bytes;
 
             tokio::select! {
@@ -263,7 +264,7 @@ impl Child {
                     // some of the written bytes make it through in which case we
                     // must cycle back around and try to write the remainder of the
                     // buffer.
-                    let blk = rcv.next().await.unwrap(); // actually advance through the blocks
+                    let blk = rcv.next().await.expect("Error: failed to advance through the blocks"); // actually advance through the blocks
                     let blk_max: usize = total_bytes.get() as usize;
                     let mut blk_offset = 0;
                     while blk_offset < blk_max {

--- a/lading/src/generator/unix_datagram.rs
+++ b/lading/src/generator/unix_datagram.rs
@@ -113,14 +113,22 @@ impl UnixDatagram {
             .clone()
             .unwrap_or_else(|| {
                 vec![
-                    Byte::from_unit(1.0 / 32.0, ByteUnit::MB).unwrap(),
-                    Byte::from_unit(1.0 / 16.0, ByteUnit::MB).unwrap(),
-                    Byte::from_unit(1.0 / 8.0, ByteUnit::MB).unwrap(),
-                    Byte::from_unit(1.0 / 4.0, ByteUnit::MB).unwrap(),
-                    Byte::from_unit(1.0 / 2.0, ByteUnit::MB).unwrap(),
-                    Byte::from_unit(1_f64, ByteUnit::MB).unwrap(),
-                    Byte::from_unit(2_f64, ByteUnit::MB).unwrap(),
-                    Byte::from_unit(4_f64, ByteUnit::MB).unwrap(),
+                    Byte::from_unit(1.0 / 32.0, ByteUnit::MB)
+                        .expect("Error: Bytes must not be negative"),
+                    Byte::from_unit(1.0 / 16.0, ByteUnit::MB)
+                        .expect("Error: Bytes must not be negative"),
+                    Byte::from_unit(1.0 / 8.0, ByteUnit::MB)
+                        .expect("Error: Bytes must not be negative"),
+                    Byte::from_unit(1.0 / 4.0, ByteUnit::MB)
+                        .expect("Error: Bytes must not be negative"),
+                    Byte::from_unit(1.0 / 2.0, ByteUnit::MB)
+                        .expect("Error: Bytes must not be negative"),
+                    Byte::from_unit(1_f64, ByteUnit::MB)
+                        .expect("Error: Bytes must not be negative"),
+                    Byte::from_unit(2_f64, ByteUnit::MB)
+                        .expect("Error: Bytes must not be negative"),
+                    Byte::from_unit(4_f64, ByteUnit::MB)
+                        .expect("Error: Bytes must not be negative"),
                 ]
             })
             .iter()

--- a/lading/src/generator/unix_datagram.rs
+++ b/lading/src/generator/unix_datagram.rs
@@ -113,22 +113,14 @@ impl UnixDatagram {
             .clone()
             .unwrap_or_else(|| {
                 vec![
-                    Byte::from_unit(1.0 / 32.0, ByteUnit::MB)
-                        .expect("Error: Bytes must not be negative"),
-                    Byte::from_unit(1.0 / 16.0, ByteUnit::MB)
-                        .expect("Error: Bytes must not be negative"),
-                    Byte::from_unit(1.0 / 8.0, ByteUnit::MB)
-                        .expect("Error: Bytes must not be negative"),
-                    Byte::from_unit(1.0 / 4.0, ByteUnit::MB)
-                        .expect("Error: Bytes must not be negative"),
-                    Byte::from_unit(1.0 / 2.0, ByteUnit::MB)
-                        .expect("Error: Bytes must not be negative"),
-                    Byte::from_unit(1_f64, ByteUnit::MB)
-                        .expect("Error: Bytes must not be negative"),
-                    Byte::from_unit(2_f64, ByteUnit::MB)
-                        .expect("Error: Bytes must not be negative"),
-                    Byte::from_unit(4_f64, ByteUnit::MB)
-                        .expect("Error: Bytes must not be negative"),
+                    Byte::from_unit(1.0 / 32.0, ByteUnit::MB).expect("Bytes must not be negative"),
+                    Byte::from_unit(1.0 / 16.0, ByteUnit::MB).expect("Bytes must not be negative"),
+                    Byte::from_unit(1.0 / 8.0, ByteUnit::MB).expect("Bytes must not be negative"),
+                    Byte::from_unit(1.0 / 4.0, ByteUnit::MB).expect("Bytes must not be negative"),
+                    Byte::from_unit(1.0 / 2.0, ByteUnit::MB).expect("Bytes must not be negative"),
+                    Byte::from_unit(1_f64, ByteUnit::MB).expect("Bytes must not be negative"),
+                    Byte::from_unit(2_f64, ByteUnit::MB).expect("Bytes must not be negative"),
+                    Byte::from_unit(4_f64, ByteUnit::MB).expect("Bytes must not be negative"),
                 ]
             })
             .iter()
@@ -143,7 +135,7 @@ impl UnixDatagram {
         }
 
         let bytes_per_second = NonZeroU32::new(config.bytes_per_second.get_bytes() as u32)
-            .expect("Error: config bytes per second must be non-zero");
+            .expect("config bytes per second must be non-zero");
         gauge!(
             "bytes_per_second",
             f64::from(bytes_per_second.get()),
@@ -255,7 +247,7 @@ impl Child {
         let packets_sent = register_counter!("packets_sent", &self.metric_labels);
 
         loop {
-            let blk = rcv.peek().await.expect("Error: block cache is empty");
+            let blk = rcv.peek().await.expect("block cache is empty");
             let total_bytes = blk.total_bytes;
 
             tokio::select! {
@@ -264,7 +256,7 @@ impl Child {
                     // some of the written bytes make it through in which case we
                     // must cycle back around and try to write the remainder of the
                     // buffer.
-                    let blk = rcv.next().await.expect("Error: failed to advance through the blocks"); // actually advance through the blocks
+                    let blk = rcv.next().await.expect("failed to advance through the blocks"); // actually advance through the blocks
                     let blk_max: usize = total_bytes.get() as usize;
                     let mut blk_offset = 0;
                     while blk_offset < blk_max {

--- a/lading/src/generator/unix_stream.rs
+++ b/lading/src/generator/unix_stream.rs
@@ -94,14 +94,22 @@ impl UnixStream {
             .clone()
             .unwrap_or_else(|| {
                 vec![
-                    Byte::from_unit(1.0 / 32.0, ByteUnit::MB).unwrap(),
-                    Byte::from_unit(1.0 / 16.0, ByteUnit::MB).unwrap(),
-                    Byte::from_unit(1.0 / 8.0, ByteUnit::MB).unwrap(),
-                    Byte::from_unit(1.0 / 4.0, ByteUnit::MB).unwrap(),
-                    Byte::from_unit(1.0 / 2.0, ByteUnit::MB).unwrap(),
-                    Byte::from_unit(1_f64, ByteUnit::MB).unwrap(),
-                    Byte::from_unit(2_f64, ByteUnit::MB).unwrap(),
-                    Byte::from_unit(4_f64, ByteUnit::MB).unwrap(),
+                    Byte::from_unit(1.0 / 32.0, ByteUnit::MB)
+                        .expect("Error: Bytes must not be negative"),
+                    Byte::from_unit(1.0 / 16.0, ByteUnit::MB)
+                        .expect("Error: Bytes must not be negative"),
+                    Byte::from_unit(1.0 / 8.0, ByteUnit::MB)
+                        .expect("Error: Bytes must not be negative"),
+                    Byte::from_unit(1.0 / 4.0, ByteUnit::MB)
+                        .expect("Error: Bytes must not be negative"),
+                    Byte::from_unit(1.0 / 2.0, ByteUnit::MB)
+                        .expect("Error: Bytes must not be negative"),
+                    Byte::from_unit(1_f64, ByteUnit::MB)
+                        .expect("Error: Bytes must not be negative"),
+                    Byte::from_unit(2_f64, ByteUnit::MB)
+                        .expect("Error: Bytes must not be negative"),
+                    Byte::from_unit(4_f64, ByteUnit::MB)
+                        .expect("Error: Bytes must not be negative"),
                 ]
             })
             .iter()

--- a/lading/src/generator/unix_stream.rs
+++ b/lading/src/generator/unix_stream.rs
@@ -94,22 +94,14 @@ impl UnixStream {
             .clone()
             .unwrap_or_else(|| {
                 vec![
-                    Byte::from_unit(1.0 / 32.0, ByteUnit::MB)
-                        .expect("Error: Bytes must not be negative"),
-                    Byte::from_unit(1.0 / 16.0, ByteUnit::MB)
-                        .expect("Error: Bytes must not be negative"),
-                    Byte::from_unit(1.0 / 8.0, ByteUnit::MB)
-                        .expect("Error: Bytes must not be negative"),
-                    Byte::from_unit(1.0 / 4.0, ByteUnit::MB)
-                        .expect("Error: Bytes must not be negative"),
-                    Byte::from_unit(1.0 / 2.0, ByteUnit::MB)
-                        .expect("Error: Bytes must not be negative"),
-                    Byte::from_unit(1_f64, ByteUnit::MB)
-                        .expect("Error: Bytes must not be negative"),
-                    Byte::from_unit(2_f64, ByteUnit::MB)
-                        .expect("Error: Bytes must not be negative"),
-                    Byte::from_unit(4_f64, ByteUnit::MB)
-                        .expect("Error: Bytes must not be negative"),
+                    Byte::from_unit(1.0 / 32.0, ByteUnit::MB).expect("Bytes must not be negative"),
+                    Byte::from_unit(1.0 / 16.0, ByteUnit::MB).expect("Bytes must not be negative"),
+                    Byte::from_unit(1.0 / 8.0, ByteUnit::MB).expect("Bytes must not be negative"),
+                    Byte::from_unit(1.0 / 4.0, ByteUnit::MB).expect("Bytes must not be negative"),
+                    Byte::from_unit(1.0 / 2.0, ByteUnit::MB).expect("Bytes must not be negative"),
+                    Byte::from_unit(1_f64, ByteUnit::MB).expect("Bytes must not be negative"),
+                    Byte::from_unit(2_f64, ByteUnit::MB).expect("Bytes must not be negative"),
+                    Byte::from_unit(4_f64, ByteUnit::MB).expect("Bytes must not be negative"),
                 ]
             })
             .iter()
@@ -124,7 +116,7 @@ impl UnixStream {
         }
 
         let bytes_per_second = NonZeroU32::new(config.bytes_per_second.get_bytes() as u32)
-            .expect("Error: config bytes per second must be non-zero");
+            .expect("config bytes per second must be non-zero");
         gauge!(
             "bytes_per_second",
             f64::from(bytes_per_second.get()),
@@ -202,7 +194,7 @@ impl UnixStream {
                 continue;
             };
 
-            let blk = rcv.peek().await.expect("Error: block cache is empty");
+            let blk = rcv.peek().await.expect("block cache is empty");
             let total_bytes = blk.total_bytes;
 
             tokio::select! {
@@ -213,7 +205,7 @@ impl UnixStream {
                     // buffer.
                     let blk_max: usize = total_bytes.get() as usize;
                     let mut blk_offset = 0;
-                    let blk = rcv.next().await.expect("Error: failed to advance to peeked block"); // advance to the block that was previously peeked
+                    let blk = rcv.next().await.expect("failed to advance to peeked block"); // advance to the block that was previously peeked
                     while blk_offset < blk_max {
                         let stream = &socket;
 
@@ -221,7 +213,7 @@ impl UnixStream {
                             .ready(tokio::io::Interest::WRITABLE)
                             .await
                             .map_err(Error::Io)
-                            .expect("Error: Unable to start stream"); // Cannot ? in a spawned task :<. Mimics UDP generator.
+                            .expect("Unable to start stream"); // Cannot ? in a spawned task :<. Mimics UDP generator.
                         if ready.is_writable() {
                             // Try to write data, this may still fail with `WouldBlock`
                             // if the readiness event is a false positive.

--- a/lading/src/inspector.rs
+++ b/lading/src/inspector.rs
@@ -146,7 +146,7 @@ impl Server {
                 // Note that `Child::kill` sends SIGKILL which is not what we
                 // want. We instead send SIGTERM so that the child has a chance
                 // to clean up.
-                let pid: Pid = Pid::from_raw(target_child.id().expect("Error: Process ID provided is already done").try_into().expect("Error: Failed to convert into valid PID"));
+                let pid: Pid = Pid::from_raw(target_child.id().expect("Process ID provided is already done").try_into().expect("Failed to convert into valid PID"));
                 kill(pid, SIGTERM).map_err(Error::Errno)?;
                 let res = target_child.wait().await.map_err(Error::Io)?;
                 Ok(res)

--- a/lading/src/inspector.rs
+++ b/lading/src/inspector.rs
@@ -146,7 +146,7 @@ impl Server {
                 // Note that `Child::kill` sends SIGKILL which is not what we
                 // want. We instead send SIGTERM so that the child has a chance
                 // to clean up.
-                let pid: Pid = Pid::from_raw(target_child.id().unwrap().try_into().unwrap());
+                let pid: Pid = Pid::from_raw(target_child.id().expect("Error: Process ID provided is already done").try_into().expect("Error: Failed to convert into valid PID"));
                 kill(pid, SIGTERM).map_err(Error::Errno)?;
                 let res = target_child.wait().await.map_err(Error::Io)?;
                 Ok(res)

--- a/lading/src/observer/linux.rs
+++ b/lading/src/observer/linux.rs
@@ -122,7 +122,7 @@ impl Sampler {
             // infinite loops.
             if let Ok(tasks) = process.tasks() {
                 for task in tasks.filter(std::result::Result::is_ok) {
-                    let task = task.unwrap(); // SAFETY: filter on iterator
+                    let task = task.expect("Error: failed to read task"); // SAFETY: filter on iterator
                     if let Ok(mut children) = task.children() {
                         for child in children
                             .drain(..)
@@ -148,7 +148,7 @@ impl Sampler {
                 // have sufficient permission.
                 continue;
             }
-            let status = status.unwrap(); // SAFETY: is_err check above
+            let status = status.expect("Error: issue with status"); // SAFETY: is_err check above
             if status.tgid != pid {
                 // This is a thread, not a process and we do not wish to scan it.
                 continue;
@@ -160,7 +160,11 @@ impl Sampler {
             // and name, again like `top`.
             let basename: String = if let Ok(exe) = process.exe() {
                 if let Some(basename) = exe.file_name() {
-                    String::from(basename.to_str().unwrap())
+                    String::from(
+                        basename
+                            .to_str()
+                            .expect("Error: could not convert basename to str"),
+                    )
                 } else {
                     // It's possible to have a process with no named exe. On
                     // Linux systems with functional security setups it's not
@@ -178,7 +182,7 @@ impl Sampler {
                 // likely, the process has exited.
                 continue;
             }
-            let stats = stats.unwrap(); // SAFETY: is_err check above
+            let stats = stats.expect("Error: stats failed"); // SAFETY: is_err check above
 
             // Calculate process uptime. We have two pieces of information from
             // the kernel: computer uptime and process starttime relative to

--- a/lading/src/observer/linux.rs
+++ b/lading/src/observer/linux.rs
@@ -122,7 +122,7 @@ impl Sampler {
             // infinite loops.
             if let Ok(tasks) = process.tasks() {
                 for task in tasks.filter(std::result::Result::is_ok) {
-                    let task = task.expect("Error: failed to read task"); // SAFETY: filter on iterator
+                    let task = task.expect("failed to read task"); // SAFETY: filter on iterator
                     if let Ok(mut children) = task.children() {
                         for child in children
                             .drain(..)
@@ -148,7 +148,7 @@ impl Sampler {
                 // have sufficient permission.
                 continue;
             }
-            let status = status.expect("Error: issue with status"); // SAFETY: is_err check above
+            let status = status.expect("issue with status"); // SAFETY: is_err check above
             if status.tgid != pid {
                 // This is a thread, not a process and we do not wish to scan it.
                 continue;
@@ -163,7 +163,7 @@ impl Sampler {
                     String::from(
                         basename
                             .to_str()
-                            .expect("Error: could not convert basename to str"),
+                            .expect("could not convert basename to str"),
                     )
                 } else {
                     // It's possible to have a process with no named exe. On
@@ -182,7 +182,7 @@ impl Sampler {
                 // likely, the process has exited.
                 continue;
             }
-            let stats = stats.expect("Error: stats failed"); // SAFETY: is_err check above
+            let stats = stats.expect("stats failed"); // SAFETY: is_err check above
 
             // Calculate process uptime. We have two pieces of information from
             // the kernel: computer uptime and process starttime relative to

--- a/lading/src/target.rs
+++ b/lading/src/target.rs
@@ -349,7 +349,7 @@ impl Server {
                     // Note that `Child::kill` sends SIGKILL which is not what we
                     // want. We instead send SIGTERM so that the child has a chance
                     // to clean up.
-                    let pid: Pid = Pid::from_raw(target_id.try_into().expect("Error: Failed to convert into valid PID"));
+                    let pid: Pid = Pid::from_raw(target_id.try_into().expect("Failed to convert into valid PID"));
                     kill(pid, SIGTERM).map_err(Error::SigTerm)?;
                     let res = target_child.wait().await.map_err(Error::TargetWait)?;
                     break Ok(res)

--- a/lading/src/target.rs
+++ b/lading/src/target.rs
@@ -349,7 +349,7 @@ impl Server {
                     // Note that `Child::kill` sends SIGKILL which is not what we
                     // want. We instead send SIGTERM so that the child has a chance
                     // to clean up.
-                    let pid: Pid = Pid::from_raw(target_id.try_into().unwrap());
+                    let pid: Pid = Pid::from_raw(target_id.try_into().expect("Error: Failed to convert into valid PID"));
                     kill(pid, SIGTERM).map_err(Error::SigTerm)?;
                     let res = target_child.wait().await.map_err(Error::TargetWait)?;
                     break Ok(res)

--- a/lading/src/target_metrics/prometheus.rs
+++ b/lading/src/target_metrics/prometheus.rs
@@ -131,13 +131,11 @@ impl Prometheus {
 
                     if line.starts_with("# TYPE") {
                         let mut parts = line.split_ascii_whitespace().skip(2);
-                        let name = parts.next().expect("Error: parts iterator is missing name");
-                        let metric_type = parts
-                            .next()
-                            .expect("Error: parts iterator is missing metric type");
-                        let metric_type: MetricType = metric_type
-                            .parse()
-                            .expect("Error: failed to parse metric type");
+                        let name = parts.next().expect("parts iterator is missing name");
+                        let metric_type =
+                            parts.next().expect("parts iterator is missing metric type");
+                        let metric_type: MetricType =
+                            metric_type.parse().expect("failed to parse metric type");
                         // summary and histogram metrics additionally report names suffixed with _sum, _count, _bucket
                         if matches!(metric_type, MetricType::Histogram | MetricType::Summary) {
                             typemap.insert(format!("{name}_sum"), metric_type);
@@ -151,10 +149,8 @@ impl Prometheus {
                     let mut parts = line.split_ascii_whitespace();
                     let name_and_labels = parts
                         .next()
-                        .expect("Error: parts iterator is missing name and labels");
-                    let value = parts
-                        .next()
-                        .expect("Error: parts iterator is missing value");
+                        .expect("parts iterator is missing name and labels");
+                    let value = parts.next().expect("parts iterator is missing value");
 
                     if value.contains('#') {
                         trace!("Unknown format: {value}");
@@ -167,7 +163,7 @@ impl Prometheus {
                             let labels = labels.split(',').map(|label| {
                                 let (label_name, label_value) = label
                                     .split_once('=')
-                                    .expect("Error: label failed to split on first =");
+                                    .expect("label failed to split on first =");
                                 let label_value = label_value.trim_matches('\"');
                                 (label_name.to_owned(), label_value.to_owned())
                             });

--- a/lading/src/target_metrics/prometheus.rs
+++ b/lading/src/target_metrics/prometheus.rs
@@ -131,9 +131,13 @@ impl Prometheus {
 
                     if line.starts_with("# TYPE") {
                         let mut parts = line.split_ascii_whitespace().skip(2);
-                        let name = parts.next().unwrap();
-                        let metric_type = parts.next().unwrap();
-                        let metric_type: MetricType = metric_type.parse().unwrap();
+                        let name = parts.next().expect("Error: parts iterator is missing name");
+                        let metric_type = parts
+                            .next()
+                            .expect("Error: parts iterator is missing metric type");
+                        let metric_type: MetricType = metric_type
+                            .parse()
+                            .expect("Error: failed to parse metric type");
                         // summary and histogram metrics additionally report names suffixed with _sum, _count, _bucket
                         if matches!(metric_type, MetricType::Histogram | MetricType::Summary) {
                             typemap.insert(format!("{name}_sum"), metric_type);
@@ -145,8 +149,12 @@ impl Prometheus {
                     }
 
                     let mut parts = line.split_ascii_whitespace();
-                    let name_and_labels = parts.next().unwrap();
-                    let value = parts.next().unwrap();
+                    let name_and_labels = parts
+                        .next()
+                        .expect("Error: parts iterator is missing name and labels");
+                    let value = parts
+                        .next()
+                        .expect("Error: parts iterator is missing value");
 
                     if value.contains('#') {
                         trace!("Unknown format: {value}");
@@ -157,7 +165,9 @@ impl Prometheus {
                         if let Some((name, labels)) = name_and_labels.split_once('{') {
                             let labels = labels.trim_end_matches('}');
                             let labels = labels.split(',').map(|label| {
-                                let (label_name, label_value) = label.split_once('=').unwrap();
+                                let (label_name, label_value) = label
+                                    .split_once('=')
+                                    .expect("Error: label failed to split on first =");
                                 let label_value = label_value.trim_matches('\"');
                                 (label_name.to_owned(), label_value.to_owned())
                             });

--- a/lading_capture/build.rs
+++ b/lading_capture/build.rs
@@ -2,7 +2,7 @@ fn main() {
     println!("cargo:rerun-if-changed=proto/",);
 
     let manifest_dir =
-        std::env::var("CARGO_MANIFEST_DIR").expect("Error: CARGO_MANIFEST_DIR var not found");
+        std::env::var("CARGO_MANIFEST_DIR").expect("CARGO_MANIFEST_DIR var not found");
     let payloads_proto = format!("{manifest_dir}/../../");
 
     let includes = ["proto/", &payloads_proto];
@@ -10,5 +10,5 @@ fn main() {
         .out_dir("src/proto")
         .extern_path(".libs", "")
         .compile_protos(&["proto/capture/v1/capture.proto"], &includes)
-        .expect("Error: Failed to compile protos!");
+        .expect("Failed to compile protos!");
 }

--- a/lading_capture/build.rs
+++ b/lading_capture/build.rs
@@ -1,7 +1,8 @@
 fn main() {
     println!("cargo:rerun-if-changed=proto/",);
 
-    let manifest_dir = std::env::var("CARGO_MANIFEST_DIR").unwrap();
+    let manifest_dir =
+        std::env::var("CARGO_MANIFEST_DIR").expect("Error: CARGO_MANIFEST_DIR var not found");
     let payloads_proto = format!("{manifest_dir}/../../");
 
     let includes = ["proto/", &payloads_proto];
@@ -9,5 +10,5 @@ fn main() {
         .out_dir("src/proto")
         .extern_path(".libs", "")
         .compile_protos(&["proto/capture/v1/capture.proto"], &includes)
-        .unwrap();
+        .expect("Error: Failed to compile protos!");
 }

--- a/lading_payload/benches/apache_common.rs
+++ b/lading_payload/benches/apache_common.rs
@@ -26,7 +26,7 @@ fn apache_common_all(c: &mut Criterion) {
                 let mut writer = Vec::with_capacity(size);
 
                 ac.to_bytes(rng, size, &mut writer)
-                    .expect("Error: failed to convert to bytes");
+                    .expect("failed to convert to bytes");
             });
         });
     }

--- a/lading_payload/benches/apache_common.rs
+++ b/lading_payload/benches/apache_common.rs
@@ -25,7 +25,8 @@ fn apache_common_all(c: &mut Criterion) {
                 let ac = apache_common::ApacheCommon::new(&mut rng);
                 let mut writer = Vec::with_capacity(size);
 
-                ac.to_bytes(rng, size, &mut writer).unwrap();
+                ac.to_bytes(rng, size, &mut writer)
+                    .expect("Error: failed to convert to bytes");
             });
         });
     }

--- a/lading_payload/benches/ascii.rs
+++ b/lading_payload/benches/ascii.rs
@@ -25,7 +25,8 @@ fn ascii_all(c: &mut Criterion) {
                 let asc = ascii::Ascii::new(&mut rng);
                 let mut writer = Vec::with_capacity(size);
 
-                asc.to_bytes(rng, size, &mut writer).unwrap();
+                asc.to_bytes(rng, size, &mut writer)
+                    .expect("Error: failed to convert to bytes");
             });
         });
     }

--- a/lading_payload/benches/ascii.rs
+++ b/lading_payload/benches/ascii.rs
@@ -26,7 +26,7 @@ fn ascii_all(c: &mut Criterion) {
                 let mut writer = Vec::with_capacity(size);
 
                 asc.to_bytes(rng, size, &mut writer)
-                    .expect("Error: failed to convert to bytes");
+                    .expect("failed to convert to bytes");
             });
         });
     }

--- a/lading_payload/benches/dogstatsd.rs
+++ b/lading_payload/benches/dogstatsd.rs
@@ -26,7 +26,7 @@ fn dogstatsd_all(c: &mut Criterion) {
                 let mut writer = Vec::with_capacity(size);
 
                 dd.to_bytes(rng, size, &mut writer)
-                    .expect("Error: failed to convert to bytes");
+                    .expect("failed to convert to bytes");
             });
         });
     }

--- a/lading_payload/benches/dogstatsd.rs
+++ b/lading_payload/benches/dogstatsd.rs
@@ -25,7 +25,8 @@ fn dogstatsd_all(c: &mut Criterion) {
                 let dd = dogstatsd::DogStatsD::default(&mut rng);
                 let mut writer = Vec::with_capacity(size);
 
-                dd.to_bytes(rng, size, &mut writer).unwrap();
+                dd.to_bytes(rng, size, &mut writer)
+                    .expect("Error: failed to convert to bytes");
             });
         });
     }

--- a/lading_payload/benches/fluent.rs
+++ b/lading_payload/benches/fluent.rs
@@ -25,7 +25,8 @@ fn fluent_all(c: &mut Criterion) {
                 let ta = Fluent::new(&mut rng);
                 let mut writer = Vec::with_capacity(size);
 
-                ta.to_bytes(rng, size, &mut writer).unwrap();
+                ta.to_bytes(rng, size, &mut writer)
+                    .expect("Error: failed to convert to bytes");
             });
         });
     }

--- a/lading_payload/benches/fluent.rs
+++ b/lading_payload/benches/fluent.rs
@@ -26,7 +26,7 @@ fn fluent_all(c: &mut Criterion) {
                 let mut writer = Vec::with_capacity(size);
 
                 ta.to_bytes(rng, size, &mut writer)
-                    .expect("Error: failed to convert to bytes");
+                    .expect("failed to convert to bytes");
             });
         });
     }

--- a/lading_payload/benches/opentelemetry_log.rs
+++ b/lading_payload/benches/opentelemetry_log.rs
@@ -26,7 +26,7 @@ fn opentelemetry_log_all(c: &mut Criterion) {
                 let mut writer = Vec::with_capacity(size);
 
                 ot.to_bytes(rng, size, &mut writer)
-                    .expect("Error: failed to convert to bytes");
+                    .expect("failed to convert to bytes");
             });
         });
     }

--- a/lading_payload/benches/opentelemetry_log.rs
+++ b/lading_payload/benches/opentelemetry_log.rs
@@ -25,7 +25,8 @@ fn opentelemetry_log_all(c: &mut Criterion) {
                 let ot = OpentelemetryLogs::new(&mut rng);
                 let mut writer = Vec::with_capacity(size);
 
-                ot.to_bytes(rng, size, &mut writer).unwrap();
+                ot.to_bytes(rng, size, &mut writer)
+                    .expect("Error: failed to convert to bytes");
             });
         });
     }

--- a/lading_payload/benches/opentelemetry_metric.rs
+++ b/lading_payload/benches/opentelemetry_metric.rs
@@ -26,7 +26,7 @@ fn opentelemetry_metric_all(c: &mut Criterion) {
                 let mut writer = Vec::with_capacity(size);
 
                 ot.to_bytes(rng, size, &mut writer)
-                    .expect("Error: failed to convert to bytes");
+                    .expect("failed to convert to bytes");
             });
         });
     }

--- a/lading_payload/benches/opentelemetry_metric.rs
+++ b/lading_payload/benches/opentelemetry_metric.rs
@@ -25,7 +25,8 @@ fn opentelemetry_metric_all(c: &mut Criterion) {
                 let ot = OpentelemetryMetrics::new(&mut rng);
                 let mut writer = Vec::with_capacity(size);
 
-                ot.to_bytes(rng, size, &mut writer).unwrap();
+                ot.to_bytes(rng, size, &mut writer)
+                    .expect("Error: failed to convert to bytes");
             });
         });
     }

--- a/lading_payload/benches/opentelemetry_traces.rs
+++ b/lading_payload/benches/opentelemetry_traces.rs
@@ -25,7 +25,8 @@ fn opentelemetry_traces_all(c: &mut Criterion) {
                 let ot = OpentelemetryTraces::new(&mut rng);
                 let mut writer = Vec::with_capacity(size);
 
-                ot.to_bytes(rng, size, &mut writer).unwrap();
+                ot.to_bytes(rng, size, &mut writer)
+                    .expect("Error: failed to convert to bytes");
             });
         });
     }

--- a/lading_payload/benches/opentelemetry_traces.rs
+++ b/lading_payload/benches/opentelemetry_traces.rs
@@ -26,7 +26,7 @@ fn opentelemetry_traces_all(c: &mut Criterion) {
                 let mut writer = Vec::with_capacity(size);
 
                 ot.to_bytes(rng, size, &mut writer)
-                    .expect("Error: failed to convert to bytes");
+                    .expect("failed to convert to bytes");
             });
         });
     }

--- a/lading_payload/benches/trace_agent.rs
+++ b/lading_payload/benches/trace_agent.rs
@@ -26,7 +26,7 @@ fn trace_agent_all(c: &mut Criterion) {
                 let mut writer = Vec::with_capacity(size);
 
                 ta.to_bytes(rng, size, &mut writer)
-                    .expect("Error: failed to convert to bytes");
+                    .expect("failed to convert to bytes");
             });
         });
     }

--- a/lading_payload/benches/trace_agent.rs
+++ b/lading_payload/benches/trace_agent.rs
@@ -25,7 +25,8 @@ fn trace_agent_all(c: &mut Criterion) {
                 let ta = trace_agent::TraceAgent::msg_pack(&mut rng);
                 let mut writer = Vec::with_capacity(size);
 
-                ta.to_bytes(rng, size, &mut writer).unwrap();
+                ta.to_bytes(rng, size, &mut writer)
+                    .expect("Error: failed to convert to bytes");
             });
         });
     }

--- a/lading_payload/src/apache_common.rs
+++ b/lading_payload/src/apache_common.rs
@@ -30,7 +30,7 @@ impl Distribution<StatusCode> for Standard {
         StatusCode(
             *STATUS_CODES
                 .choose(rng)
-                .expect("Error: failed to choose status codes"),
+                .expect("failed to choose status codes"),
         )
     }
 }
@@ -328,7 +328,7 @@ impl<'a> Generator<'a> for ApacheCommon {
             user: self
                 .str_pool
                 .of_size_range(&mut rng, 1_u16..16_u16)
-                .expect("Error: failed to generate string"),
+                .expect("failed to generate string"),
             timestamp: rng.gen(),
             method: rng.gen(),
             path: rng.gen(),
@@ -379,11 +379,11 @@ mod test {
             let apache = ApacheCommon::new(&mut rng);
 
             let mut bytes = Vec::with_capacity(max_bytes);
-            apache.to_bytes(rng, max_bytes, &mut bytes).expect("Error: failed to convert to bytes");
+            apache.to_bytes(rng, max_bytes, &mut bytes).expect("failed to convert to bytes");
             debug_assert!(
                 bytes.len() <= max_bytes,
                 "{:?}",
-                std::str::from_utf8(&bytes).expect("Error: failed to convert from utf-8 to str")
+                std::str::from_utf8(&bytes).expect("failed to convert from utf-8 to str")
             );
         }
     }

--- a/lading_payload/src/apache_common.rs
+++ b/lading_payload/src/apache_common.rs
@@ -27,7 +27,11 @@ impl Distribution<StatusCode> for Standard {
     where
         R: Rng + ?Sized,
     {
-        StatusCode(*STATUS_CODES.choose(rng).unwrap())
+        StatusCode(
+            *STATUS_CODES
+                .choose(rng)
+                .expect("Error: failed to choose status codes"),
+        )
     }
 }
 
@@ -324,7 +328,7 @@ impl<'a> Generator<'a> for ApacheCommon {
             user: self
                 .str_pool
                 .of_size_range(&mut rng, 1_u16..16_u16)
-                .unwrap(),
+                .expect("Error: failed to generate string"),
             timestamp: rng.gen(),
             method: rng.gen(),
             path: rng.gen(),
@@ -375,11 +379,11 @@ mod test {
             let apache = ApacheCommon::new(&mut rng);
 
             let mut bytes = Vec::with_capacity(max_bytes);
-            apache.to_bytes(rng, max_bytes, &mut bytes).unwrap();
+            apache.to_bytes(rng, max_bytes, &mut bytes).expect("Error: failed to convert to bytes");
             debug_assert!(
                 bytes.len() <= max_bytes,
                 "{:?}",
-                std::str::from_utf8(&bytes).unwrap()
+                std::str::from_utf8(&bytes).expect("Error: failed to convert from utf-8 to str")
             );
         }
     }

--- a/lading_payload/src/ascii.rs
+++ b/lading_payload/src/ascii.rs
@@ -42,7 +42,7 @@ impl crate::Serialize for Ascii {
             let encoding: &str = self
                 .pool
                 .of_size(&mut rng, usize::from(bytes))
-                .expect("Error: failed to generate string");
+                .expect("failed to generate string");
             let line_length = encoding.len() + 1; // add one for the newline
             match bytes_remaining.checked_sub(line_length) {
                 Some(remainder) => {
@@ -72,7 +72,7 @@ mod test {
             let ascii = Ascii::new(&mut rng);
 
             let mut bytes = Vec::with_capacity(max_bytes);
-            ascii.to_bytes(rng, max_bytes, &mut bytes).expect("Error: failed to convert to bytes");
+            ascii.to_bytes(rng, max_bytes, &mut bytes).expect("failed to convert to bytes");
             prop_assert!(bytes.len() <= max_bytes);
         }
     }

--- a/lading_payload/src/ascii.rs
+++ b/lading_payload/src/ascii.rs
@@ -39,7 +39,10 @@ impl crate::Serialize for Ascii {
             let bytes = rng.gen_range(1..MAX_LENGTH);
             // SAFETY: the maximum request is always less than the size of the
             // pool, per our constructor.
-            let encoding: &str = self.pool.of_size(&mut rng, usize::from(bytes)).unwrap();
+            let encoding: &str = self
+                .pool
+                .of_size(&mut rng, usize::from(bytes))
+                .expect("Error: failed to generate string");
             let line_length = encoding.len() + 1; // add one for the newline
             match bytes_remaining.checked_sub(line_length) {
                 Some(remainder) => {
@@ -69,7 +72,7 @@ mod test {
             let ascii = Ascii::new(&mut rng);
 
             let mut bytes = Vec::with_capacity(max_bytes);
-            ascii.to_bytes(rng, max_bytes, &mut bytes).unwrap();
+            ascii.to_bytes(rng, max_bytes, &mut bytes).expect("Error: failed to convert to bytes");
             prop_assert!(bytes.len() <= max_bytes);
         }
     }

--- a/lading_payload/src/block.rs
+++ b/lading_payload/src/block.rs
@@ -88,7 +88,7 @@ impl<'a> arbitrary::Arbitrary<'a> for Block {
         let total_bytes = u32::arbitrary(u)?;
         let bytes = u.bytes(total_bytes as usize).map(Bytes::copy_from_slice)?;
         Ok(Self {
-            total_bytes: NonZeroU32::new(total_bytes).expect("Error: total_bytes must be non-zero"),
+            total_bytes: NonZeroU32::new(total_bytes).expect("total_bytes must be non-zero"),
             bytes,
         })
     }
@@ -561,10 +561,7 @@ fn chunk_bytes<const N: usize>(
             break;
         }
         // SAFETY: By construction, the iterator will never terminate.
-        let block_size = iter
-            .next()
-            .expect("Error: iterator has no next value")
-            .get();
+        let block_size = iter.next().expect("iterator has no next value").get();
 
         // Determine if the block_size fits in the remaining bytes. If it does,
         // great. If not, we break out of the round-robin.
@@ -665,9 +662,7 @@ where
         // push blocks into the sender until such time as it's full. When that
         // happens we overflow into the cache until such time as that's full.
         'refill: loop {
-            let block_size = block_chunks
-                .choose(&mut rng)
-                .expect("Error: rng slice is empty");
+            let block_size = block_chunks.choose(&mut rng).expect("rng slice is empty");
             if let Some(block) = construct_block(&mut rng, serializer, *block_size) {
                 match snd.try_reserve() {
                     Ok(permit) => permit.send(block),
@@ -702,7 +697,7 @@ where
     let mut block: Writer<BytesMut> = BytesMut::with_capacity(chunk_size as usize).writer();
     serializer
         .to_bytes(&mut rng, chunk_size as usize, &mut block)
-        .expect("Error: failed to convert to bytes");
+        .expect("failed to convert to bytes");
     let bytes: Bytes = block.into_inner().freeze();
     if bytes.is_empty() {
         // Blocks may be empty, especially when the amount of bytes
@@ -718,9 +713,9 @@ where
             bytes
                 .len()
                 .try_into()
-                .expect("Error: failed to get length of bytes"),
+                .expect("failed to get length of bytes"),
         )
-        .expect("Error: total_bytes must be non-zero");
+        .expect("total_bytes must be non-zero");
         Some(Block { total_bytes, bytes })
     }
 }
@@ -807,7 +802,7 @@ mod verification {
         let mut block_chunks: [u32; 10] = [0; 10];
 
         let chunks = chunk_bytes(total_bytes, &byte_sizes, &mut block_chunks)
-            .expect("Error: chunk_bytes should never fail");
+            .expect("chunk_bytes should never fail");
         kani::assert(
             chunks > 0,
             "chunk_bytes should never return an empty vec of chunks",
@@ -830,11 +825,10 @@ mod verification {
         let mut block_chunks: [u32; 10] = [0; 10];
 
         let chunks = chunk_bytes(total_bytes, &byte_sizes, &mut block_chunks)
-            .expect("Error: chunk_bytes should never fail");
+            .expect("chunk_bytes should never fail");
         for chunk in &block_chunks[0..chunks] {
             kani::assert(
-                byte_sizes
-                    .contains(&NonZeroU32::new(*chunk).expect("Error: chunk must be non-zero")),
+                byte_sizes.contains(&NonZeroU32::new(*chunk).expect("chunk must be non-zero")),
                 "chunk_bytes should never return a chunk that is not present in the byte sizes",
             );
         }
@@ -856,7 +850,7 @@ mod verification {
         let mut block_chunks: [u32; 10] = [0; 10];
 
         let chunks = chunk_bytes(total_bytes, &byte_sizes, &mut block_chunks)
-            .expect("Error: chunk_bytes should never fail");
+            .expect("chunk_bytes should never fail");
         for chunk in &block_chunks[chunks..] {
             kani::assert(
                 *chunk == 0,

--- a/lading_payload/src/datadog_logs.rs
+++ b/lading_payload/src/datadog_logs.rs
@@ -54,8 +54,15 @@ where
     R: rand::Rng + ?Sized,
 {
     match rng.gen_range(0..2) {
-        0 => Message::Unstructured(str_pool.of_size_range(rng, 1_u8..16).unwrap()),
-        1 => Message::Structured(serde_json::to_string(&rng.gen::<Structured>()).unwrap()),
+        0 => Message::Unstructured(
+            str_pool
+                .of_size_range(rng, 1_u8..16)
+                .expect("Error: failed to generate string"),
+        ),
+        1 => Message::Structured(
+            serde_json::to_string(&rng.gen::<Structured>())
+                .expect("Error: failed to generate string"),
+        ),
         _ => unreachable!(),
     }
 }
@@ -106,12 +113,22 @@ impl<'a> Generator<'a> for DatadogLog {
     {
         Member {
             message: message(&mut rng, &self.str_pool),
-            status: STATUSES.choose(rng).unwrap(),
+            status: STATUSES
+                .choose(rng)
+                .expect("Error: failed to generate status"),
             timestamp: rng.gen(),
-            hostname: HOSTNAMES.choose(rng).unwrap(),
-            service: SERVICES.choose(rng).unwrap(),
-            ddsource: SOURCES.choose(rng).unwrap(),
-            ddtags: TAG_OPTIONS.choose(rng).unwrap(),
+            hostname: HOSTNAMES
+                .choose(rng)
+                .expect("Error: failed to generate hostnames"),
+            service: SERVICES
+                .choose(rng)
+                .expect("Error: failed to generate services"),
+            ddsource: SOURCES
+                .choose(rng)
+                .expect("Error: failed to generate sources"),
+            ddtags: TAG_OPTIONS
+                .choose(rng)
+                .expect("Error: failed to generate tag options"),
         }
     }
 }
@@ -172,11 +189,11 @@ mod test {
             let ddlogs = DatadogLog::new(&mut rng);
 
             let mut bytes = Vec::with_capacity(max_bytes);
-            ddlogs.to_bytes(rng, max_bytes, &mut bytes).unwrap();
+            ddlogs.to_bytes(rng, max_bytes, &mut bytes).expect("Error: failed to convert to bytes");
             debug_assert!(
                 bytes.len() <= max_bytes,
                 "{:?}",
-                std::str::from_utf8(&bytes).unwrap()
+                std::str::from_utf8(&bytes).expect("Error: failed to convert from utf-8 to str")
             );
         }
     }
@@ -191,11 +208,11 @@ mod test {
             let ddlogs = DatadogLog::new(&mut rng);
 
             let mut bytes: Vec<u8> = Vec::with_capacity(max_bytes);
-            ddlogs.to_bytes(rng, max_bytes, &mut bytes).unwrap();
+            ddlogs.to_bytes(rng, max_bytes, &mut bytes).expect("Error: failed to convert to bytes");
 
-            let payload = std::str::from_utf8(&bytes).unwrap();
+            let payload = std::str::from_utf8(&bytes).expect("Error: failed to convert from utf-8 to str");
             for msg in payload.lines() {
-                let _members: Vec<Member> = serde_json::from_str(msg).unwrap();
+                let _members: Vec<Member> = serde_json::from_str(msg).expect("Error: failed to deserialize from str");
             }
         }
     }

--- a/lading_payload/src/datadog_logs.rs
+++ b/lading_payload/src/datadog_logs.rs
@@ -57,11 +57,10 @@ where
         0 => Message::Unstructured(
             str_pool
                 .of_size_range(rng, 1_u8..16)
-                .expect("Error: failed to generate string"),
+                .expect("failed to generate string"),
         ),
         1 => Message::Structured(
-            serde_json::to_string(&rng.gen::<Structured>())
-                .expect("Error: failed to generate string"),
+            serde_json::to_string(&rng.gen::<Structured>()).expect("failed to generate string"),
         ),
         _ => unreachable!(),
     }
@@ -113,22 +112,14 @@ impl<'a> Generator<'a> for DatadogLog {
     {
         Member {
             message: message(&mut rng, &self.str_pool),
-            status: STATUSES
-                .choose(rng)
-                .expect("Error: failed to generate status"),
+            status: STATUSES.choose(rng).expect("failed to generate status"),
             timestamp: rng.gen(),
-            hostname: HOSTNAMES
-                .choose(rng)
-                .expect("Error: failed to generate hostnames"),
-            service: SERVICES
-                .choose(rng)
-                .expect("Error: failed to generate services"),
-            ddsource: SOURCES
-                .choose(rng)
-                .expect("Error: failed to generate sources"),
+            hostname: HOSTNAMES.choose(rng).expect("failed to generate hostnames"),
+            service: SERVICES.choose(rng).expect("failed to generate services"),
+            ddsource: SOURCES.choose(rng).expect("failed to generate sources"),
             ddtags: TAG_OPTIONS
                 .choose(rng)
-                .expect("Error: failed to generate tag options"),
+                .expect("failed to generate tag options"),
         }
     }
 }
@@ -189,11 +180,11 @@ mod test {
             let ddlogs = DatadogLog::new(&mut rng);
 
             let mut bytes = Vec::with_capacity(max_bytes);
-            ddlogs.to_bytes(rng, max_bytes, &mut bytes).expect("Error: failed to convert to bytes");
+            ddlogs.to_bytes(rng, max_bytes, &mut bytes).expect("failed to convert to bytes");
             debug_assert!(
                 bytes.len() <= max_bytes,
                 "{:?}",
-                std::str::from_utf8(&bytes).expect("Error: failed to convert from utf-8 to str")
+                std::str::from_utf8(&bytes).expect("failed to convert from utf-8 to str")
             );
         }
     }
@@ -208,11 +199,11 @@ mod test {
             let ddlogs = DatadogLog::new(&mut rng);
 
             let mut bytes: Vec<u8> = Vec::with_capacity(max_bytes);
-            ddlogs.to_bytes(rng, max_bytes, &mut bytes).expect("Error: failed to convert to bytes");
+            ddlogs.to_bytes(rng, max_bytes, &mut bytes).expect("failed to convert to bytes");
 
-            let payload = std::str::from_utf8(&bytes).expect("Error: failed to convert from utf-8 to str");
+            let payload = std::str::from_utf8(&bytes).expect("failed to convert from utf-8 to str");
             for msg in payload.lines() {
-                let _members: Vec<Member> = serde_json::from_str(msg).expect("Error: failed to deserialize from str");
+                let _members: Vec<Member> = serde_json::from_str(msg).expect("failed to deserialize from str");
             }
         }
     }

--- a/lading_payload/src/dogstatsd.rs
+++ b/lading_payload/src/dogstatsd.rs
@@ -418,7 +418,10 @@ where
     let mut buf = Vec::with_capacity(total);
     for _ in 0..total {
         let sz = length_range.sample(&mut rng) as usize;
-        buf.push(String::from(pool.of_size(&mut rng, sz).unwrap()));
+        buf.push(String::from(
+            pool.of_size(&mut rng, sz)
+                .expect("Error: failed to generate string"),
+        ));
     }
     buf
 }
@@ -611,7 +614,7 @@ impl DogStatsD {
             length_prefix_framed(),
             rng,
         )
-        .unwrap()
+        .expect("Error: failed to create DogStatsD")
     }
 
     /// Generate a single `Member`.
@@ -813,14 +816,14 @@ mod test {
                                            name_length(), tag_key_length(),
                                            tag_value_length(), tags_per_msg(),
                                            multivalue_count(), multivalue_pack_probability, sampling_range(), sampling_probability(), kind_weights,
-                                           metric_weights, value_conf, false, &mut rng).unwrap();
+                                           metric_weights, value_conf, false, &mut rng).expect("Error: failed to create DogStatsD");
 
             let mut bytes = Vec::with_capacity(max_bytes);
-            dogstatsd.to_bytes(rng, max_bytes, &mut bytes).unwrap();
+            dogstatsd.to_bytes(rng, max_bytes, &mut bytes).expect("Error: failed to convert to bytes");
             debug_assert!(
                 bytes.len() <= max_bytes,
                 "{:?}",
-                std::str::from_utf8(&bytes).unwrap()
+                std::str::from_utf8(&bytes).expect("Error: failed to convert from utf-8 to str")
             );
         }
     }
@@ -841,14 +844,14 @@ mod test {
                                            name_length(), tag_key_length(),
                                            tag_value_length(), tags_per_msg(),
                                            multivalue_count(), multivalue_pack_probability, sampling_range(), sampling_probability(), kind_weights,
-                                           metric_weights, value_conf, true, &mut rng).unwrap();
+                                           metric_weights, value_conf, true, &mut rng).expect("Error: failed to create DogStatsD");
 
             let mut bytes = Vec::with_capacity(max_bytes);
-            dogstatsd.to_bytes(rng, max_bytes, &mut bytes).unwrap();
+            dogstatsd.to_bytes(rng, max_bytes, &mut bytes).expect("Error: failed to convert to bytes");
             debug_assert!(
                 bytes.len() <= max_bytes,
                 "{:?}",
-                std::str::from_utf8(&bytes).unwrap()
+                std::str::from_utf8(&bytes).expect("Error: failed to convert from utf-8 to str")
             );
         }
     }

--- a/lading_payload/src/dogstatsd.rs
+++ b/lading_payload/src/dogstatsd.rs
@@ -420,7 +420,7 @@ where
         let sz = length_range.sample(&mut rng) as usize;
         buf.push(String::from(
             pool.of_size(&mut rng, sz)
-                .expect("Error: failed to generate string"),
+                .expect("failed to generate string"),
         ));
     }
     buf
@@ -614,7 +614,7 @@ impl DogStatsD {
             length_prefix_framed(),
             rng,
         )
-        .expect("Error: failed to create DogStatsD")
+        .expect("failed to create DogStatsD")
     }
 
     /// Generate a single `Member`.
@@ -816,14 +816,14 @@ mod test {
                                            name_length(), tag_key_length(),
                                            tag_value_length(), tags_per_msg(),
                                            multivalue_count(), multivalue_pack_probability, sampling_range(), sampling_probability(), kind_weights,
-                                           metric_weights, value_conf, false, &mut rng).expect("Error: failed to create DogStatsD");
+                                           metric_weights, value_conf, false, &mut rng).expect("failed to create DogStatsD");
 
             let mut bytes = Vec::with_capacity(max_bytes);
-            dogstatsd.to_bytes(rng, max_bytes, &mut bytes).expect("Error: failed to convert to bytes");
+            dogstatsd.to_bytes(rng, max_bytes, &mut bytes).expect("failed to convert to bytes");
             debug_assert!(
                 bytes.len() <= max_bytes,
                 "{:?}",
-                std::str::from_utf8(&bytes).expect("Error: failed to convert from utf-8 to str")
+                std::str::from_utf8(&bytes).expect("failed to convert from utf-8 to str")
             );
         }
     }
@@ -844,14 +844,14 @@ mod test {
                                            name_length(), tag_key_length(),
                                            tag_value_length(), tags_per_msg(),
                                            multivalue_count(), multivalue_pack_probability, sampling_range(), sampling_probability(), kind_weights,
-                                           metric_weights, value_conf, true, &mut rng).expect("Error: failed to create DogStatsD");
+                                           metric_weights, value_conf, true, &mut rng).expect("failed to create DogStatsD");
 
             let mut bytes = Vec::with_capacity(max_bytes);
-            dogstatsd.to_bytes(rng, max_bytes, &mut bytes).expect("Error: failed to convert to bytes");
+            dogstatsd.to_bytes(rng, max_bytes, &mut bytes).expect("failed to convert to bytes");
             debug_assert!(
                 bytes.len() <= max_bytes,
                 "{:?}",
-                std::str::from_utf8(&bytes).expect("Error: failed to convert from utf-8 to str")
+                std::str::from_utf8(&bytes).expect("failed to convert from utf-8 to str")
             );
         }
     }

--- a/lading_payload/src/dogstatsd/event.rs
+++ b/lading_payload/src/dogstatsd/event.rs
@@ -27,11 +27,11 @@ impl<'a> Generator<'a> for EventGenerator {
         let title = self
             .str_pool
             .of_size(&mut rng, title_sz)
-            .expect("Error: failed to generate string");
+            .expect("failed to generate string");
         let text = self
             .str_pool
             .of_size_range(&mut rng, self.texts_or_messages_length_range.clone())
-            .expect("Error: failed to generate string");
+            .expect("failed to generate string");
         let tags = if rng.gen() {
             Some(self.tags_generator.generate(&mut rng))
         } else {

--- a/lading_payload/src/dogstatsd/event.rs
+++ b/lading_payload/src/dogstatsd/event.rs
@@ -24,11 +24,14 @@ impl<'a> Generator<'a> for EventGenerator {
         R: rand::Rng + ?Sized,
     {
         let title_sz = self.title_length.sample(&mut rng) as usize;
-        let title = self.str_pool.of_size(&mut rng, title_sz).unwrap();
+        let title = self
+            .str_pool
+            .of_size(&mut rng, title_sz)
+            .expect("Error: failed to generate string");
         let text = self
             .str_pool
             .of_size_range(&mut rng, self.texts_or_messages_length_range.clone())
-            .unwrap();
+            .expect("Error: failed to generate string");
         let tags = if rng.gen() {
             Some(self.tags_generator.generate(&mut rng))
         } else {

--- a/lading_payload/src/dogstatsd/metric.rs
+++ b/lading_payload/src/dogstatsd/metric.rs
@@ -57,7 +57,7 @@ impl MetricGenerator {
             let name = String::from(
                 str_pool
                     .of_size(&mut rng, name_sz)
-                    .expect("Error: failed to generate string"),
+                    .expect("failed to generate string"),
             );
 
             let res = match metric_weights.sample(rng) {
@@ -96,7 +96,7 @@ impl<'a> Generator<'a> for MetricGenerator {
         let template: &Template = self
             .templates
             .choose(&mut rng)
-            .expect("Error: failed to choose templates");
+            .expect("failed to choose templates");
 
         let container_id = choose_or_not_ref(&mut rng, &self.container_ids).map(String::as_str);
         // https://docs.datadoghq.com/metrics/custom_metrics/dogstatsd_metrics_submission/#sample-rates
@@ -104,7 +104,7 @@ impl<'a> Generator<'a> for MetricGenerator {
         let sample_rate = if prob < self.sampling_probability {
             let sample_rate = self.sampling.sample(&mut rng).clamp(0.0, 1.0);
             let sample_rate = common::ZeroToOne::try_from(sample_rate)
-                .expect("Error: failed to convert sample rate to ZeroToOne");
+                .expect("failed to convert sample rate to ZeroToOne");
             Some(sample_rate)
         } else {
             None
@@ -159,7 +159,7 @@ impl<'a> Generator<'a> for MetricGenerator {
             }),
             Template::Set(ref set) => Metric::Set(Set {
                 name: &set.name,
-                value: values.pop().expect("Error: failed to pop value from Vec"),
+                value: values.pop().expect("failed to pop value from Vec"),
                 tags: &set.tags,
                 container_id,
             }),

--- a/lading_payload/src/dogstatsd/service_check.rs
+++ b/lading_payload/src/dogstatsd/service_check.rs
@@ -25,7 +25,10 @@ impl<'a> Generator<'a> for ServiceCheckGenerator {
     where
         R: rand::Rng + ?Sized,
     {
-        let name = self.names.choose(&mut rng).unwrap();
+        let name = self
+            .names
+            .choose(&mut rng)
+            .expect("Error: failed to choose name");
         let hostname = choose_or_not_ref(&mut rng, &self.small_strings).map(String::as_str);
         let message = choose_or_not_ref(&mut rng, &self.texts_or_messages).map(String::as_str);
         let tags = if rng.gen() {

--- a/lading_payload/src/dogstatsd/service_check.rs
+++ b/lading_payload/src/dogstatsd/service_check.rs
@@ -25,10 +25,7 @@ impl<'a> Generator<'a> for ServiceCheckGenerator {
     where
         R: rand::Rng + ?Sized,
     {
-        let name = self
-            .names
-            .choose(&mut rng)
-            .expect("Error: failed to choose name");
+        let name = self.names.choose(&mut rng).expect("failed to choose name");
         let hostname = choose_or_not_ref(&mut rng, &self.small_strings).map(String::as_str);
         let message = choose_or_not_ref(&mut rng, &self.texts_or_messages).map(String::as_str);
         let tags = if rng.gen() {

--- a/lading_payload/src/fluent.rs
+++ b/lading_payload/src/fluent.rs
@@ -43,7 +43,7 @@ impl<'a> Generator<'a> for Fluent {
                     let key = self
                         .str_pool
                         .of_size_range(rng, 1_u8..16)
-                        .expect("Error: failed to generate string");
+                        .expect("failed to generate string");
                     let val = record_value(rng, &self.str_pool);
                     rec.insert(key, val);
                 }
@@ -51,7 +51,7 @@ impl<'a> Generator<'a> for Fluent {
                     tag: self
                         .str_pool
                         .of_size_range(rng, 1_u8..16)
-                        .expect("Error: failed to generate string"),
+                        .expect("failed to generate string"),
                     time: rng.gen(),
                     record: rec,
                 })
@@ -66,7 +66,7 @@ impl<'a> Generator<'a> for Fluent {
                         let key = self
                             .str_pool
                             .of_size_range(rng, 1_u8..16)
-                            .expect("Error: failed to generate string");
+                            .expect("failed to generate string");
                         let val = record_value(rng, &self.str_pool);
                         rec.insert(key, val);
                     }
@@ -80,7 +80,7 @@ impl<'a> Generator<'a> for Fluent {
                     tag: self
                         .str_pool
                         .of_size_range(rng, 1_u8..16)
-                        .expect("Error: failed to generate string"),
+                        .expect("failed to generate string"),
                     entries,
                 })
             }
@@ -124,14 +124,14 @@ where
         0 => RecordValue::String(
             str_pool
                 .of_size_range(rng, 1_u8..16)
-                .expect("Error: failed to generate string"),
+                .expect("failed to generate string"),
         ),
         1 => {
             let mut obj = FxHashMap::default();
             for _ in 0..rng.gen_range(0..128) {
                 let key = str_pool
                     .of_size_range(rng, 1_u8..16)
-                    .expect("Error: failed to generate string");
+                    .expect("failed to generate string");
                 let val = rng.gen();
 
                 obj.insert(key, val);
@@ -166,7 +166,7 @@ impl crate::Serialize for Fluent {
 
         let mut members: Vec<Vec<u8>> = (0..10)
             .map(|_| self.generate(&mut rng))
-            .map(|m: Member| rmp_serde::to_vec(&m).expect("Error: failed to serialize"))
+            .map(|m: Member| rmp_serde::to_vec(&m).expect("failed to serialize"))
             .collect();
 
         // Search for too many Member instances.
@@ -179,7 +179,7 @@ impl crate::Serialize for Fluent {
             members.extend(
                 (0..10)
                     .map(|_| self.generate(&mut rng))
-                    .map(|m: Member| rmp_serde::to_vec(&m).expect("Error: failed to serialize")),
+                    .map(|m: Member| rmp_serde::to_vec(&m).expect("failed to serialize")),
             );
         }
 
@@ -218,11 +218,11 @@ mod test {
             let fluent = Fluent::new(&mut rng);
 
             let mut bytes = Vec::with_capacity(max_bytes);
-            fluent.to_bytes(rng, max_bytes, &mut bytes).expect("Error: failed to convert to bytes");
+            fluent.to_bytes(rng, max_bytes, &mut bytes).expect("failed to convert to bytes");
             debug_assert!(
                 bytes.len() <= max_bytes,
                 "{:?}",
-                std::str::from_utf8(&bytes).expect("Error: failed to convert from utf-8 to str")
+                std::str::from_utf8(&bytes).expect("failed to convert from utf-8 to str")
             );
         }
     }

--- a/lading_payload/src/fluent.rs
+++ b/lading_payload/src/fluent.rs
@@ -40,12 +40,18 @@ impl<'a> Generator<'a> for Fluent {
                 let mut rec = FxHashMap::default();
                 rec.insert("message", record_value(rng, &self.str_pool));
                 for _ in 0..rng.gen_range(0..128) {
-                    let key = self.str_pool.of_size_range(rng, 1_u8..16).unwrap();
+                    let key = self
+                        .str_pool
+                        .of_size_range(rng, 1_u8..16)
+                        .expect("Error: failed to generate string");
                     let val = record_value(rng, &self.str_pool);
                     rec.insert(key, val);
                 }
                 Member::Message(FluentMessage {
-                    tag: self.str_pool.of_size_range(rng, 1_u8..16).unwrap(),
+                    tag: self
+                        .str_pool
+                        .of_size_range(rng, 1_u8..16)
+                        .expect("Error: failed to generate string"),
                     time: rng.gen(),
                     record: rec,
                 })
@@ -57,7 +63,10 @@ impl<'a> Generator<'a> for Fluent {
                     rec.insert("message", record_value(rng, &self.str_pool));
                     rec.insert("event", record_value(rng, &self.str_pool));
                     for _ in 0..rng.gen_range(0..128) {
-                        let key = self.str_pool.of_size_range(rng, 1_u8..16).unwrap();
+                        let key = self
+                            .str_pool
+                            .of_size_range(rng, 1_u8..16)
+                            .expect("Error: failed to generate string");
                         let val = record_value(rng, &self.str_pool);
                         rec.insert(key, val);
                     }
@@ -68,7 +77,10 @@ impl<'a> Generator<'a> for Fluent {
                 }
 
                 Member::Forward(FluentForward {
-                    tag: self.str_pool.of_size_range(rng, 1_u8..16).unwrap(),
+                    tag: self
+                        .str_pool
+                        .of_size_range(rng, 1_u8..16)
+                        .expect("Error: failed to generate string"),
                     entries,
                 })
             }
@@ -109,11 +121,17 @@ where
     R: rand::Rng + ?Sized,
 {
     match rng.gen_range(0..2) {
-        0 => RecordValue::String(str_pool.of_size_range(rng, 1_u8..16).unwrap()),
+        0 => RecordValue::String(
+            str_pool
+                .of_size_range(rng, 1_u8..16)
+                .expect("Error: failed to generate string"),
+        ),
         1 => {
             let mut obj = FxHashMap::default();
             for _ in 0..rng.gen_range(0..128) {
-                let key = str_pool.of_size_range(rng, 1_u8..16).unwrap();
+                let key = str_pool
+                    .of_size_range(rng, 1_u8..16)
+                    .expect("Error: failed to generate string");
                 let val = rng.gen();
 
                 obj.insert(key, val);
@@ -148,7 +166,7 @@ impl crate::Serialize for Fluent {
 
         let mut members: Vec<Vec<u8>> = (0..10)
             .map(|_| self.generate(&mut rng))
-            .map(|m: Member| rmp_serde::to_vec(&m).unwrap())
+            .map(|m: Member| rmp_serde::to_vec(&m).expect("Error: failed to serialize"))
             .collect();
 
         // Search for too many Member instances.
@@ -161,7 +179,7 @@ impl crate::Serialize for Fluent {
             members.extend(
                 (0..10)
                     .map(|_| self.generate(&mut rng))
-                    .map(|m: Member| rmp_serde::to_vec(&m).unwrap()),
+                    .map(|m: Member| rmp_serde::to_vec(&m).expect("Error: failed to serialize")),
             );
         }
 
@@ -200,11 +218,11 @@ mod test {
             let fluent = Fluent::new(&mut rng);
 
             let mut bytes = Vec::with_capacity(max_bytes);
-            fluent.to_bytes(rng, max_bytes, &mut bytes).unwrap();
+            fluent.to_bytes(rng, max_bytes, &mut bytes).expect("Error: failed to convert to bytes");
             debug_assert!(
                 bytes.len() <= max_bytes,
                 "{:?}",
-                std::str::from_utf8(&bytes).unwrap()
+                std::str::from_utf8(&bytes).expect("Error: failed to convert from utf-8 to str")
             );
         }
     }

--- a/lading_payload/src/json.rs
+++ b/lading_payload/src/json.rs
@@ -28,7 +28,7 @@ impl Distribution<Member> for Standard {
     where
         R: Rng + ?Sized,
     {
-        let max = SIZES.choose(rng).unwrap();
+        let max = SIZES.choose(rng).expect("Error: failed to choose size");
 
         Member {
             id: rng.gen(),
@@ -98,7 +98,7 @@ mod test {
             let json = Json;
 
             let mut bytes = Vec::with_capacity(max_bytes);
-            json.to_bytes(rng, max_bytes, &mut bytes).unwrap();
+            json.to_bytes(rng, max_bytes, &mut bytes).expect("Error: failed to convert to bytes");
             assert!(bytes.len() <= max_bytes);
         }
     }
@@ -113,11 +113,11 @@ mod test {
             let json = Json;
 
             let mut bytes: Vec<u8> = Vec::with_capacity(max_bytes);
-            json.to_bytes(rng, max_bytes, &mut bytes).unwrap();
+            json.to_bytes(rng, max_bytes, &mut bytes).expect("Error: failed to convert to bytes");
 
-            let payload = std::str::from_utf8(&bytes).unwrap();
+            let payload = std::str::from_utf8(&bytes).expect("Error: failed to convert from utf-8 to str");
             for msg in payload.lines() {
-                let _members: Member = serde_json::from_str(msg).unwrap();
+                let _members: Member = serde_json::from_str(msg).expect("Error: failed to deserialize from str");
             }
         }
     }

--- a/lading_payload/src/json.rs
+++ b/lading_payload/src/json.rs
@@ -28,7 +28,7 @@ impl Distribution<Member> for Standard {
     where
         R: Rng + ?Sized,
     {
-        let max = SIZES.choose(rng).expect("Error: failed to choose size");
+        let max = SIZES.choose(rng).expect("failed to choose size");
 
         Member {
             id: rng.gen(),
@@ -98,7 +98,7 @@ mod test {
             let json = Json;
 
             let mut bytes = Vec::with_capacity(max_bytes);
-            json.to_bytes(rng, max_bytes, &mut bytes).expect("Error: failed to convert to bytes");
+            json.to_bytes(rng, max_bytes, &mut bytes).expect("failed to convert to bytes");
             assert!(bytes.len() <= max_bytes);
         }
     }
@@ -113,11 +113,11 @@ mod test {
             let json = Json;
 
             let mut bytes: Vec<u8> = Vec::with_capacity(max_bytes);
-            json.to_bytes(rng, max_bytes, &mut bytes).expect("Error: failed to convert to bytes");
+            json.to_bytes(rng, max_bytes, &mut bytes).expect("failed to convert to bytes");
 
-            let payload = std::str::from_utf8(&bytes).expect("Error: failed to convert from utf-8 to str");
+            let payload = std::str::from_utf8(&bytes).expect("failed to convert from utf-8 to str");
             for msg in payload.lines() {
-                let _members: Member = serde_json::from_str(msg).expect("Error: failed to deserialize from str");
+                let _members: Member = serde_json::from_str(msg).expect("failed to deserialize from str");
             }
         }
     }

--- a/lading_payload/src/opentelemetry_log.rs
+++ b/lading_payload/src/opentelemetry_log.rs
@@ -69,7 +69,7 @@ impl<'a> Generator<'a> for OpentelemetryLogs {
         let body: String = String::from(
             self.str_pool
                 .of_size_range(&mut rng, 1_u16..16_u16)
-                .unwrap(),
+                .expect("Error: failed to generate string"),
         );
 
         #[allow(deprecated)]
@@ -143,7 +143,7 @@ mod test {
             let logs = OpentelemetryLogs::new(&mut rng);
 
             let mut bytes = Vec::with_capacity(max_bytes);
-            logs.to_bytes(rng, max_bytes, &mut bytes).unwrap();
+            logs.to_bytes(rng, max_bytes, &mut bytes).expect("Error: failed to convert to bytes");
             assert!(bytes.len() <= max_bytes, "max len: {max_bytes}, actual: {}", bytes.len());
         }
     }
@@ -157,7 +157,7 @@ mod test {
             let logs = OpentelemetryLogs::new(&mut rng);
 
             let mut bytes = Vec::with_capacity(max_bytes);
-            logs.to_bytes(rng, max_bytes, &mut bytes).unwrap();
+            logs.to_bytes(rng, max_bytes, &mut bytes).expect("Error: failed to convert to bytes");
 
             assert!(!bytes.is_empty());
         }
@@ -173,9 +173,9 @@ mod test {
             let logs = OpentelemetryLogs::new(&mut rng);
 
             let mut bytes: Vec<u8> = Vec::with_capacity(max_bytes);
-            logs.to_bytes(rng, max_bytes, &mut bytes).unwrap();
+            logs.to_bytes(rng, max_bytes, &mut bytes).expect("Error: failed to convert to bytes");
 
-            opentelemetry_proto::tonic::collector::logs::v1::ExportLogsServiceRequest::decode(bytes.as_slice()).unwrap();
+            opentelemetry_proto::tonic::collector::logs::v1::ExportLogsServiceRequest::decode(bytes.as_slice()).expect("Error: failed to decode the message from the buffer");
         }
     }
 }

--- a/lading_payload/src/opentelemetry_log.rs
+++ b/lading_payload/src/opentelemetry_log.rs
@@ -69,7 +69,7 @@ impl<'a> Generator<'a> for OpentelemetryLogs {
         let body: String = String::from(
             self.str_pool
                 .of_size_range(&mut rng, 1_u16..16_u16)
-                .expect("Error: failed to generate string"),
+                .expect("failed to generate string"),
         );
 
         #[allow(deprecated)]
@@ -143,7 +143,7 @@ mod test {
             let logs = OpentelemetryLogs::new(&mut rng);
 
             let mut bytes = Vec::with_capacity(max_bytes);
-            logs.to_bytes(rng, max_bytes, &mut bytes).expect("Error: failed to convert to bytes");
+            logs.to_bytes(rng, max_bytes, &mut bytes).expect("failed to convert to bytes");
             assert!(bytes.len() <= max_bytes, "max len: {max_bytes}, actual: {}", bytes.len());
         }
     }
@@ -157,7 +157,7 @@ mod test {
             let logs = OpentelemetryLogs::new(&mut rng);
 
             let mut bytes = Vec::with_capacity(max_bytes);
-            logs.to_bytes(rng, max_bytes, &mut bytes).expect("Error: failed to convert to bytes");
+            logs.to_bytes(rng, max_bytes, &mut bytes).expect("failed to convert to bytes");
 
             assert!(!bytes.is_empty());
         }
@@ -173,9 +173,9 @@ mod test {
             let logs = OpentelemetryLogs::new(&mut rng);
 
             let mut bytes: Vec<u8> = Vec::with_capacity(max_bytes);
-            logs.to_bytes(rng, max_bytes, &mut bytes).expect("Error: failed to convert to bytes");
+            logs.to_bytes(rng, max_bytes, &mut bytes).expect("failed to convert to bytes");
 
-            opentelemetry_proto::tonic::collector::logs::v1::ExportLogsServiceRequest::decode(bytes.as_slice()).expect("Error: failed to decode the message from the buffer");
+            opentelemetry_proto::tonic::collector::logs::v1::ExportLogsServiceRequest::decode(bytes.as_slice()).expect("failed to decode the message from the buffer");
         }
     }
 }

--- a/lading_payload/src/opentelemetry_metric.rs
+++ b/lading_payload/src/opentelemetry_metric.rs
@@ -92,7 +92,7 @@ impl Distribution<Sum> for Standard {
         // 2: Cumulative
         let aggregation_temporality = *[1, 2]
             .choose(rng)
-            .expect("Error: failed to choose aggregation temporality");
+            .expect("failed to choose aggregation temporality");
         let is_monotonic = rng.gen();
         let total = rng.gen_range(0..64);
         let data_points = Standard
@@ -145,15 +145,15 @@ impl<'a> Generator<'a> for OpentelemetryMetrics {
         let name = self
             .str_pool
             .of_size_range(&mut rng, 1_u8..16)
-            .expect("Error: failed to generate string");
+            .expect("failed to generate string");
         let description = self
             .str_pool
             .of_size_range(&mut rng, 1_u8..16)
-            .expect("Error: failed to generate string");
+            .expect("failed to generate string");
         let unit = self
             .str_pool
             .of_size_range(&mut rng, 1_u8..16)
-            .expect("Error: failed to generate string");
+            .expect("failed to generate string");
 
         Metric(v1::Metric {
             name: String::from(name),
@@ -214,7 +214,7 @@ mod test {
             let logs = OpentelemetryMetrics::new(&mut rng);
 
             let mut bytes = Vec::with_capacity(max_bytes);
-            logs.to_bytes(rng, max_bytes, &mut bytes).expect("Error: failed to convert to bytes");
+            logs.to_bytes(rng, max_bytes, &mut bytes).expect("failed to convert to bytes");
             assert!(bytes.len() <= max_bytes, "max len: {max_bytes}, actual: {}", bytes.len());
         }
     }
@@ -228,7 +228,7 @@ mod test {
             let logs = OpentelemetryMetrics::new(&mut rng);
 
             let mut bytes = Vec::with_capacity(max_bytes);
-            logs.to_bytes(rng, max_bytes, &mut bytes).expect("Error: failed to convert to bytes");
+            logs.to_bytes(rng, max_bytes, &mut bytes).expect("failed to convert to bytes");
 
             assert!(!bytes.is_empty());
         }
@@ -244,9 +244,9 @@ mod test {
             let logs = OpentelemetryMetrics::new(&mut rng);
 
             let mut bytes: Vec<u8> = Vec::with_capacity(max_bytes);
-            logs.to_bytes(rng, max_bytes, &mut bytes).expect("Error: failed to convert to bytes");
+            logs.to_bytes(rng, max_bytes, &mut bytes).expect("failed to convert to bytes");
 
-            opentelemetry_proto::tonic::collector::metrics::v1::ExportMetricsServiceRequest::decode(bytes.as_slice()).expect("Error: failed to decode the message from the buffer");
+            opentelemetry_proto::tonic::collector::metrics::v1::ExportMetricsServiceRequest::decode(bytes.as_slice()).expect("failed to decode the message from the buffer");
         }
     }
 }

--- a/lading_payload/src/opentelemetry_metric.rs
+++ b/lading_payload/src/opentelemetry_metric.rs
@@ -90,7 +90,9 @@ impl Distribution<Sum> for Standard {
         // 0: Unspecified AggregationTemporality, MUST not be used
         // 1: Delta
         // 2: Cumulative
-        let aggregation_temporality = *[1, 2].choose(rng).unwrap();
+        let aggregation_temporality = *[1, 2]
+            .choose(rng)
+            .expect("Error: failed to choose aggregation temporality");
         let is_monotonic = rng.gen();
         let total = rng.gen_range(0..64);
         let data_points = Standard
@@ -140,9 +142,18 @@ impl<'a> Generator<'a> for OpentelemetryMetrics {
         };
         let data = Some(data);
 
-        let name = self.str_pool.of_size_range(&mut rng, 1_u8..16).unwrap();
-        let description = self.str_pool.of_size_range(&mut rng, 1_u8..16).unwrap();
-        let unit = self.str_pool.of_size_range(&mut rng, 1_u8..16).unwrap();
+        let name = self
+            .str_pool
+            .of_size_range(&mut rng, 1_u8..16)
+            .expect("Error: failed to generate string");
+        let description = self
+            .str_pool
+            .of_size_range(&mut rng, 1_u8..16)
+            .expect("Error: failed to generate string");
+        let unit = self
+            .str_pool
+            .of_size_range(&mut rng, 1_u8..16)
+            .expect("Error: failed to generate string");
 
         Metric(v1::Metric {
             name: String::from(name),
@@ -203,7 +214,7 @@ mod test {
             let logs = OpentelemetryMetrics::new(&mut rng);
 
             let mut bytes = Vec::with_capacity(max_bytes);
-            logs.to_bytes(rng, max_bytes, &mut bytes).unwrap();
+            logs.to_bytes(rng, max_bytes, &mut bytes).expect("Error: failed to convert to bytes");
             assert!(bytes.len() <= max_bytes, "max len: {max_bytes}, actual: {}", bytes.len());
         }
     }
@@ -217,7 +228,7 @@ mod test {
             let logs = OpentelemetryMetrics::new(&mut rng);
 
             let mut bytes = Vec::with_capacity(max_bytes);
-            logs.to_bytes(rng, max_bytes, &mut bytes).unwrap();
+            logs.to_bytes(rng, max_bytes, &mut bytes).expect("Error: failed to convert to bytes");
 
             assert!(!bytes.is_empty());
         }
@@ -233,9 +244,9 @@ mod test {
             let logs = OpentelemetryMetrics::new(&mut rng);
 
             let mut bytes: Vec<u8> = Vec::with_capacity(max_bytes);
-            logs.to_bytes(rng, max_bytes, &mut bytes).unwrap();
+            logs.to_bytes(rng, max_bytes, &mut bytes).expect("Error: failed to convert to bytes");
 
-            opentelemetry_proto::tonic::collector::metrics::v1::ExportMetricsServiceRequest::decode(bytes.as_slice()).unwrap();
+            opentelemetry_proto::tonic::collector::metrics::v1::ExportMetricsServiceRequest::decode(bytes.as_slice()).expect("Error: failed to decode the message from the buffer");
         }
     }
 }

--- a/lading_payload/src/opentelemetry_trace.rs
+++ b/lading_payload/src/opentelemetry_trace.rs
@@ -78,7 +78,7 @@ impl<'a> Generator<'a> for OpentelemetryTraces {
         let name = self
             .str_pool
             .of_size_range(&mut rng, 1_u8..16)
-            .expect("Error: failed to generate string");
+            .expect("failed to generate string");
 
         Span(v1::Span {
             trace_id,
@@ -153,7 +153,7 @@ mod test {
             let traces = OpentelemetryTraces::new(&mut rng);
 
             let mut bytes = Vec::with_capacity(max_bytes);
-            traces.to_bytes(rng, max_bytes, &mut bytes).expect("Error: failed to convert to bytes");
+            traces.to_bytes(rng, max_bytes, &mut bytes).expect("failed to convert to bytes");
             assert!(bytes.len() <= max_bytes, "max len: {max_bytes}, actual: {}", bytes.len());
         }
     }
@@ -167,7 +167,7 @@ mod test {
             let traces = OpentelemetryTraces::new(&mut rng);
 
             let mut bytes = Vec::with_capacity(max_bytes);
-            traces.to_bytes(rng, max_bytes, &mut bytes).expect("Error: failed to convert to bytes");
+            traces.to_bytes(rng, max_bytes, &mut bytes).expect("failed to convert to bytes");
 
             assert!(!bytes.is_empty());
         }
@@ -183,9 +183,9 @@ mod test {
             let traces = OpentelemetryTraces::new(&mut rng);
 
             let mut bytes: Vec<u8> = Vec::with_capacity(max_bytes);
-            traces.to_bytes(rng, max_bytes, &mut bytes).expect("Error: failed to convert to bytes");
+            traces.to_bytes(rng, max_bytes, &mut bytes).expect("failed to convert to bytes");
 
-            opentelemetry_proto::tonic::collector::trace::v1::ExportTraceServiceRequest::decode(bytes.as_slice()).expect("Error: failed to decode the message from the buffer");
+            opentelemetry_proto::tonic::collector::trace::v1::ExportTraceServiceRequest::decode(bytes.as_slice()).expect("failed to decode the message from the buffer");
         }
     }
 }

--- a/lading_payload/src/opentelemetry_trace.rs
+++ b/lading_payload/src/opentelemetry_trace.rs
@@ -75,7 +75,10 @@ impl<'a> Generator<'a> for OpentelemetryTraces {
         // end time is expected to be greater than or equal to start time
         let end_time_unix_nano: u64 = rng.gen_range(start_time_unix_nano..=u64::MAX);
 
-        let name = self.str_pool.of_size_range(&mut rng, 1_u8..16).unwrap();
+        let name = self
+            .str_pool
+            .of_size_range(&mut rng, 1_u8..16)
+            .expect("Error: failed to generate string");
 
         Span(v1::Span {
             trace_id,
@@ -150,7 +153,7 @@ mod test {
             let traces = OpentelemetryTraces::new(&mut rng);
 
             let mut bytes = Vec::with_capacity(max_bytes);
-            traces.to_bytes(rng, max_bytes, &mut bytes).unwrap();
+            traces.to_bytes(rng, max_bytes, &mut bytes).expect("Error: failed to convert to bytes");
             assert!(bytes.len() <= max_bytes, "max len: {max_bytes}, actual: {}", bytes.len());
         }
     }
@@ -164,7 +167,7 @@ mod test {
             let traces = OpentelemetryTraces::new(&mut rng);
 
             let mut bytes = Vec::with_capacity(max_bytes);
-            traces.to_bytes(rng, max_bytes, &mut bytes).unwrap();
+            traces.to_bytes(rng, max_bytes, &mut bytes).expect("Error: failed to convert to bytes");
 
             assert!(!bytes.is_empty());
         }
@@ -180,9 +183,9 @@ mod test {
             let traces = OpentelemetryTraces::new(&mut rng);
 
             let mut bytes: Vec<u8> = Vec::with_capacity(max_bytes);
-            traces.to_bytes(rng, max_bytes, &mut bytes).unwrap();
+            traces.to_bytes(rng, max_bytes, &mut bytes).expect("Error: failed to convert to bytes");
 
-            opentelemetry_proto::tonic::collector::trace::v1::ExportTraceServiceRequest::decode(bytes.as_slice()).unwrap();
+            opentelemetry_proto::tonic::collector::trace::v1::ExportTraceServiceRequest::decode(bytes.as_slice()).expect("Error: failed to decode the message from the buffer");
         }
     }
 }

--- a/lading_payload/src/procfs.rs
+++ b/lading_payload/src/procfs.rs
@@ -1687,7 +1687,7 @@ impl<'a> Generator<'a> for ProcessGenerator {
         let cmdline = String::from(
             self.str_pool
                 .of_size(rng, cmdline_size)
-                .expect("Error: failed to generate process command line"),
+                .expect("failed to generate process command line"),
         );
 
         // Assume the comm name and task name are derived from `cmdline`. Note

--- a/lading_payload/src/procfs.rs
+++ b/lading_payload/src/procfs.rs
@@ -1684,7 +1684,11 @@ impl<'a> Generator<'a> for ProcessGenerator {
 
         // SAFETY: If this call fails, then execution should panic because an
         // inability to generate process command lines is a serious bug.
-        let cmdline = String::from(self.str_pool.of_size(rng, cmdline_size).unwrap());
+        let cmdline = String::from(
+            self.str_pool
+                .of_size(rng, cmdline_size)
+                .expect("Error: failed to generate process command line"),
+        );
 
         // Assume the comm name and task name are derived from `cmdline`. Note
         // from `man 5 proc` that a thread may modify its `comm` (command name)

--- a/lading_payload/src/splunk_hec.rs
+++ b/lading_payload/src/splunk_hec.rs
@@ -53,13 +53,33 @@ impl Distribution<Attrs> for Standard {
         R: Rng + ?Sized,
     {
         Attrs {
-            system_id: String::from(*SYSTEM_IDS.choose(rng).unwrap()),
-            stage: String::from(*STAGES.choose(rng).unwrap()),
-            event_type: String::from(*EVENT_TYPES.choose(rng).unwrap()),
-            c2c_service: String::from(*SERVICES.choose(rng).unwrap()),
-            c2c_partition: String::from(*PARTITIONS.choose(rng).unwrap()),
-            c2c_stage: String::from(*STAGES.choose(rng).unwrap()),
-            c2c_container_type: String::from(*CONTAINER_TYPES.choose(rng).unwrap()),
+            system_id: String::from(
+                *SYSTEM_IDS
+                    .choose(rng)
+                    .expect("Error: failed to choose system ids"),
+            ),
+            stage: String::from(*STAGES.choose(rng).expect("Error: failed to choose stages")),
+            event_type: String::from(
+                *EVENT_TYPES
+                    .choose(rng)
+                    .expect("Error: failed to choose event types"),
+            ),
+            c2c_service: String::from(
+                *SERVICES
+                    .choose(rng)
+                    .expect("Error: failed to choose services"),
+            ),
+            c2c_partition: String::from(
+                *PARTITIONS
+                    .choose(rng)
+                    .expect("Error: failed to choose partitions"),
+            ),
+            c2c_stage: String::from(*STAGES.choose(rng).expect("Error: failed to choose stages")),
+            c2c_container_type: String::from(
+                *CONTAINER_TYPES
+                    .choose(rng)
+                    .expect("Error: failed to choose container types"),
+            ),
             aws_account: String::from("verymodelofthemodernmajor"),
         }
     }
@@ -79,7 +99,11 @@ impl Distribution<Event> for Standard {
     {
         Event {
             timestamp: 1_606_215_269.333_915,
-            message: String::from(*MESSAGES.choose(rng).unwrap()),
+            message: String::from(
+                *MESSAGES
+                    .choose(rng)
+                    .expect("Error: failed to choose messages"),
+            ),
             attrs: rng.gen(),
         }
     }
@@ -101,8 +125,16 @@ impl Distribution<Member> for Standard {
         Member {
             event: rng.gen(),
             time: rng.gen(),
-            host: String::from(*SYSTEM_IDS.choose(rng).unwrap()),
-            index: String::from(*PARTITIONS.choose(rng).unwrap()),
+            host: String::from(
+                *SYSTEM_IDS
+                    .choose(rng)
+                    .expect("Error: failed to choose system ids"),
+            ),
+            index: String::from(
+                *PARTITIONS
+                    .choose(rng)
+                    .expect("Error: failed to choose partitions"),
+            ),
         }
     }
 }
@@ -193,7 +225,7 @@ mod test {
             let hec = SplunkHec::default();
 
             let mut bytes = Vec::with_capacity(max_bytes);
-            hec.to_bytes(rng, max_bytes, &mut bytes).unwrap();
+            hec.to_bytes(rng, max_bytes, &mut bytes).expect("Error: failed to convert to bytes");
             assert!(bytes.len() <= max_bytes);
         }
     }
@@ -208,11 +240,11 @@ mod test {
             let hec = SplunkHec::default();
 
             let mut bytes: Vec<u8> = Vec::with_capacity(max_bytes);
-            hec.to_bytes(rng, max_bytes, &mut bytes).unwrap();
+            hec.to_bytes(rng, max_bytes, &mut bytes).expect("Error: failed to convert to bytes");
 
-            let payload = std::str::from_utf8(&bytes).unwrap();
+            let payload = std::str::from_utf8(&bytes).expect("Error: failed to convert from utf-8 to str");
             for msg in payload.lines() {
-                let _members: Member = serde_json::from_str(msg).unwrap();
+                let _members: Member = serde_json::from_str(msg).expect("Error: failed to deserialize from str");
             }
         }
     }

--- a/lading_payload/src/splunk_hec.rs
+++ b/lading_payload/src/splunk_hec.rs
@@ -53,32 +53,22 @@ impl Distribution<Attrs> for Standard {
         R: Rng + ?Sized,
     {
         Attrs {
-            system_id: String::from(
-                *SYSTEM_IDS
-                    .choose(rng)
-                    .expect("Error: failed to choose system ids"),
-            ),
-            stage: String::from(*STAGES.choose(rng).expect("Error: failed to choose stages")),
+            system_id: String::from(*SYSTEM_IDS.choose(rng).expect("failed to choose system ids")),
+            stage: String::from(*STAGES.choose(rng).expect("failed to choose stages")),
             event_type: String::from(
                 *EVENT_TYPES
                     .choose(rng)
-                    .expect("Error: failed to choose event types"),
+                    .expect("failed to choose event types"),
             ),
-            c2c_service: String::from(
-                *SERVICES
-                    .choose(rng)
-                    .expect("Error: failed to choose services"),
-            ),
+            c2c_service: String::from(*SERVICES.choose(rng).expect("failed to choose services")),
             c2c_partition: String::from(
-                *PARTITIONS
-                    .choose(rng)
-                    .expect("Error: failed to choose partitions"),
+                *PARTITIONS.choose(rng).expect("failed to choose partitions"),
             ),
-            c2c_stage: String::from(*STAGES.choose(rng).expect("Error: failed to choose stages")),
+            c2c_stage: String::from(*STAGES.choose(rng).expect("failed to choose stages")),
             c2c_container_type: String::from(
                 *CONTAINER_TYPES
                     .choose(rng)
-                    .expect("Error: failed to choose container types"),
+                    .expect("failed to choose container types"),
             ),
             aws_account: String::from("verymodelofthemodernmajor"),
         }
@@ -99,11 +89,7 @@ impl Distribution<Event> for Standard {
     {
         Event {
             timestamp: 1_606_215_269.333_915,
-            message: String::from(
-                *MESSAGES
-                    .choose(rng)
-                    .expect("Error: failed to choose messages"),
-            ),
+            message: String::from(*MESSAGES.choose(rng).expect("failed to choose messages")),
             attrs: rng.gen(),
         }
     }
@@ -125,16 +111,8 @@ impl Distribution<Member> for Standard {
         Member {
             event: rng.gen(),
             time: rng.gen(),
-            host: String::from(
-                *SYSTEM_IDS
-                    .choose(rng)
-                    .expect("Error: failed to choose system ids"),
-            ),
-            index: String::from(
-                *PARTITIONS
-                    .choose(rng)
-                    .expect("Error: failed to choose partitions"),
-            ),
+            host: String::from(*SYSTEM_IDS.choose(rng).expect("failed to choose system ids")),
+            index: String::from(*PARTITIONS.choose(rng).expect("failed to choose partitions")),
         }
     }
 }
@@ -225,7 +203,7 @@ mod test {
             let hec = SplunkHec::default();
 
             let mut bytes = Vec::with_capacity(max_bytes);
-            hec.to_bytes(rng, max_bytes, &mut bytes).expect("Error: failed to convert to bytes");
+            hec.to_bytes(rng, max_bytes, &mut bytes).expect("failed to convert to bytes");
             assert!(bytes.len() <= max_bytes);
         }
     }
@@ -240,11 +218,11 @@ mod test {
             let hec = SplunkHec::default();
 
             let mut bytes: Vec<u8> = Vec::with_capacity(max_bytes);
-            hec.to_bytes(rng, max_bytes, &mut bytes).expect("Error: failed to convert to bytes");
+            hec.to_bytes(rng, max_bytes, &mut bytes).expect("failed to convert to bytes");
 
-            let payload = std::str::from_utf8(&bytes).expect("Error: failed to convert from utf-8 to str");
+            let payload = std::str::from_utf8(&bytes).expect("failed to convert from utf-8 to str");
             for msg in payload.lines() {
-                let _members: Member = serde_json::from_str(msg).expect("Error: failed to deserialize from str");
+                let _members: Member = serde_json::from_str(msg).expect("failed to deserialize from str");
             }
         }
     }

--- a/lading_payload/src/syslog.rs
+++ b/lading_payload/src/syslog.rs
@@ -67,18 +67,11 @@ impl Distribution<Member> for Standard {
             priority: rng.gen_range(0..=191),
             syslog_version: rng.gen_range(1..=3),
             timestamp: to_rfc3339(SystemTime::now()),
-            hostname: (*HOSTNAMES
-                .choose(rng)
-                .expect("Error: failed to choose hostnanme"))
-            .to_string(),
-            app_name: (*APP_NAMES
-                .choose(rng)
-                .expect("Error: failed to choose app name"))
-            .to_string(),
+            hostname: (*HOSTNAMES.choose(rng).expect("failed to choose hostnanme")).to_string(),
+            app_name: (*APP_NAMES.choose(rng).expect("failed to choose app name")).to_string(),
             procid: rng.gen_range(100..=9999),
             msgid: rng.gen_range(1..=999),
-            message: serde_json::to_string(&rng.gen::<Message>())
-                .expect("Error: failed to serialize"),
+            message: serde_json::to_string(&rng.gen::<Message>()).expect("failed to serialize"),
         }
     }
 }
@@ -87,7 +80,7 @@ fn to_rfc3339<T>(dt: T) -> String
 where
     T: Into<OffsetDateTime>,
 {
-    dt.into().format(&Rfc3339).expect("Error: failed to format")
+    dt.into().format(&Rfc3339).expect("failed to format")
 }
 
 impl Member {
@@ -152,11 +145,11 @@ mod test {
             let syslog = Syslog5424::default();
 
             let mut bytes = Vec::with_capacity(max_bytes);
-            syslog.to_bytes(rng, max_bytes, &mut bytes).expect("Error: failed to convert to bytes");
+            syslog.to_bytes(rng, max_bytes, &mut bytes).expect("failed to convert to bytes");
             debug_assert!(
                 bytes.len() <= max_bytes,
                 "{:?}",
-                std::str::from_utf8(&bytes).expect("Error: failed to convert from utf-8 to str")
+                std::str::from_utf8(&bytes).expect("failed to convert from utf-8 to str")
             );
         }
     }

--- a/lading_payload/src/syslog.rs
+++ b/lading_payload/src/syslog.rs
@@ -67,11 +67,18 @@ impl Distribution<Member> for Standard {
             priority: rng.gen_range(0..=191),
             syslog_version: rng.gen_range(1..=3),
             timestamp: to_rfc3339(SystemTime::now()),
-            hostname: (*HOSTNAMES.choose(rng).unwrap()).to_string(),
-            app_name: (*APP_NAMES.choose(rng).unwrap()).to_string(),
+            hostname: (*HOSTNAMES
+                .choose(rng)
+                .expect("Error: failed to choose hostnanme"))
+            .to_string(),
+            app_name: (*APP_NAMES
+                .choose(rng)
+                .expect("Error: failed to choose app name"))
+            .to_string(),
             procid: rng.gen_range(100..=9999),
             msgid: rng.gen_range(1..=999),
-            message: serde_json::to_string(&rng.gen::<Message>()).unwrap(),
+            message: serde_json::to_string(&rng.gen::<Message>())
+                .expect("Error: failed to serialize"),
         }
     }
 }
@@ -80,7 +87,7 @@ fn to_rfc3339<T>(dt: T) -> String
 where
     T: Into<OffsetDateTime>,
 {
-    dt.into().format(&Rfc3339).unwrap()
+    dt.into().format(&Rfc3339).expect("Error: failed to format")
 }
 
 impl Member {
@@ -145,11 +152,11 @@ mod test {
             let syslog = Syslog5424::default();
 
             let mut bytes = Vec::with_capacity(max_bytes);
-            syslog.to_bytes(rng, max_bytes, &mut bytes).unwrap();
+            syslog.to_bytes(rng, max_bytes, &mut bytes).expect("Error: failed to convert to bytes");
             debug_assert!(
                 bytes.len() <= max_bytes,
                 "{:?}",
-                std::str::from_utf8(&bytes).unwrap()
+                std::str::from_utf8(&bytes).expect("Error: failed to convert from utf-8 to str")
             );
         }
     }

--- a/lading_payload/src/trace_agent.rs
+++ b/lading_payload/src/trace_agent.rs
@@ -163,11 +163,19 @@ impl<'a> Generator<'a> for TraceAgent {
             metrics.insert(*k, rng.gen());
         }
 
-        let name = self.str_pool.of_size_range(&mut rng, 1_u8..16).unwrap();
-        let resource = self.str_pool.of_size_range(&mut rng, 1_u8..8).unwrap();
+        let name = self
+            .str_pool
+            .of_size_range(&mut rng, 1_u8..16)
+            .expect("Error: failed to generate string");
+        let resource = self
+            .str_pool
+            .of_size_range(&mut rng, 1_u8..8)
+            .expect("Error: failed to generate string");
 
         Span {
-            service: SERVICES.choose(rng).unwrap(),
+            service: SERVICES
+                .choose(rng)
+                .expect("Error: failed to choose service"),
             name,
             resource,
             trace_id: rng.gen(),
@@ -178,7 +186,9 @@ impl<'a> Generator<'a> for TraceAgent {
             error: rng.gen_range(0..=1),
             meta: FxHashMap::default(),
             metrics,
-            kind: SERVICE_KIND.choose(rng).unwrap(),
+            kind: SERVICE_KIND
+                .choose(rng)
+                .expect("Error: failed to choose service kind"),
             meta_struct: FxHashMap::default(),
         }
     }
@@ -267,11 +277,11 @@ mod test {
             let trace_agent = TraceAgent::json(&mut rng);
 
             let mut bytes = Vec::with_capacity(max_bytes);
-            trace_agent.to_bytes(rng, max_bytes, &mut bytes).unwrap();
+            trace_agent.to_bytes(rng, max_bytes, &mut bytes).expect("Error: failed to convert to bytes");
             debug_assert!(
                 bytes.len() <= max_bytes,
                 "{:?}",
-                std::str::from_utf8(&bytes).unwrap()
+                std::str::from_utf8(&bytes).expect("Error: failed to convert from utf-8 to str")
             );
         }
     }
@@ -284,11 +294,11 @@ mod test {
             let trace_agent = TraceAgent::json(&mut rng);
 
             let mut bytes = Vec::with_capacity(max_bytes);
-            trace_agent.to_bytes(rng, max_bytes, &mut bytes).unwrap();
+            trace_agent.to_bytes(rng, max_bytes, &mut bytes).expect("Error: failed to convert to bytes");
             debug_assert!(
                 bytes.len() <= max_bytes,
                 "{:?}",
-                std::str::from_utf8(&bytes).unwrap()
+                std::str::from_utf8(&bytes).expect("Error: failed to convert from utf-8 to str")
             );
         }
     }

--- a/lading_payload/src/trace_agent.rs
+++ b/lading_payload/src/trace_agent.rs
@@ -166,16 +166,14 @@ impl<'a> Generator<'a> for TraceAgent {
         let name = self
             .str_pool
             .of_size_range(&mut rng, 1_u8..16)
-            .expect("Error: failed to generate string");
+            .expect("failed to generate string");
         let resource = self
             .str_pool
             .of_size_range(&mut rng, 1_u8..8)
-            .expect("Error: failed to generate string");
+            .expect("failed to generate string");
 
         Span {
-            service: SERVICES
-                .choose(rng)
-                .expect("Error: failed to choose service"),
+            service: SERVICES.choose(rng).expect("failed to choose service"),
             name,
             resource,
             trace_id: rng.gen(),
@@ -188,7 +186,7 @@ impl<'a> Generator<'a> for TraceAgent {
             metrics,
             kind: SERVICE_KIND
                 .choose(rng)
-                .expect("Error: failed to choose service kind"),
+                .expect("failed to choose service kind"),
             meta_struct: FxHashMap::default(),
         }
     }
@@ -277,11 +275,11 @@ mod test {
             let trace_agent = TraceAgent::json(&mut rng);
 
             let mut bytes = Vec::with_capacity(max_bytes);
-            trace_agent.to_bytes(rng, max_bytes, &mut bytes).expect("Error: failed to convert to bytes");
+            trace_agent.to_bytes(rng, max_bytes, &mut bytes).expect("failed to convert to bytes");
             debug_assert!(
                 bytes.len() <= max_bytes,
                 "{:?}",
-                std::str::from_utf8(&bytes).expect("Error: failed to convert from utf-8 to str")
+                std::str::from_utf8(&bytes).expect("failed to convert from utf-8 to str")
             );
         }
     }
@@ -294,11 +292,11 @@ mod test {
             let trace_agent = TraceAgent::json(&mut rng);
 
             let mut bytes = Vec::with_capacity(max_bytes);
-            trace_agent.to_bytes(rng, max_bytes, &mut bytes).expect("Error: failed to convert to bytes");
+            trace_agent.to_bytes(rng, max_bytes, &mut bytes).expect("failed to convert to bytes");
             debug_assert!(
                 bytes.len() <= max_bytes,
                 "{:?}",
-                std::str::from_utf8(&bytes).expect("Error: failed to convert from utf-8 to str")
+                std::str::from_utf8(&bytes).expect("failed to convert from utf-8 to str")
             );
         }
     }

--- a/lading_throttle/src/stable.rs
+++ b/lading_throttle/src/stable.rs
@@ -168,7 +168,9 @@ mod verification {
 
         let ticks_elapsed: u64 = kani::any();
 
-        let slop = valve.request(ticks_elapsed, 0).unwrap();
+        let slop = valve
+            .request(ticks_elapsed, 0)
+            .expect("Error: request failed.");
         kani::assert(slop == 0, "Requests that are zero always succeed.");
     }
 
@@ -185,7 +187,9 @@ mod verification {
         let request: u32 = kani::any_where(|r: &u32| *r <= maximum_capacity);
         let ticks_elapsed: u64 = kani::any_where(|t: &u64| *t <= INTERVAL_TICKS);
 
-        let slop = valve.request(ticks_elapsed, request).unwrap();
+        let slop = valve
+            .request(ticks_elapsed, request)
+            .expect("Error: request failed");
         kani::assert(
             slop == 0,
             "Request in-capacity, interval should succeed without wait.",
@@ -211,7 +215,9 @@ mod verification {
             kani::any_where(|r: &u32| original_capacity < *r && *r <= maximum_capacity);
         let ticks_elapsed: u64 = kani::any_where(|t: &u64| *t <= INTERVAL_TICKS);
 
-        let slop = valve.request(ticks_elapsed, request).unwrap();
+        let slop = valve
+            .request(ticks_elapsed, request)
+            .expect("Error: request failed");
         kani::assert(slop > 0, "Should be forced to wait.");
         kani::assert(
             valve.capacity == original_capacity,

--- a/lading_throttle/src/stable.rs
+++ b/lading_throttle/src/stable.rs
@@ -168,9 +168,7 @@ mod verification {
 
         let ticks_elapsed: u64 = kani::any();
 
-        let slop = valve
-            .request(ticks_elapsed, 0)
-            .expect("Error: request failed.");
+        let slop = valve.request(ticks_elapsed, 0).expect("request failed.");
         kani::assert(slop == 0, "Requests that are zero always succeed.");
     }
 
@@ -189,7 +187,7 @@ mod verification {
 
         let slop = valve
             .request(ticks_elapsed, request)
-            .expect("Error: request failed");
+            .expect("request failed");
         kani::assert(
             slop == 0,
             "Request in-capacity, interval should succeed without wait.",
@@ -217,7 +215,7 @@ mod verification {
 
         let slop = valve
             .request(ticks_elapsed, request)
-            .expect("Error: request failed");
+            .expect("request failed");
         kani::assert(slop > 0, "Should be forced to wait.");
         kani::assert(
             valve.capacity == original_capacity,


### PR DESCRIPTION
### What does this PR do?

This PR is the first step removing all unwraps and expects from lading. The goal of this PR is to first turn each unwrap into an expect so a user can at least get feedback when the program panics. The next step would be to completely remove expects by handling errors properly

### Motivation

In general it is not a good idea for the program to panic and it is much better stylistically if the program handles errors instead.

### Related issues

SMPTNG-114

### Additional Notes

Anything else we should know when reviewing?
