### PR TITLE
Add more memory collection telemetry

### DIFF
--- a/lading/src/observer/linux.rs
+++ b/lading/src/observer/linux.rs
@@ -280,11 +280,23 @@ impl Sampler {
                     ("cmdline", cmdline.clone()),
                     ("pathname", pathname),
                 ];
-                gauge!("smaps.rss", measures.rss as f64, &labels);
-                gauge!("smaps.pss", measures.pss as f64, &labels);
-                gauge!("smaps.size", measures.size as f64, &labels);
-                gauge!("smaps.swap", measures.swap as f64, &labels);
+                gauge!("smaps.rss.by_pathname", measures.rss as f64, &labels);
+                gauge!("smaps.pss.by_pathname", measures.pss as f64, &labels);
+                gauge!("smaps.size.by_pathname", measures.size as f64, &labels);
+                gauge!("smaps.swap.by_pathname", measures.swap as f64, &labels);
             }
+
+            let measures = memory_regions.aggregate();
+            let labels = [
+                ("pid", format!("{pid}")),
+                ("exe", basename.clone()),
+                ("cmdline", cmdline.clone()),
+            ];
+
+            gauge!("smaps.rss.sum", measures.rss as f64, &labels);
+            gauge!("smaps.pss.sum", measures.pss as f64, &labels);
+            gauge!("smaps.size.sum", measures.size as f64, &labels);
+            gauge!("smaps.swap.sum", measures.swap as f64, &labels);
         }
 
         gauge!("num_processes", total_processes as f64);

--- a/lading/src/observer/memory.rs
+++ b/lading/src/observer/memory.rs
@@ -217,6 +217,7 @@ impl Region {
     }
 }
 
+#[derive(Default)]
 pub(crate) struct AggrMeasure {
     pub(crate) size: u64,
     pub(crate) pss: u64,
@@ -227,6 +228,20 @@ pub(crate) struct AggrMeasure {
 impl Regions {
     pub(crate) fn from_pid(pid: i32) -> Result<Self, Error> {
         Regions::from_file(&format!("/proc/{pid}/smaps"))
+    }
+
+    /// Returns a sum of all the fields from each region within this Regions
+    pub(crate) fn aggregate(&self) -> AggrMeasure {
+        let mut aggr = AggrMeasure::default();
+
+        for region in &self.0 {
+            aggr.size = aggr.size.saturating_add(region.size);
+            aggr.pss = aggr.pss.saturating_add(region.pss);
+            aggr.swap = aggr.swap.saturating_add(aggr.swap);
+            aggr.rss = aggr.rss.saturating_add(region.rss);
+        }
+
+        aggr
     }
 
     pub(crate) fn aggregate_by_pathname(&self) -> Vec<(String, AggrMeasure)> {


### PR DESCRIPTION
### What does this PR do?

This makes 2 changes:
1. Renames `smaps.rss` to `smaps.rss.by_pathname` for clarity
2. Adds `smaps.rss.sum` which is a sum across all regions
3. Adds a variety of memory-related fields from `proc/status` 

### Motivation


### Related issues



### Additional Notes

