### PR TITLE
SMPTNG-179: Replaces 'exe' with 'cmdline' for better process detection

### DIFF
--- a/lading/src/observer/linux.rs
+++ b/lading/src/observer/linux.rs
@@ -179,7 +179,7 @@ impl Sampler {
             let cmdline: String = if let Ok(cmdline) = process.cmdline() {
                 cmdline.join(" ")
             } else {
-                String::new()
+                "zombie".to_string()
             };
 
             let stats = process.stat();


### PR DESCRIPTION
### What does this PR do?

`exe` is not unique enough, this replaces it with `cmdline` which includes the `exe`.

### Motivation

colliding metrics when different logical processes run off same executable

### Related issues


### Additional Notes

Would appreciate any thoughts on what to do in the zombie case.