### PR TITLE
Adds tool to quickly summarize capture JSON files

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -155,6 +155,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
+name = "average"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d804c74bb2d66e9b7047658d21af0f1c937d7d2466410cbf1aed3b0c04048d4"
+dependencies = [
+ "easy-cast",
+ "float-ord",
+ "num-traits",
+]
+
+[[package]]
 name = "axum"
 version = "0.6.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -558,6 +569,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "easy-cast"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10936778145f3bea71fd9bf61332cce28c28e96a380714f7ab34838b80733fd6"
+dependencies = [
+ "libm",
+]
+
+[[package]]
 name = "either"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -648,6 +668,12 @@ dependencies = [
  "crc32fast",
  "miniz_oxide",
 ]
+
+[[package]]
+name = "float-ord"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ce81f49ae8a0482e4c55ea62ebbd7e5a686af544c00b9d090bba3ff9be97b3d"
 
 [[package]]
 name = "fnv"
@@ -1052,6 +1078,7 @@ name = "lading"
 version = "0.20.6-rc0"
 dependencies = [
  "async-pidfd",
+ "average",
  "byte-unit",
  "bytes",
  "clap 3.2.25",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -160,7 +160,6 @@ version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d804c74bb2d66e9b7047658d21af0f1c937d7d2466410cbf1aed3b0c04048d4"
 dependencies = [
- "easy-cast",
  "float-ord",
  "num-traits",
 ]
@@ -566,15 +565,6 @@ dependencies = [
  "tower",
  "tracing",
  "tracing-subscriber",
-]
-
-[[package]]
-name = "easy-cast"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10936778145f3bea71fd9bf61332cce28c28e96a380714f7ab34838b80733fd6"
-dependencies = [
- "libm",
 ]
 
 [[package]]

--- a/lading/Cargo.toml
+++ b/lading/Cargo.toml
@@ -45,6 +45,7 @@ tower = { version = "0.4", default-features = false, features = ["timeout", "lim
 tracing = { workspace = true }
 tracing-subscriber = { version = "0.3", features = ["std", "env-filter"] }
 uuid = { workspace = true }
+average = "0.14.1"
 
 [target.'cfg(target_os = "linux")'.dependencies]
 procfs = { version = "0.15", default-features = false, features = [] }

--- a/lading/Cargo.toml
+++ b/lading/Cargo.toml
@@ -45,7 +45,7 @@ tower = { version = "0.4", default-features = false, features = ["timeout", "lim
 tracing = { workspace = true }
 tracing-subscriber = { version = "0.3", features = ["std", "env-filter"] }
 uuid = { workspace = true }
-average = "0.14.1"
+average = { version = "0.14.1", default-features = false, features = [] }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 procfs = { version = "0.15", default-features = false, features = [] }

--- a/lading/src/bin/captool.rs
+++ b/lading/src/bin/captool.rs
@@ -72,6 +72,7 @@ async fn main() -> Result<(), Error> {
         return Ok(());
     }
     if let Some(metric) = args.metric {
+        info!("Metric: {metric}");
         concatenate!(
             Estimator,
             [Variance, variance, mean, error],
@@ -85,8 +86,7 @@ async fn main() -> Result<(), Error> {
             .collect();
 
         info!(
-            "For metric: {}, mean: {} (+- {}), median: {}",
-            metric,
+            "Stats: mean: {} (+- {}), median: {}",
             s.mean(),
             s.error(),
             s.quantile()
@@ -107,7 +107,7 @@ async fn main() -> Result<(), Error> {
                     .insert(value.clone());
             }
         }
-        info!("Labels for metric: {}", metric);
+        info!("Labels:");
         for (key, values) in key_and_values.iter_mut() {
             println!("{}: {:?}", key, values);
         }

--- a/lading/src/bin/captool.rs
+++ b/lading/src/bin/captool.rs
@@ -1,0 +1,118 @@
+use std::collections::{HashMap, HashSet};
+
+use average::{concatenate, Estimate, Quantile, Variance};
+use clap::Parser;
+use futures::io;
+use lading_capture::json::Line;
+use rustc_hash::FxHashMap;
+use tokio::io::AsyncReadExt;
+use tracing::{error, info};
+use tracing_subscriber::{fmt::format::FmtSpan, util::SubscriberInitExt};
+
+#[derive(Parser, Debug)]
+#[clap(author, version, about, long_about = None)]
+struct Args {
+    /// list metric names
+    #[clap(short, long)]
+    list_names: bool,
+
+    /// show details about a metric
+    #[clap(short, long)]
+    metric: Option<String>,
+
+    /// Path to line-delimited capture file
+    capture_path: String,
+}
+
+#[derive(thiserror::Error, Debug)]
+pub enum Error {
+    #[error("Invalid arguments specified")]
+    InvalidArgs,
+    #[error(transparent)]
+    Io(#[from] io::Error),
+    #[error(transparent)]
+    Deserialize(#[from] serde_json::Error),
+}
+
+#[tokio::main(flavor = "current_thread")]
+async fn main() -> Result<(), Error> {
+    tracing_subscriber::fmt()
+        .with_span_events(FmtSpan::FULL)
+        .with_ansi(false)
+        .finish()
+        .init();
+
+    info!("Welcome to captool");
+    let args = Args::parse();
+
+    let capture_path = std::path::Path::new(&args.capture_path);
+    if !capture_path.exists() {
+        error!("Capture file {} does not exist", &args.capture_path);
+        return Err(Error::InvalidArgs);
+    }
+
+    let mut file = tokio::fs::File::open(capture_path).await?;
+
+    let mut contents = String::with_capacity(file.metadata().await?.len() as usize);
+
+    file.read_to_string(&mut contents).await?;
+
+    let lines: Vec<Line> = serde_json::Deserializer::from_str(&contents)
+        .into_iter::<Line>()
+        .map(|line| line.unwrap())
+        .collect();
+
+    if args.list_names {
+        let mut names: Vec<String> = lines.iter().map(|line| line.metric_name.clone()).collect();
+        names.sort();
+        names.dedup();
+        for name in names {
+            println!("{}", name);
+        }
+        return Ok(());
+    }
+    if let Some(metric) = args.metric {
+        concatenate!(
+            Estimator,
+            [Variance, variance, mean, error],
+            [Quantile, quantile, quantile]
+        );
+
+        let s: Estimator = lines
+            .iter()
+            .filter(|line| line.metric_name == metric)
+            .map(|line| line.value.as_f64())
+            .collect();
+
+        info!(
+            "For metric: {}, mean: {} (+- {}), median: {}",
+            metric,
+            s.mean(),
+            s.error(),
+            s.quantile()
+        );
+
+        let mut key_and_values: HashMap<String, HashSet<String>> = HashMap::new();
+        // TODO consolidate these loops into two, one to compute, one to print
+        let labels: Vec<FxHashMap<String, String>> = lines
+            .iter()
+            .filter(|line| line.metric_name == metric)
+            .map(|line| line.labels.clone())
+            .collect();
+        for label in labels.iter() {
+            for (key, value) in label.iter() {
+                key_and_values
+                    .entry(key.clone())
+                    .or_default()
+                    .insert(value.clone());
+            }
+        }
+        info!("Labels for metric: {}", metric);
+        for (key, values) in key_and_values.iter_mut() {
+            println!("{}: {:?}", key, values);
+        }
+    }
+
+    info!("Bye. :)");
+    Ok(())
+}


### PR DESCRIPTION
### What does this PR do?

Adds a new binary alongside `lading` called `captool` which provides some basic summarization of a given capture file.

The two main functions it serves:
1. Listing out metric names present in the file `--list-names`
2. Printing stats and labels for a given metric name `--metric foo`

### Motivation

The `capture.json` file is full of collected data, but manually sifting through json is no fun.

### Related issues


### Additional Notes

Example output:
```
2024-01-30T21:37:17.372138Z  INFO captool: Welcome to captool
2024-01-30T21:37:17.434764Z  INFO captool: Metric: smaps_rss
2024-01-30T21:37:17.439565Z  INFO captool: Labels:
pathname: {"/usr/lib/x86_64-linux-gnu/ld-linux-x86-64.so.2", "<empty pathname>", "[stack]", "[vvar]", "/usr/lib/x86_64-linux-gnu/libc.so.6", "/usr/lib/x86_64-linux-gnu/libm.so.6", "/home/ubuntu/dev/datadog-agent/dev/lib/libdatadog-agent-rtloader.so.0.1.0", "[vsyscall]", "/home/ubuntu/dev/datadog-agent/bin/agent/agent", "/usr/lib/x86_64-linux-gnu/libstdc++.so.6.0.30", "/usr/lib/x86_64-linux-gnu/libgcc_s.so.1", "[vdso]"}
pid: {"3896747"}
exe: {"agent"}
2024-01-30T21:37:17.440679Z  INFO captool: Stats for smaps_rss[pathname:/usr/lib/x86_64-linux-gnu/ld-linux-x86-64.so.2]: mean: 236
2024-01-30T21:37:17.441726Z  INFO captool: Stats for smaps_rss[pathname:<empty pathname>]: mean: 171100
2024-01-30T21:37:17.442736Z  INFO captool: Stats for smaps_rss[pathname:[stack]]: mean: 20
2024-01-30T21:37:17.443705Z  INFO captool: Stats for smaps_rss[pathname:[vvar]]: mean: 0
2024-01-30T21:37:17.444678Z  INFO captool: Stats for smaps_rss[pathname:/usr/lib/x86_64-linux-gnu/libc.so.6]: mean: 1996
2024-01-30T21:37:17.445675Z  INFO captool: Stats for smaps_rss[pathname:/usr/lib/x86_64-linux-gnu/libm.so.6]: mean: 292
2024-01-30T21:37:17.446653Z  INFO captool: Stats for smaps_rss[pathname:/home/ubuntu/dev/datadog-agent/dev/lib/libdatadog-agent-rtloader.so.0.1.0]: mean: 40
2024-01-30T21:37:17.447638Z  INFO captool: Stats for smaps_rss[pathname:[vsyscall]]: mean: 0
2024-01-30T21:37:17.448607Z  INFO captool: Stats for smaps_rss[pathname:/home/ubuntu/dev/datadog-agent/bin/agent/agent]: mean: 0
2024-01-30T21:37:17.449596Z  INFO captool: Stats for smaps_rss[pathname:/usr/lib/x86_64-linux-gnu/libstdc++.so.6.0.30]: mean: 1528
2024-01-30T21:37:17.450599Z  INFO captool: Stats for smaps_rss[pathname:/usr/lib/x86_64-linux-gnu/libgcc_s.so.1]: mean: 128
2024-01-30T21:37:17.451565Z  INFO captool: Stats for smaps_rss[pathname:[vdso]]: mean: 8
2024-01-30T21:37:17.452679Z  INFO captool: Stats for smaps_rss[pid:3896747]: mean: 14612.333333333314
2024-01-30T21:37:17.453834Z  INFO captool: Stats for smaps_rss[exe:agent]: mean: 14612.333333333314
2024-01-30T21:37:17.453856Z  INFO captool: Bye. :)
```
