### PR TITLE
Linux 'observer' collects smaps entries and reports them into capture file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.20.6-rc2]
 ### Fixed
-- Addresses some compilation errors present in rc1
+- Addresses some compilation errors present in rc1, fixes pss_dirty assumption
 
 ## [0.20.6-rc1]
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Fixed a bug in CLI key/value parsing where values might be incorrectly parsed
   as key/value pairs if they held lading's delimiter character.
+### Added
+- Adds experimental /proc/<pid>/smap parsing to add very detailed memory usage
 
 ## [0.20.5]
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.20.6-rc2]
 ### Fixed
-- Addresses some compilation errors present in rc1, fixes pss_dirty assumption
+- Fixes some bugs in the initial smaps parsing logic, renames metrics to
+  `smaps.*`
 
 ## [0.20.6-rc1]
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,12 +6,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## [0.20.6-rc2]
+### Fixed
+- Addresses some compilation errors present in rc1
+
+## [0.20.6-rc1]
+### Added
+- Adds experimental /proc/<pid>/smap parsing to add very detailed memory usage
+
 ## [0.20.6-rc0]
 ### Fixed
 - Fixed a bug in CLI key/value parsing where values might be incorrectly parsed
   as key/value pairs if they held lading's delimiter character.
-### Added
-- Adds experimental /proc/<pid>/smap parsing to add very detailed memory usage
 
 ## [0.20.5]
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1065,7 +1065,7 @@ dependencies = [
 
 [[package]]
 name = "lading"
-version = "0.20.6-rc1"
+version = "0.20.6-rc2"
 dependencies = [
  "async-pidfd",
  "average",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1065,7 +1065,7 @@ dependencies = [
 
 [[package]]
 name = "lading"
-version = "0.20.6-rc0"
+version = "0.20.6-rc1"
 dependencies = [
  "async-pidfd",
  "average",

--- a/lading/Cargo.toml
+++ b/lading/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lading"
-version = "0.20.6-rc1"
+version = "0.20.6-rc2"
 authors = ["Brian L. Troutwine <brian.troutwine@datadoghq.com>", "George Hahn <george.hahn@datadoghq.com"]
 edition = "2021"
 license = "MIT"

--- a/lading/Cargo.toml
+++ b/lading/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lading"
-version = "0.20.6-rc0"
+version = "0.20.6-rc1"
 authors = ["Brian L. Troutwine <brian.troutwine@datadoghq.com>", "George Hahn <george.hahn@datadoghq.com"]
 edition = "2021"
 license = "MIT"

--- a/lading/src/observer.rs
+++ b/lading/src/observer.rs
@@ -22,7 +22,6 @@ mod linux;
 mod memory;
 
 #[allow(dead_code)] // used on Linux
-#[allow(dead_code)] // used on Linux
 /// Expose the process' current RSS consumption, allowing abstractions to be
 /// built on top in the Target implementation.
 pub(crate) static RSS_BYTES: AtomicU64 = AtomicU64::new(0);

--- a/lading/src/observer.rs
+++ b/lading/src/observer.rs
@@ -18,6 +18,10 @@ use crate::signals::Phase;
 #[cfg(target_os = "linux")]
 mod linux;
 
+#[cfg(target_os = "linux")]
+mod memory;
+
+#[allow(dead_code)] // used on Linux
 #[allow(dead_code)] // used on Linux
 /// Expose the process' current RSS consumption, allowing abstractions to be
 /// built on top in the Target implementation.

--- a/lading/src/observer/linux.rs
+++ b/lading/src/observer/linux.rs
@@ -274,21 +274,16 @@ impl Sampler {
                     continue;
                 }
             };
-            // This is not the final reporter code
-            // the memory_regions need to be accumulated by `pathname`
-            // and report one guage per `pathname`
-            // Alternatively, make the metrics library do this and submit
-            // this as a "count", but I trust my own logic more than I trust
-            // metrics "count"
-            for region in memory_regions.0 {
-                // todo re-use above labels probs
+            for (pathname, measures) in memory_regions.aggregate_by_pathname() {
                 let labels = [
                     ("pid", format!("{pid}")),
                     ("exe", basename.clone()),
-                    ("pathname", region.pathname.clone()),
+                    ("pathname", pathname),
                 ];
-                gauge!("maps_rss", region.rss as f64, &labels);
-                gauge!("maps_pss", region.pss as f64, &labels);
+                gauge!("smaps_rss", measures.rss as f64, &labels);
+                gauge!("smaps_pss", measures.pss as f64, &labels);
+                gauge!("smaps_size", measures.size as f64, &labels);
+                gauge!("smaps_swap", measures.swap as f64, &labels);
             }
         }
 

--- a/lading/src/observer/linux.rs
+++ b/lading/src/observer/linux.rs
@@ -263,7 +263,6 @@ impl Sampler {
             total_rss += rss;
             total_processes += 1;
 
-            // todo add maps parsing
             let memory_regions = match Regions::from_pid(pid) {
                 Ok(memory_regions) => memory_regions,
                 Err(e) => {
@@ -280,10 +279,10 @@ impl Sampler {
                     ("exe", basename.clone()),
                     ("pathname", pathname),
                 ];
-                gauge!("smaps_rss", measures.rss as f64, &labels);
-                gauge!("smaps_pss", measures.pss as f64, &labels);
-                gauge!("smaps_size", measures.size as f64, &labels);
-                gauge!("smaps_swap", measures.swap as f64, &labels);
+                gauge!("smaps.rss", measures.rss as f64, &labels);
+                gauge!("smaps.pss", measures.pss as f64, &labels);
+                gauge!("smaps.size", measures.size as f64, &labels);
+                gauge!("smaps.swap", measures.swap as f64, &labels);
             }
         }
 

--- a/lading/src/observer/linux.rs
+++ b/lading/src/observer/linux.rs
@@ -277,6 +277,7 @@ impl Sampler {
                 let labels = [
                     ("pid", format!("{pid}")),
                     ("exe", basename.clone()),
+                    ("cmdline", cmdline.clone()),
                     ("pathname", pathname),
                 ];
                 gauge!("smaps.rss", measures.rss as f64, &labels);

--- a/lading/src/observer/linux.rs
+++ b/lading/src/observer/linux.rs
@@ -4,6 +4,9 @@ use metrics::{gauge, register_gauge};
 use nix::errno::Errno;
 use procfs::process::Process;
 use rustc_hash::{FxHashMap, FxHashSet};
+use tracing::warn;
+
+use crate::observer::memory::Regions;
 
 use super::RSS_BYTES;
 
@@ -236,7 +239,7 @@ impl Sampler {
 
             let labels = [
                 ("pid", format!("{pid}")),
-                ("exe", basename),
+                ("exe", basename.clone()),
                 ("cmdline", cmdline.clone()),
             ];
 
@@ -259,6 +262,34 @@ impl Sampler {
 
             total_rss += rss;
             total_processes += 1;
+
+            // todo add maps parsing
+            let memory_regions = match Regions::from_pid(pid) {
+                Ok(memory_regions) => memory_regions,
+                Err(e) => {
+                    // We don't want to bail out entirely if we can't read stats
+                    // which will happen if we don't have permissions or, more
+                    // likely, the process has exited.
+                    warn!("Couldn't process `/proc/{pid}/maps`: {}", e);
+                    continue;
+                }
+            };
+            // This is not the final reporter code
+            // the memory_regions need to be accumulated by `pathname`
+            // and report one guage per `pathname`
+            // Alternatively, make the metrics library do this and submit
+            // this as a "count", but I trust my own logic more than I trust
+            // metrics "count"
+            for region in memory_regions.0 {
+                // todo re-use above labels probs
+                let labels = [
+                    ("pid", format!("{pid}")),
+                    ("exe", basename.clone()),
+                    ("pathname", region.pathname.clone()),
+                ];
+                gauge!("maps_rss", region.rss as f64, &labels);
+                gauge!("maps_pss", region.pss as f64, &labels);
+            }
         }
 
         gauge!("num_processes", total_processes as f64);

--- a/lading/src/observer/linux.rs
+++ b/lading/src/observer/linux.rs
@@ -270,7 +270,7 @@ impl Sampler {
                     // We don't want to bail out entirely if we can't read stats
                     // which will happen if we don't have permissions or, more
                     // likely, the process has exited.
-                    warn!("Couldn't process `/proc/{pid}/maps`: {}", e);
+                    warn!("Couldn't process `/proc/{pid}/smaps`: {}", e);
                     continue;
                 }
             };

--- a/lading/src/observer/memory.rs
+++ b/lading/src/observer/memory.rs
@@ -59,7 +59,11 @@ impl Region {
 
         // parse metadata
         // 7fffa9f39000-7fffa9f3b000 r-xp 00000000 00:00 0                          [vdso]
-        let metadata_line = lines.next().unwrap();
+        let Some(metadata_line) = lines.next() else {
+            return Err(Error::Parsing(format!(
+                "No metadata line found in given region '{contents}'"
+            )));
+        };
 
         let mut start: Option<u64> = None;
         let mut end: Option<u64> = None;
@@ -285,12 +289,11 @@ impl Regions {
 #[cfg(test)]
 #[allow(clippy::identity_op)]
 #[allow(clippy::erasing_op)]
+#[allow(clippy::unreadable_literal)]
 mod tests {
-    use std::fs;
-
     use super::*;
 
-    const TWO_REGION: &str = "
+    const KERNEL_6_TWO_REGIONS: &str = "
 7fffa9f35000-7fffa9f39000 r--p 00000000 12:11 0                          [vvar]
 Size:                 16 kB
 KernelPageSize:        4 kB
@@ -342,10 +345,9 @@ THPeligible:    0
 ProtectionKey:         0
 VmFlags: rd ex mr mw me de sd";
 
-    #[allow(clippy::unreadable_literal)]
     #[test]
     fn test_basic_case() {
-        let regions = Regions::from_str(TWO_REGION).unwrap();
+        let regions = Regions::from_str(KERNEL_6_TWO_REGIONS).unwrap();
         assert_eq!(regions.0.len(), 2);
 
         let region_one = &regions.0[0];
@@ -377,7 +379,6 @@ VmFlags: rd ex mr mw me de sd";
         assert_eq!(region_two.pss_dirty, Some(0));
     }
 
-    #[allow(clippy::unreadable_literal)]
     #[test]
     fn test_empty_pathname() {
         let smap_region = "
@@ -424,7 +425,6 @@ VmFlags: rd ex mr mw me de sd";
         assert_eq!(region_one.pss_dirty, Some(2 * BYTES_PER_KIBIBYTE));
     }
 
-    #[allow(clippy::unreadable_literal)]
     #[test]
     fn test_no_pss_dirty() {
         let smap_region = "

--- a/lading/src/observer/memory.rs
+++ b/lading/src/observer/memory.rs
@@ -1,0 +1,216 @@
+use regex::Regex;
+use std::io::Read;
+
+#[derive(thiserror::Error, Debug)]
+/// Errors produced by functions in this module
+pub(crate) enum Error {
+    /// Wrapper for [`std::io::Error`]
+    #[error("IO error: {0}")]
+    Io(#[from] std::io::Error),
+
+    #[error("Number Parsing: {0}")]
+    ParseInt(#[from] std::num::ParseIntError),
+}
+
+pub(crate) struct Regions(pub(crate) Vec<Region>);
+
+pub(crate) struct Region {
+    // Metadata
+    pub(crate) start: u64,
+    pub(crate) end: u64,
+    pub(crate) perms: String,
+    pub(crate) offset: u64,
+    pub(crate) dev: String,
+    pub(crate) inode: u64,
+    pub(crate) pathname: String,
+    // Values
+    pub(crate) size: u64,
+    pub(crate) pss: u64,
+    pub(crate) swap: u64,
+    pub(crate) rss: u64,
+    pub(crate) pss_dirty: u64,
+}
+
+impl Region {
+    #[allow(clippy::similar_names)]
+    pub(crate) fn from_str(contents: &str) -> Result<Self, Error> {
+        let mut lines = contents.lines();
+
+        let metadata_line = lines.next().unwrap();
+        let metadata = metadata_line.split_whitespace().collect::<Vec<_>>();
+
+        let values = lines
+            .map(|l| l.split_whitespace().collect::<Vec<_>>())
+            .collect::<Vec<_>>();
+
+        // lol this is all gpt-generated, I don't think it'll be correct
+        // but lets try it out maybe it works
+        // okay update, gpt got it pretty much entirely right
+        // not very efficient to allocate all these Vecs, but w/e
+
+        let start = u64::from_str_radix(&metadata[0][..12], 16)?;
+        let end = u64::from_str_radix(&metadata[0][13..], 16)?;
+        let perms = metadata[1].to_string();
+        let offset = u64::from_str_radix(&metadata[2], 16)?;
+        let dev = metadata[3].to_string();
+        let inode = u64::from_str_radix(&metadata[4], 10)?;
+        let pathname = metadata[5].to_string();
+
+        let size = u64::from_str_radix(&values[0][1], 10)?;
+        let rss = u64::from_str_radix(&values[3][1], 10)?;
+        let pss = u64::from_str_radix(&values[4][1], 10)?;
+        let pss_dirty = u64::from_str_radix(&values[5][1], 10)?;
+        let swap = u64::from_str_radix(&values[18][1], 10)?;
+
+        // todo no units taken into account right now
+        // everything in is kB, but implicitly
+        Ok(Region {
+            start,
+            end,
+            perms,
+            offset,
+            dev,
+            inode,
+            pathname,
+            size,
+            pss,
+            swap,
+            rss,
+            pss_dirty,
+        })
+    }
+}
+
+impl Regions {
+    pub(crate) fn from_pid(pid: i32) -> Result<Self, Error> {
+        Regions::from_file(&format!("/proc/{pid}/smaps"))
+    }
+
+    fn from_file(path: &str) -> Result<Self, Error> {
+        let mut file: std::fs::File = std::fs::OpenOptions::new().read(true).open(path)?;
+
+        let mut contents = String::new(); // todo add pre-set capacity probs
+        file.read_to_string(&mut contents).unwrap();
+
+        Self::from_str(&contents)
+    }
+
+    fn from_str(contents: &str) -> Result<Self, Error> {
+        let mut str_regions = Vec::new();
+        // split this smaps file into regions
+        // regions are separated by a line like this:
+        // 7fffa9f39000-7fffa9f3b000 r-xp 00000000 00:00 0                          [vdso]
+        let mut start_index = 0;
+        let region_start_regex =
+            Regex::new("[0-9a-fA-F]{12}-[0-9a-fA-F]{12}").expect("Regex to be valid"); // todo can I use char classes here?
+        let mut start_indices = region_start_regex.find_iter(contents).map(|m| m.start());
+
+        if let Some(mut start_index) = start_indices.next() {
+            for end_match in start_indices {
+                str_regions.push(&contents[start_index..end_match]);
+                start_index = end_match;
+            }
+
+            str_regions.push(&contents[start_index..]);
+        };
+
+        let regions = str_regions
+            .iter()
+            .map(|s| Region::from_str(s))
+            .collect::<Result<Vec<_>, _>>()?;
+
+        Ok(Regions(regions))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const TWO_REGION: &str = "
+7fffa9f35000-7fffa9f39000 r--p 00000000 12:11 0                          [vvar]
+Size:                 16 kB
+KernelPageSize:        4 kB
+MMUPageSize:           4 kB
+Rss:                   0 kB
+Pss:                   0 kB
+Pss_Dirty:             0 kB
+Shared_Clean:          0 kB
+Shared_Dirty:          0 kB
+Private_Clean:         0 kB
+Private_Dirty:         0 kB
+Referenced:            0 kB
+Anonymous:             0 kB
+LazyFree:              0 kB
+AnonHugePages:         0 kB
+ShmemPmdMapped:        0 kB
+FilePmdMapped:         0 kB
+Shared_Hugetlb:        0 kB
+Private_Hugetlb:       0 kB
+Swap:                  7 kB
+SwapPss:               0 kB
+Locked:                0 kB
+THPeligible:    0
+ProtectionKey:         0
+VmFlags: rd mr pf io de dd sd
+7fffa9f39000-7fffa9f3b000 r-xp 00000000 00:00 0                          [vdso]
+Size:                  8 kB
+KernelPageSize:        4 kB
+MMUPageSize:           4 kB
+Rss:                   8 kB
+Pss:                   2 kB
+Pss_Dirty:             0 kB
+Shared_Clean:          8 kB
+Shared_Dirty:          0 kB
+Private_Clean:         0 kB
+Private_Dirty:         0 kB
+Referenced:            8 kB
+Anonymous:             0 kB
+LazyFree:              0 kB
+AnonHugePages:         0 kB
+ShmemPmdMapped:        0 kB
+FilePmdMapped:         0 kB
+Shared_Hugetlb:        0 kB
+Private_Hugetlb:       0 kB
+Swap:                  0 kB
+SwapPss:               0 kB
+Locked:                0 kB
+THPeligible:    0
+ProtectionKey:         0
+VmFlags: rd ex mr mw me de sd";
+
+    #[allow(clippy::unreadable_literal)]
+    #[test]
+    fn test_basic_case() {
+        let regions = Regions::from_str(TWO_REGION).unwrap();
+        assert_eq!(regions.0.len(), 2);
+
+        let region_one = &regions.0[0];
+        assert_eq!(region_one.start, 0x7fffa9f35000);
+        assert_eq!(region_one.end, 0x7fffa9f39000);
+        assert_eq!(region_one.perms, "r--p");
+        assert_eq!(region_one.offset, 0);
+        assert_eq!(region_one.dev, "12:11");
+        assert_eq!(region_one.inode, 0);
+        assert_eq!(region_one.pathname, "[vvar]");
+        assert_eq!(region_one.size, 16);
+        assert_eq!(region_one.pss, 0);
+        assert_eq!(region_one.swap, 7);
+        assert_eq!(region_one.rss, 0);
+        assert_eq!(region_one.pss_dirty, 0);
+
+        let region_two = &regions.0[1];
+        assert_eq!(region_two.start, 0x7fffa9f39000);
+        assert_eq!(region_two.end, 0x7fffa9f3b000);
+        assert_eq!(region_two.perms, "r-xp");
+        assert_eq!(region_two.offset, 0);
+        assert_eq!(region_two.dev, "00:00");
+        assert_eq!(region_two.inode, 0);
+        assert_eq!(region_two.pathname, "[vdso]");
+        assert_eq!(region_two.size, 8);
+        assert_eq!(region_two.pss, 2);
+        assert_eq!(region_two.swap, 0);
+        assert_eq!(region_two.rss, 8);
+        assert_eq!(region_two.pss_dirty, 0);
+    }
+}

--- a/lading/src/observer/memory.rs
+++ b/lading/src/observer/memory.rs
@@ -19,6 +19,7 @@ pub(crate) enum Error {
 
 pub(crate) struct Regions(pub(crate) Vec<Region>);
 
+#[allow(dead_code)]
 pub(crate) struct Region {
     // Metadata
     pub(crate) start: u64,
@@ -100,11 +101,11 @@ impl Region {
             } else if perms.is_none() {
                 perms = Some(token.to_string());
             } else if offset.is_none() {
-                offset = Some(u64::from_str_radix(token, 10)?);
+                offset = Some(token.parse::<u64>()?);
             } else if dev.is_none() {
                 dev = Some(token.to_string());
             } else if inode.is_none() {
-                inode = Some(u64::from_str_radix(token, 10)?);
+                inode = Some(token.parse::<u64>()?);
             } else if pathname.is_none() {
                 pathname = Some(token.to_string());
             } else {


### PR DESCRIPTION
### What does this PR do?
Adds support in the linux observer to parse a given PIDs `/proc/pid/smaps` file in order to provide more detail about memory usage.


### Motivation
If RSS increases, it can be difficult to determine exactly _why_ rss went up.
Language-specific profilers and runtime telemetry will be valuable for the parts managed by that language's runtime, but OS-level details can be helpful as well.

### Related issues

REF [SMPTNG-185](https://datadoghq.atlassian.net/browse/SMPTNG-185)

### Additional Notes



[SMPTNG-185]: https://datadoghq.atlassian.net/browse/SMPTNG-185?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ