### PR TITLE
Removing More Expects and Massive Refactor for Generator to remove expects in the future

### DIFF
--- a/lading/src/generator/file_gen/logrotate.rs
+++ b/lading/src/generator/file_gen/logrotate.rs
@@ -57,9 +57,6 @@ pub enum Error {
     /// Failed to convert, value is 0
     #[error("Value provided must not be zero")]
     Zero,
-    /// Iterator has already finished
-    #[error("Next failed, iterator already finished")]
-    Next,
     /// Empty block cache
     #[error("Block cache does not have any blocks")]
     EmptyBlockCache,
@@ -314,7 +311,7 @@ impl Child {
 
             tokio::select! {
                 _ = self.throttle.wait_for(total_bytes) => {
-                    let blk = rcv.next().await.ok_or(Error::Next)?; // actually advance through the blocks
+                    let blk = rcv.next().await.expect("there is no next block in rcv"); // actually advance through the blocks
                     let total_bytes = u64::from(total_bytes.get());
 
                     {

--- a/lading/src/generator/file_gen/logrotate.rs
+++ b/lading/src/generator/file_gen/logrotate.rs
@@ -57,9 +57,6 @@ pub enum Error {
     /// Failed to convert, value is 0
     #[error("Value provided must not be zero")]
     Zero,
-    /// Empty block cache
-    #[error("Block cache does not have any blocks")]
-    EmptyBlockCache,
 }
 
 #[derive(Debug, Deserialize, PartialEq)]
@@ -306,7 +303,7 @@ impl Child {
         loop {
             // SAFETY: By construction the block cache will never be empty
             // except in the event of a catastrophic failure.
-            let blk = rcv.peek().await.ok_or(Error::EmptyBlockCache)?;
+            let blk = rcv.peek().await.expect("block cache is empty");
             let total_bytes = blk.total_bytes;
 
             tokio::select! {

--- a/lading/src/generator/file_gen/logrotate.rs
+++ b/lading/src/generator/file_gen/logrotate.rs
@@ -303,12 +303,12 @@ impl Child {
         loop {
             // SAFETY: By construction the block cache will never be empty
             // except in the event of a catastrophic failure.
-            let blk = rcv.peek().await.expect("block cache is empty");
+            let blk = rcv.peek().await.expect("block cache should never be empty");
             let total_bytes = blk.total_bytes;
 
             tokio::select! {
                 _ = self.throttle.wait_for(total_bytes) => {
-                    let blk = rcv.next().await.expect("there is no next block in rcv"); // actually advance through the blocks
+                    let blk = rcv.next().await.expect("failed to advance through the blocks"); // actually advance through the blocks
                     let total_bytes = u64::from(total_bytes.get());
 
                     {

--- a/lading/src/generator/file_gen/traditional.rs
+++ b/lading/src/generator/file_gen/traditional.rs
@@ -63,9 +63,6 @@ pub enum Error {
     /// Failed to convert, value is 0
     #[error("Value provided must not be zero")]
     Zero,
-    /// Empty block cache
-    #[error("Block cache does not have any blocks")]
-    EmptyBlockCache,
 }
 
 fn default_rotation() -> bool {
@@ -280,7 +277,7 @@ impl Child {
         let bytes_written = register_counter!("bytes_written");
 
         loop {
-            let blk = rcv.peek().await.ok_or(Error::EmptyBlockCache)?;
+            let blk = rcv.peek().await.expect("block cache is empty");
             let total_bytes = blk.total_bytes;
 
             tokio::select! {

--- a/lading/src/generator/file_gen/traditional.rs
+++ b/lading/src/generator/file_gen/traditional.rs
@@ -277,12 +277,12 @@ impl Child {
         let bytes_written = register_counter!("bytes_written");
 
         loop {
-            let blk = rcv.peek().await.expect("block cache is empty");
+            let blk = rcv.peek().await.expect("block cache should never be empty");
             let total_bytes = blk.total_bytes;
 
             tokio::select! {
                 _ = self.throttle.wait_for(total_bytes) => {
-                    let blk = rcv.next().await.expect("there is no next block in rcv"); // actually advance through the blocks
+                    let blk = rcv.next().await.expect("failed to advance through blocks"); // actually advance through the blocks
                     let total_bytes = u64::from(total_bytes.get());
 
                     {

--- a/lading/src/generator/file_gen/traditional.rs
+++ b/lading/src/generator/file_gen/traditional.rs
@@ -63,9 +63,6 @@ pub enum Error {
     /// Failed to convert, value is 0
     #[error("Value provided must not be zero")]
     Zero,
-    /// Iterator has already finished
-    #[error("Next failed, iterator already finished")]
-    Next,
     /// Empty block cache
     #[error("Block cache does not have any blocks")]
     EmptyBlockCache,
@@ -288,7 +285,7 @@ impl Child {
 
             tokio::select! {
                 _ = self.throttle.wait_for(total_bytes) => {
-                    let blk = rcv.next().await.ok_or(Error::Next)?; // actually advance through the blocks
+                    let blk = rcv.next().await.expect("there is no next block in rcv"); // actually advance through the blocks
                     let total_bytes = u64::from(total_bytes.get());
 
                     {

--- a/lading/src/generator/file_tree.rs
+++ b/lading/src/generator/file_tree.rs
@@ -42,9 +42,6 @@ pub enum Error {
     /// Folder has no parent error
     #[error("Folder has no parent")]
     Parent,
-    /// Iterator has already finished
-    #[error("next failed, node path already finished")]
-    Next,
     /// Error converting path to string
     #[error("Error converting path to string")]
     ToStr,
@@ -182,7 +179,7 @@ impl FileTree {
         loop {
             tokio::select! {
                 _ = self.open_throttle.wait() => {
-                    let node = iter.next().ok_or(Error::Next)?;
+                    let node = iter.next().expect("there is no next block in rcv");
                     if node.exists() {
                         File::open(node.as_path()).await?;
                     } else {

--- a/lading/src/generator/file_tree.rs
+++ b/lading/src/generator/file_tree.rs
@@ -179,7 +179,7 @@ impl FileTree {
         loop {
             tokio::select! {
                 _ = self.open_throttle.wait() => {
-                    let node = iter.next().expect("there is no next block in rcv");
+                    let node = iter.next().expect("node is not populated properly");
                     if node.exists() {
                         File::open(node.as_path()).await?;
                     } else {

--- a/lading/src/generator/grpc.rs
+++ b/lading/src/generator/grpc.rs
@@ -55,9 +55,6 @@ pub enum Error {
     /// Zero value
     #[error("Value provided must not be zero")]
     Zero,
-    /// Empty block cache
-    #[error("Block cache does not have any blocks")]
-    EmptyBlockCache,
 }
 
 /// Config for [`Grpc`]
@@ -303,7 +300,7 @@ impl Grpc {
         let response_bytes = register_counter!("response_bytes", &self.metric_labels);
 
         loop {
-            let blk = rcv.peek().await.ok_or(Error::EmptyBlockCache)?;
+            let blk = rcv.peek().await.expect("block cache is empty");
             let total_bytes = blk.total_bytes;
 
             tokio::select! {

--- a/lading/src/generator/grpc.rs
+++ b/lading/src/generator/grpc.rs
@@ -53,11 +53,8 @@ pub enum Error {
     #[error("Bytes must not be negative: {0}")]
     Byte(#[from] ByteError),
     /// Zero value
-    #[error("Value cannot be zero")]
+    #[error("Value provided must not be zero")]
     Zero,
-    /// Iterator has already finished
-    #[error("Next failed, iterator already finished")]
-    Next,
     /// Empty block cache
     #[error("Block cache does not have any blocks")]
     EmptyBlockCache,
@@ -313,7 +310,7 @@ impl Grpc {
                 _ = self.throttle.wait_for(total_bytes) => {
                     let block_length = blk.bytes.len();
                     requests_sent.increment(1);
-                    let blk = rcv.next().await.ok_or(Error::Next)?; // actually advance through the blocks
+                    let blk = rcv.next().await.expect("there is no next block in rcv"); // actually advance through the blocks
                     let res = Self::req(
                         &mut client,
                         rpc_path.clone(),

--- a/lading/src/generator/grpc.rs
+++ b/lading/src/generator/grpc.rs
@@ -300,14 +300,14 @@ impl Grpc {
         let response_bytes = register_counter!("response_bytes", &self.metric_labels);
 
         loop {
-            let blk = rcv.peek().await.expect("block cache is empty");
+            let blk = rcv.peek().await.expect("block cache should never be empty");
             let total_bytes = blk.total_bytes;
 
             tokio::select! {
                 _ = self.throttle.wait_for(total_bytes) => {
                     let block_length = blk.bytes.len();
                     requests_sent.increment(1);
-                    let blk = rcv.next().await.expect("there is no next block in rcv"); // actually advance through the blocks
+                    let blk = rcv.next().await.expect("failed to advance through blocks"); // actually advance through the blocks
                     let res = Self::req(
                         &mut client,
                         rpc_path.clone(),

--- a/lading/src/generator/http.rs
+++ b/lading/src/generator/http.rs
@@ -97,6 +97,9 @@ pub enum Error {
     /// Failed to convert, value is 0
     #[error("Value provided must not be zero")]
     Zero,
+    /// Iterator has already finished
+    #[error("Next failed, iterator already finished")]
+    Next,
 }
 
 /// The HTTP generator.
@@ -230,7 +233,7 @@ impl Http {
         thread::Builder::new().spawn(|| block_cache.spin(snd))?;
 
         loop {
-            let blk = rcv.next().await.expect("block cache closed");
+            let blk = rcv.next().await.ok_or(Error::Next)?;
             let total_bytes = blk.total_bytes;
 
             let body = Body::from(blk.bytes.clone());

--- a/lading/src/generator/http.rs
+++ b/lading/src/generator/http.rs
@@ -230,7 +230,7 @@ impl Http {
         thread::Builder::new().spawn(|| block_cache.spin(snd))?;
 
         loop {
-            let blk = rcv.next().await.expect("there is no next block in rcv");
+            let blk = rcv.next().await.expect("block cache should never be empty");
             let total_bytes = blk.total_bytes;
 
             let body = Body::from(blk.bytes.clone());

--- a/lading/src/generator/http.rs
+++ b/lading/src/generator/http.rs
@@ -97,9 +97,6 @@ pub enum Error {
     /// Failed to convert, value is 0
     #[error("Value provided must not be zero")]
     Zero,
-    /// Iterator has already finished
-    #[error("Next failed, iterator already finished")]
-    Next,
 }
 
 /// The HTTP generator.
@@ -233,7 +230,7 @@ impl Http {
         thread::Builder::new().spawn(|| block_cache.spin(snd))?;
 
         loop {
-            let blk = rcv.next().await.ok_or(Error::Next)?;
+            let blk = rcv.next().await.expect("there is no next block in rcv");
             let total_bytes = blk.total_bytes;
 
             let body = Body::from(blk.bytes.clone());

--- a/lading/src/generator/process_tree.rs
+++ b/lading/src/generator/process_tree.rs
@@ -89,9 +89,6 @@ pub enum Error {
     /// Utf8 error
     #[error("Utf8 error: {0}")]
     Utf8(#[from] str::Utf8Error),
-    /// Iterator has already finished
-    #[error("next failed, node path already finished")]
-    Next,
 }
 
 fn default_max_depth() -> NonZeroU32 {
@@ -454,7 +451,7 @@ pub fn spawn_tree(nodes: &VecDeque<Process>, sleep_ns: u32) -> Result<(), Error>
         let duration = Duration::from_nanos(sleep_ns.into());
         thread::sleep(duration);
 
-        let process = iter.next().ok_or(Error::Next)?;
+        let process = iter.next().expect("there is no next block in rcv");
 
         if let Some(exec) = &process.exec {
             let status = std::process::Command::new(&exec.executable)

--- a/lading/src/generator/process_tree.rs
+++ b/lading/src/generator/process_tree.rs
@@ -451,7 +451,7 @@ pub fn spawn_tree(nodes: &VecDeque<Process>, sleep_ns: u32) -> Result<(), Error>
         let duration = Duration::from_nanos(sleep_ns.into());
         thread::sleep(duration);
 
-        let process = iter.next().expect("there is no next block in rcv");
+        let process = iter.next().expect("process is not populated properly");
 
         if let Some(exec) = &process.exec {
             let status = std::process::Command::new(&exec.executable)

--- a/lading/src/generator/procfs.rs
+++ b/lading/src/generator/procfs.rs
@@ -28,6 +28,9 @@ pub enum Error {
     /// Unable to strip prefix from passed copy file
     #[error(transparent)]
     Strip(#[from] StripPrefixError),
+    /// Wrapper aroun [`lading_payload::Error`]
+    #[error(transparent)]
+    Payload(#[from] lading_payload::Error),
 }
 
 fn default_copy_from_host() -> Vec<PathBuf> {
@@ -74,7 +77,7 @@ impl ProcFs {
         let mut rng = StdRng::from_seed(config.seed);
 
         let total_processes = config.total_processes.get();
-        let mut processes = procfs::fixed(&mut rng, total_processes as usize);
+        let mut processes = procfs::fixed(&mut rng, total_processes as usize)?;
 
         for process in processes.drain(..) {
             let pid = process.pid;

--- a/lading/src/generator/splunk_hec.rs
+++ b/lading/src/generator/splunk_hec.rs
@@ -118,9 +118,6 @@ pub enum Error {
     /// Failed to convert, value is 0
     #[error("Value provided must not be zero")]
     Zero,
-    /// Empty block cache
-    #[error("Block cache does not have any blocks")]
-    EmptyBlockCache,
 }
 
 /// Defines a task that emits variant lines to a Splunk HEC server controlling
@@ -291,7 +288,7 @@ impl SplunkHec {
                 .next()
                 .expect("there is no next block in rcv")
                 .clone();
-            let blk = rcv.peek().await.ok_or(Error::EmptyBlockCache)?;
+            let blk = rcv.peek().await.expect("block cache is empty");
             let total_bytes = blk.total_bytes;
 
             tokio::select! {

--- a/lading/src/generator/splunk_hec.rs
+++ b/lading/src/generator/splunk_hec.rs
@@ -118,6 +118,12 @@ pub enum Error {
     /// Failed to convert, value is 0
     #[error("Value provided must not be zero")]
     Zero,
+    /// Iterator has already finished
+    #[error("Next failed, iterator already finished")]
+    Next,
+    /// Empty block cache
+    #[error("Block cache does not have any blocks")]
+    EmptyBlockCache,
 }
 
 /// Defines a task that emits variant lines to a Splunk HEC server controlling
@@ -284,14 +290,8 @@ impl SplunkHec {
         let mut channels = self.channels.iter().cycle();
 
         loop {
-            let channel: Channel = channels
-                .next()
-                .expect("channel iteration already finished")
-                .clone();
-            let blk = rcv
-                .peek()
-                .await
-                .expect("block cache does not have any blocks");
+            let channel: Channel = channels.next().ok_or(Error::Next)?.clone();
+            let blk = rcv.peek().await.ok_or(Error::EmptyBlockCache)?;
             let total_bytes = blk.total_bytes;
 
             tokio::select! {
@@ -300,7 +300,7 @@ impl SplunkHec {
                     let labels = labels.clone();
                     let uri = uri.clone();
 
-                    let blk = rcv.next().await.expect("block cache failed to find next value"); // actually advance through the blocks
+                    let blk = rcv.next().await.ok_or(Error::Next)?; // actually advance through the blocks
                     let body = Body::from(blk.bytes.clone());
                     let block_length = blk.bytes.len();
 

--- a/lading/src/generator/splunk_hec.rs
+++ b/lading/src/generator/splunk_hec.rs
@@ -286,9 +286,9 @@ impl SplunkHec {
         loop {
             let channel: Channel = channels
                 .next()
-                .expect("there is no next block in rcv")
+                .expect("channel should never be empty")
                 .clone();
-            let blk = rcv.peek().await.expect("block cache is empty");
+            let blk = rcv.peek().await.expect("block cache should never be empty");
             let total_bytes = blk.total_bytes;
 
             tokio::select! {
@@ -297,7 +297,7 @@ impl SplunkHec {
                     let labels = labels.clone();
                     let uri = uri.clone();
 
-                    let blk = rcv.next().await.expect("there is no next block in rcv"); // actually advance through the blocks
+                    let blk = rcv.next().await.expect("failed to advance through blocks"); // actually advance through the blocks
                     let body = Body::from(blk.bytes.clone());
                     let block_length = blk.bytes.len();
 

--- a/lading/src/generator/tcp.rs
+++ b/lading/src/generator/tcp.rs
@@ -144,7 +144,7 @@ impl Tcp {
             .to_socket_addrs()
             .expect("could not convert to socket")
             .next()
-            .expect("there is no next block in rcv");
+            .expect("could not convert to socket addr");
         Ok(Self {
             addr,
             block_cache,
@@ -193,12 +193,12 @@ impl Tcp {
                 continue;
             };
 
-            let blk = rcv.peek().await.expect("block cache is empty");
+            let blk = rcv.peek().await.expect("block cache should never be empty");
             let total_bytes = blk.total_bytes;
 
             tokio::select! {
                 _ = self.throttle.wait_for(total_bytes) => {
-                    let blk = rcv.next().await.expect("there is no next block in rcv"); // actually advance through the blocks
+                    let blk = rcv.next().await.expect("failed to advance through the blocks"); // actually advance through the blocks
                     match connection.write_all(&blk.bytes).await {
                         Ok(()) => {
                             bytes_written.increment(u64::from(blk.total_bytes.get()));

--- a/lading/src/generator/tcp.rs
+++ b/lading/src/generator/tcp.rs
@@ -66,9 +66,6 @@ pub enum Error {
     /// Zero value error
     #[error("Value cannot be zero")]
     Zero,
-    /// Empty block cache
-    #[error("Block cache does not have any blocks")]
-    EmptyBlockCache,
 }
 
 #[derive(Debug)]
@@ -196,7 +193,7 @@ impl Tcp {
                 continue;
             };
 
-            let blk = rcv.peek().await.ok_or(Error::EmptyBlockCache)?;
+            let blk = rcv.peek().await.expect("block cache is empty");
             let total_bytes = blk.total_bytes;
 
             tokio::select! {

--- a/lading/src/generator/udp.rs
+++ b/lading/src/generator/udp.rs
@@ -67,9 +67,6 @@ pub enum Error {
     /// Failed to convert, value is 0
     #[error("Value provided is zero")]
     Zero,
-    /// Iterator has already finished
-    #[error("Next failed, iterator already finished")]
-    Next,
     /// Empty block cache
     #[error("Block cache does not have any blocks")]
     EmptyBlockCache,
@@ -151,7 +148,7 @@ impl Udp {
             .to_socket_addrs()
             .expect("could not convert to socket")
             .next()
-            .ok_or(Error::Next)?;
+            .expect("there is no next block in rcv");
 
         Ok(Self {
             addr,
@@ -212,7 +209,7 @@ impl Udp {
                 }
                 _ = self.throttle.wait_for(total_bytes), if connection.is_some() => {
                     let sock = connection.expect("connection failed");
-                    let blk = rcv.next().await.ok_or(Error::Next)?; // actually advance through the blocks
+                    let blk = rcv.next().await.expect("there is no next block in rcv"); // actually advance through the blocks
                     match sock.send_to(&blk.bytes, self.addr).await {
                         Ok(bytes) => {
                             bytes_written.increment(bytes as u64);

--- a/lading/src/generator/udp.rs
+++ b/lading/src/generator/udp.rs
@@ -67,9 +67,6 @@ pub enum Error {
     /// Failed to convert, value is 0
     #[error("Value provided is zero")]
     Zero,
-    /// Empty block cache
-    #[error("Block cache does not have any blocks")]
-    EmptyBlockCache,
 }
 
 #[derive(Debug)]
@@ -183,7 +180,7 @@ impl Udp {
         let packets_sent = register_counter!("packets_sent", &self.metric_labels);
 
         loop {
-            let blk = rcv.peek().await.ok_or(Error::EmptyBlockCache)?;
+            let blk = rcv.peek().await.expect("block cache is empty");
             let total_bytes = blk.total_bytes;
             assert!(
                 total_bytes.get() <= 65507,

--- a/lading/src/generator/unix_datagram.rs
+++ b/lading/src/generator/unix_datagram.rs
@@ -87,9 +87,6 @@ pub enum Error {
     /// Byte error
     #[error("Bytes must not be negative: {0}")]
     Byte(#[from] ByteError),
-    /// Empty block cache
-    #[error("Block cache does not have any blocks")]
-    EmptyBlockCache,
 }
 
 #[derive(Debug)]
@@ -259,7 +256,7 @@ impl Child {
         let packets_sent = register_counter!("packets_sent", &self.metric_labels);
 
         loop {
-            let blk = rcv.peek().await.ok_or(Error::EmptyBlockCache)?;
+            let blk = rcv.peek().await.expect("block cache is empty");
             let total_bytes = blk.total_bytes;
 
             tokio::select! {

--- a/lading/src/generator/unix_datagram.rs
+++ b/lading/src/generator/unix_datagram.rs
@@ -87,6 +87,12 @@ pub enum Error {
     /// Byte error
     #[error("Bytes must not be negative: {0}")]
     Byte(#[from] ByteError),
+    /// Iterator has already finished
+    #[error("Next failed, iterator already finished")]
+    Next,
+    /// Empty block cache
+    #[error("Block cache does not have any blocks")]
+    EmptyBlockCache,
 }
 
 #[derive(Debug)]
@@ -256,7 +262,7 @@ impl Child {
         let packets_sent = register_counter!("packets_sent", &self.metric_labels);
 
         loop {
-            let blk = rcv.peek().await.expect("block cache is empty");
+            let blk = rcv.peek().await.ok_or(Error::EmptyBlockCache)?;
             let total_bytes = blk.total_bytes;
 
             tokio::select! {
@@ -265,7 +271,7 @@ impl Child {
                     // some of the written bytes make it through in which case we
                     // must cycle back around and try to write the remainder of the
                     // buffer.
-                    let blk = rcv.next().await.expect("failed to advance through the blocks"); // actually advance through the blocks
+                    let blk = rcv.next().await.ok_or(Error::Next)?; // actually advance through the blocks
                     let blk_max: usize = total_bytes.get() as usize;
                     let mut blk_offset = 0;
                     while blk_offset < blk_max {

--- a/lading/src/generator/unix_datagram.rs
+++ b/lading/src/generator/unix_datagram.rs
@@ -87,9 +87,6 @@ pub enum Error {
     /// Byte error
     #[error("Bytes must not be negative: {0}")]
     Byte(#[from] ByteError),
-    /// Iterator has already finished
-    #[error("Next failed, iterator already finished")]
-    Next,
     /// Empty block cache
     #[error("Block cache does not have any blocks")]
     EmptyBlockCache,
@@ -271,7 +268,7 @@ impl Child {
                     // some of the written bytes make it through in which case we
                     // must cycle back around and try to write the remainder of the
                     // buffer.
-                    let blk = rcv.next().await.ok_or(Error::Next)?; // actually advance through the blocks
+                    let blk = rcv.next().await.expect("there is no next block in rcv"); // actually advance through the blocks
                     let blk_max: usize = total_bytes.get() as usize;
                     let mut blk_offset = 0;
                     while blk_offset < blk_max {

--- a/lading/src/generator/unix_datagram.rs
+++ b/lading/src/generator/unix_datagram.rs
@@ -256,7 +256,7 @@ impl Child {
         let packets_sent = register_counter!("packets_sent", &self.metric_labels);
 
         loop {
-            let blk = rcv.peek().await.expect("block cache is empty");
+            let blk = rcv.peek().await.expect("block cache should never be empty");
             let total_bytes = blk.total_bytes;
 
             tokio::select! {
@@ -265,7 +265,7 @@ impl Child {
                     // some of the written bytes make it through in which case we
                     // must cycle back around and try to write the remainder of the
                     // buffer.
-                    let blk = rcv.next().await.expect("there is no next block in rcv"); // actually advance through the blocks
+                    let blk = rcv.next().await.expect("failed to advance through blocks"); // actually advance through the blocks
                     let blk_max: usize = total_bytes.get() as usize;
                     let mut blk_offset = 0;
                     while blk_offset < blk_max {

--- a/lading/src/generator/unix_stream.rs
+++ b/lading/src/generator/unix_stream.rs
@@ -66,9 +66,6 @@ pub enum Error {
     /// Failed to convert, value is 0
     #[error("Value provided must not be zero")]
     Zero,
-    /// Iterator has already finished
-    #[error("Next failed, iterator already finished")]
-    Next,
     /// Empty block cache
     #[error("Block cache does not have any blocks")]
     EmptyBlockCache,
@@ -220,7 +217,7 @@ impl UnixStream {
                     // buffer.
                     let blk_max: usize = total_bytes.get() as usize;
                     let mut blk_offset = 0;
-                    let blk = rcv.next().await.ok_or(Error::Next)?; // advance to the block that was previously peeked
+                    let blk = rcv.next().await.expect("there is no next block in rcv"); // advance to the block that was previously peeked
                     while blk_offset < blk_max {
                         let stream = &socket;
 

--- a/lading/src/generator/unix_stream.rs
+++ b/lading/src/generator/unix_stream.rs
@@ -203,7 +203,7 @@ impl UnixStream {
                 continue;
             };
 
-            let blk = rcv.peek().await.expect("block cache is empty");
+            let blk = rcv.peek().await.expect("block cache should never be empty");
             let total_bytes = blk.total_bytes;
 
             tokio::select! {
@@ -214,7 +214,7 @@ impl UnixStream {
                     // buffer.
                     let blk_max: usize = total_bytes.get() as usize;
                     let mut blk_offset = 0;
-                    let blk = rcv.next().await.expect("there is no next block in rcv"); // advance to the block that was previously peeked
+                    let blk = rcv.next().await.expect("failed to advance to the next block"); // advance to the block that was previously peeked
                     while blk_offset < blk_max {
                         let stream = &socket;
 

--- a/lading/src/generator/unix_stream.rs
+++ b/lading/src/generator/unix_stream.rs
@@ -66,9 +66,6 @@ pub enum Error {
     /// Failed to convert, value is 0
     #[error("Value provided must not be zero")]
     Zero,
-    /// Empty block cache
-    #[error("Block cache does not have any blocks")]
-    EmptyBlockCache,
 }
 
 #[derive(Debug)]
@@ -206,7 +203,7 @@ impl UnixStream {
                 continue;
             };
 
-            let blk = rcv.peek().await.ok_or(Error::EmptyBlockCache)?;
+            let blk = rcv.peek().await.expect("block cache is empty");
             let total_bytes = blk.total_bytes;
 
             tokio::select! {

--- a/lading_payload/src/apache_common.rs
+++ b/lading_payload/src/apache_common.rs
@@ -318,12 +318,13 @@ impl ApacheCommon {
 
 impl<'a> Generator<'a> for ApacheCommon {
     type Output = Member<'a>;
+    type Error = Error;
 
-    fn generate<R>(&'a self, mut rng: &mut R) -> Self::Output
+    fn generate<R>(&'a self, mut rng: &mut R) -> Result<Self::Output, Error>
     where
         R: rand::Rng + ?Sized,
     {
-        Member {
+        Ok(Member {
             host: rng.gen(),
             user: self
                 .str_pool
@@ -335,7 +336,7 @@ impl<'a> Generator<'a> for ApacheCommon {
             protocol: rng.gen(),
             status_code: rng.gen(),
             bytes_out: rng.gen(),
-        }
+        })
     }
 }
 
@@ -347,7 +348,7 @@ impl crate::Serialize for ApacheCommon {
     {
         let mut bytes_remaining = max_bytes;
         loop {
-            let member: Member = self.generate(&mut rng);
+            let member: Member = self.generate(&mut rng)?;
             let encoding = format!("{member}");
             let line_length = encoding.len() + 1; // add one for the newline
             match bytes_remaining.checked_sub(line_length) {

--- a/lading_payload/src/apache_common.rs
+++ b/lading_payload/src/apache_common.rs
@@ -329,7 +329,7 @@ impl<'a> Generator<'a> for ApacheCommon {
             user: self
                 .str_pool
                 .of_size_range(&mut rng, 1_u16..16_u16)
-                .expect("failed to generate string"),
+                .ok_or(Error::StringGenerate)?,
             timestamp: rng.gen(),
             method: rng.gen(),
             path: rng.gen(),

--- a/lading_payload/src/ascii.rs
+++ b/lading_payload/src/ascii.rs
@@ -42,7 +42,7 @@ impl crate::Serialize for Ascii {
             let encoding: &str = self
                 .pool
                 .of_size(&mut rng, usize::from(bytes))
-                .expect("failed to generate string");
+                .ok_or(Error::StringGenerate)?;
             let line_length = encoding.len() + 1; // add one for the newline
             match bytes_remaining.checked_sub(line_length) {
                 Some(remainder) => {
@@ -72,7 +72,7 @@ mod test {
             let ascii = Ascii::new(&mut rng);
 
             let mut bytes = Vec::with_capacity(max_bytes);
-            ascii.to_bytes(rng, max_bytes, &mut bytes).expect("failed to convert to bytes");
+            ascii.to_bytes(rng, max_bytes, &mut bytes)?;
             prop_assert!(bytes.len() <= max_bytes);
         }
     }

--- a/lading_payload/src/block.rs
+++ b/lading_payload/src/block.rs
@@ -50,9 +50,6 @@ pub enum Error {
     /// Static payload creation error
     #[error(transparent)]
     Static(#[from] crate::statik::Error),
-    /// Error from `next` method
-    #[error("Iterator has no next value")]
-    Next,
     /// Error for crate deserialization
     #[error("Deserialization error: {0}")]
     Deserialize(#[from] crate::Error),
@@ -565,7 +562,7 @@ fn chunk_bytes<const N: usize>(
             break;
         }
         // SAFETY: By construction, the iterator will never terminate.
-        let block_size = iter.next().ok_or(Error::Next)?.get();
+        let block_size = iter.next().expect("there is no next block in rcv").get();
 
         // Determine if the block_size fits in the remaining bytes. If it does,
         // great. If not, we break out of the round-robin.

--- a/lading_payload/src/block.rs
+++ b/lading_payload/src/block.rs
@@ -13,8 +13,6 @@ use serde::Deserialize;
 use tokio::sync::mpsc::{self, error::SendError, Sender};
 use tracing::{error, info, span, Level};
 
-use crate::dogstatsd;
-
 const MAX_CHUNKS: usize = 4096;
 
 /// Error for `Cache::spin`
@@ -26,15 +24,15 @@ pub enum SpinError {
     /// Provided configuration had validation errors
     #[error("Provided configuration was not valid.")]
     InvalidConfig,
-    /// DogStatsD creation error
-    #[error(transparent)]
-    DogStatsD(#[from] dogstatsd::Error),
     /// Static payload creation error
     #[error(transparent)]
     Static(#[from] crate::statik::Error),
     /// rng slice is Empty
     #[error("RNG slice is empty")]
     EmptyRng,
+    /// Error for crate deserialization
+    #[error("Deserialization error: {0}")]
+    Deserialize(#[from] crate::Error),
 }
 
 /// Error for [`Cache`]
@@ -49,15 +47,15 @@ pub enum Error {
     /// Provided configuration had validation errors
     #[error("Provided configuration was not valid.")]
     InvalidConfig,
-    /// DogStatsD creation error
-    #[error(transparent)]
-    DogStatsD(#[from] dogstatsd::Error),
     /// Static payload creation error
     #[error(transparent)]
     Static(#[from] crate::statik::Error),
     /// Error from `next` method
     #[error("Iterator has no next value")]
     Next,
+    /// Error for crate deserialization
+    #[error("Deserialization error: {0}")]
+    Deserialize(#[from] crate::Error),
 }
 
 /// Errors for the construction of chunks

--- a/lading_payload/src/block.rs
+++ b/lading_payload/src/block.rs
@@ -32,6 +32,9 @@ pub enum SpinError {
     /// Static payload creation error
     #[error(transparent)]
     Static(#[from] crate::statik::Error),
+    /// rng slice is Empty
+    #[error("RNG slice is empty")]
+    EmptyRng,
 }
 
 /// Error for [`Cache`]
@@ -665,7 +668,7 @@ where
         // push blocks into the sender until such time as it's full. When that
         // happens we overflow into the cache until such time as that's full.
         'refill: loop {
-            let block_size = block_chunks.choose(&mut rng).expect("rng slice is empty");
+            let block_size = block_chunks.choose(&mut rng).ok_or(SpinError::EmptyRng)?;
             if let Some(block) = construct_block(&mut rng, serializer, *block_size) {
                 match snd.try_reserve() {
                     Ok(permit) => permit.send(block),

--- a/lading_payload/src/block.rs
+++ b/lading_payload/src/block.rs
@@ -562,7 +562,10 @@ fn chunk_bytes<const N: usize>(
             break;
         }
         // SAFETY: By construction, the iterator will never terminate.
-        let block_size = iter.next().expect("there is no next block in rcv").get();
+        let block_size = iter
+            .next()
+            .expect("failed to get block size, should not fail")
+            .get();
 
         // Determine if the block_size fits in the remaining bytes. If it does,
         // great. If not, we break out of the round-robin.

--- a/lading_payload/src/datadog_logs.rs
+++ b/lading_payload/src/datadog_logs.rs
@@ -105,12 +105,13 @@ impl DatadogLog {
 
 impl<'a> Generator<'a> for DatadogLog {
     type Output = Member<'a>;
+    type Error = Error;
 
-    fn generate<R>(&'a self, mut rng: &mut R) -> Self::Output
+    fn generate<R>(&'a self, mut rng: &mut R) -> Result<Self::Output, Error>
     where
         R: rand::Rng + ?Sized,
     {
-        Member {
+        Ok(Member {
             message: message(&mut rng, &self.str_pool),
             status: STATUSES.choose(rng).expect("failed to generate status"),
             timestamp: rng.gen(),
@@ -120,7 +121,7 @@ impl<'a> Generator<'a> for DatadogLog {
             ddtags: TAG_OPTIONS
                 .choose(rng)
                 .expect("failed to generate tag options"),
-        }
+        })
     }
 }
 
@@ -144,7 +145,7 @@ impl crate::Serialize for DatadogLog {
         let cap = (max_bytes / approx_member_encoded_size) + 100;
         let mut members: Vec<Member> = Vec::with_capacity(cap);
         for _ in 0..cap {
-            members.push(self.generate(&mut rng));
+            members.push(self.generate(&mut rng)?);
         }
 
         // Search for an encoding that's just right.

--- a/lading_payload/src/dogstatsd/common.rs
+++ b/lading_payload/src/dogstatsd/common.rs
@@ -6,7 +6,7 @@ use rand::{
     Rng,
 };
 
-use crate::Generator;
+use crate::{Error, Generator};
 
 use super::{ConfRange, ValueConf};
 
@@ -52,8 +52,9 @@ impl NumValueGenerator {
 
 impl<'a> Generator<'a> for NumValueGenerator {
     type Output = NumValue;
+    type Error = Error;
 
-    fn generate<R>(&'a self, rng: &mut R) -> Self::Output
+    fn generate<R>(&'a self, rng: &mut R) -> Result<Self::Output, Error>
     where
         R: rand::Rng + ?Sized,
     {
@@ -65,9 +66,9 @@ impl<'a> Generator<'a> for NumValueGenerator {
                 float,
             } => {
                 if prob < *float_probability {
-                    NumValue::Float(*float)
+                    Ok(NumValue::Float(*float))
                 } else {
-                    NumValue::Int(*int)
+                    Ok(NumValue::Int(*int))
                 }
             }
             Self::Uniform {
@@ -76,9 +77,9 @@ impl<'a> Generator<'a> for NumValueGenerator {
                 float_distr,
             } => {
                 if prob < *float_probability {
-                    NumValue::Float(float_distr.sample(rng))
+                    Ok(NumValue::Float(float_distr.sample(rng)))
                 } else {
-                    NumValue::Int(int_distr.sample(rng))
+                    Ok(NumValue::Int(int_distr.sample(rng)))
                 }
             }
         }

--- a/lading_payload/src/dogstatsd/common/tags.rs
+++ b/lading_payload/src/dogstatsd/common/tags.rs
@@ -5,7 +5,7 @@ use std::{
 
 use rand::{rngs::SmallRng, SeedableRng};
 
-use crate::{common::strings, dogstatsd::ConfRange};
+use crate::{common::strings, dogstatsd::ConfRange, Error};
 
 // This represents a list of tags that will be present on a single
 // dogstatsd message.
@@ -54,8 +54,9 @@ impl Generator {
 // https://docs.datadoghq.com/getting_started/tagging/#define-tags
 impl<'a> crate::Generator<'a> for Generator {
     type Output = Tagset;
+    type Error = Error;
 
-    fn generate<R>(&'a self, _rng: &mut R) -> Self::Output
+    fn generate<R>(&'a self, _rng: &mut R) -> Result<Self::Output, Error>
     where
         R: rand::Rng + ?Sized,
     {
@@ -85,7 +86,7 @@ impl<'a> crate::Generator<'a> for Generator {
             tagset.push(format!("{key}:{value}"));
         }
 
-        tagset
+        Ok(tagset)
     }
 }
 
@@ -114,7 +115,7 @@ mod test {
                 pool.clone(),
                 num_tagsets,
             );
-            let tagset = generator.generate(&mut rng);
+            let tagset = generator.generate(&mut rng)?;
             assert!(tagset.len() <= tags_per_msg_max as usize);
         }
     }

--- a/lading_payload/src/dogstatsd/event.rs
+++ b/lading_payload/src/dogstatsd/event.rs
@@ -28,11 +28,11 @@ impl<'a> Generator<'a> for EventGenerator {
         let title = self
             .str_pool
             .of_size(&mut rng, title_sz)
-            .expect("failed to generate string");
+            .ok_or(Error::StringGenerate)?;
         let text = self
             .str_pool
             .of_size_range(&mut rng, self.texts_or_messages_length_range.clone())
-            .expect("failed to generate string");
+            .ok_or(Error::StringGenerate)?;
         let tags = if rng.gen() {
             Some(self.tags_generator.generate(&mut rng)?)
         } else {

--- a/lading_payload/src/dogstatsd/event.rs
+++ b/lading_payload/src/dogstatsd/event.rs
@@ -3,7 +3,7 @@ use std::{fmt, ops::Range, rc::Rc};
 
 use rand::{distributions::Standard, prelude::Distribution, Rng};
 
-use crate::{common::strings, Generator};
+use crate::{common::strings, Error, Generator};
 
 use super::{choose_or_not_fn, common, ConfRange};
 
@@ -18,8 +18,9 @@ pub(crate) struct EventGenerator {
 
 impl<'a> Generator<'a> for EventGenerator {
     type Output = Event<'a>;
+    type Error = Error;
 
-    fn generate<R>(&'a self, mut rng: &mut R) -> Self::Output
+    fn generate<R>(&'a self, mut rng: &mut R) -> Result<Self::Output, Error>
     where
         R: rand::Rng + ?Sized,
     {
@@ -33,12 +34,12 @@ impl<'a> Generator<'a> for EventGenerator {
             .of_size_range(&mut rng, self.texts_or_messages_length_range.clone())
             .expect("failed to generate string");
         let tags = if rng.gen() {
-            Some(self.tags_generator.generate(&mut rng))
+            Some(self.tags_generator.generate(&mut rng)?)
         } else {
             None
         };
 
-        Event {
+        Ok(Event {
             title_utf8_length: title.len(),
             text_utf8_length: text.len(),
             title,
@@ -59,7 +60,7 @@ impl<'a> Generator<'a> for EventGenerator {
             }),
             alert_type: rng.gen(),
             tags,
-        }
+        })
     }
 }
 

--- a/lading_payload/src/dogstatsd/metric.rs
+++ b/lading_payload/src/dogstatsd/metric.rs
@@ -57,7 +57,7 @@ impl MetricGenerator {
             let name = String::from(
                 str_pool
                     .of_size(&mut rng, name_sz)
-                    .expect("failed to generate string"),
+                    .ok_or(Error::StringGenerate)?,
             );
 
             let res = match metric_weights.sample(rng) {

--- a/lading_payload/src/dogstatsd/metric.rs
+++ b/lading_payload/src/dogstatsd/metric.rs
@@ -7,7 +7,7 @@ use rand::{
     Rng,
 };
 
-use crate::{common::strings, dogstatsd::metric::template::Template, Generator};
+use crate::{common::strings, dogstatsd::metric::template::Template, Error, Generator};
 use tracing::debug;
 
 use super::{
@@ -44,7 +44,7 @@ impl MetricGenerator {
         str_pool: &strings::Pool,
         value_conf: ValueConf,
         mut rng: &mut R,
-    ) -> Self
+    ) -> Result<Self, Error>
     where
         R: Rng + ?Sized,
     {
@@ -61,18 +61,18 @@ impl MetricGenerator {
             );
 
             let res = match metric_weights.sample(rng) {
-                0 => Template::Count(template::Count { name, tags }),
-                1 => Template::Gauge(template::Gauge { name, tags }),
-                2 => Template::Timer(template::Timer { name, tags }),
-                3 => Template::Distribution(template::Dist { name, tags }),
-                4 => Template::Set(template::Set { name, tags }),
-                5 => Template::Histogram(template::Histogram { name, tags }),
+                0 => Template::Count(template::Count { name, tags: tags? }),
+                1 => Template::Gauge(template::Gauge { name, tags: tags? }),
+                2 => Template::Timer(template::Timer { name, tags: tags? }),
+                3 => Template::Distribution(template::Dist { name, tags: tags? }),
+                4 => Template::Set(template::Set { name, tags: tags? }),
+                5 => Template::Histogram(template::Histogram { name, tags: tags? }),
                 _ => unreachable!(),
             };
             templates.push(res);
         }
 
-        MetricGenerator {
+        Ok(MetricGenerator {
             container_ids,
             templates,
             multivalue_count,
@@ -80,14 +80,15 @@ impl MetricGenerator {
             sampling,
             sampling_probability,
             num_value_generator: NumValueGenerator::new(value_conf),
-        }
+        })
     }
 }
 
 impl<'a> Generator<'a> for MetricGenerator {
     type Output = Metric<'a>;
+    type Error = Error;
 
-    fn generate<R>(&'a self, mut rng: &mut R) -> Self::Output
+    fn generate<R>(&'a self, mut rng: &mut R) -> Result<Self::Output, Self::Error>
     where
         R: rand::Rng + ?Sized,
     {
@@ -111,58 +112,58 @@ impl<'a> Generator<'a> for MetricGenerator {
         };
 
         let mut values = Vec::with_capacity(self.multivalue_count.end() as usize);
-        let value: common::NumValue = self.num_value_generator.generate(&mut rng);
+        let value: common::NumValue = self.num_value_generator.generate(&mut rng)?;
         values.push(value);
 
         let prob: f32 = OpenClosed01.sample(&mut rng);
         if prob < self.multivalue_pack_probability {
             let num_desired_values = self.multivalue_count.sample(&mut rng) as usize;
             for _ in 1..num_desired_values {
-                values.push(self.num_value_generator.generate(&mut rng));
+                values.push(self.num_value_generator.generate(&mut rng)?);
             }
         }
 
         match template {
-            Template::Count(ref count) => Metric::Count(Count {
+            Template::Count(ref count) => Ok(Metric::Count(Count {
                 name: &count.name,
                 values,
                 sample_rate,
                 tags: &count.tags,
                 container_id,
-            }),
-            Template::Gauge(ref gauge) => Metric::Gauge(Gauge {
+            })),
+            Template::Gauge(ref gauge) => Ok(Metric::Gauge(Gauge {
                 name: &gauge.name,
                 values,
                 tags: &gauge.tags,
                 container_id,
-            }),
-            Template::Distribution(ref dist) => Metric::Distribution(Dist {
+            })),
+            Template::Distribution(ref dist) => Ok(Metric::Distribution(Dist {
                 name: &dist.name,
                 values,
                 sample_rate,
                 tags: &dist.tags,
                 container_id,
-            }),
-            Template::Histogram(ref hist) => Metric::Histogram(Histogram {
+            })),
+            Template::Histogram(ref hist) => Ok(Metric::Histogram(Histogram {
                 name: &hist.name,
                 values,
                 sample_rate,
                 tags: &hist.tags,
                 container_id,
-            }),
-            Template::Timer(ref timer) => Metric::Timer(Timer {
+            })),
+            Template::Timer(ref timer) => Ok(Metric::Timer(Timer {
                 name: &timer.name,
                 values,
                 sample_rate,
                 tags: &timer.tags,
                 container_id,
-            }),
-            Template::Set(ref set) => Metric::Set(Set {
+            })),
+            Template::Set(ref set) => Ok(Metric::Set(Set {
                 name: &set.name,
                 value: values.pop().expect("failed to pop value from Vec"),
                 tags: &set.tags,
                 container_id,
-            }),
+            })),
         }
     }
 }

--- a/lading_payload/src/dogstatsd/service_check.rs
+++ b/lading_payload/src/dogstatsd/service_check.rs
@@ -3,7 +3,7 @@ use std::fmt;
 
 use rand::{distributions::Standard, prelude::Distribution, seq::SliceRandom, Rng};
 
-use crate::Generator;
+use crate::{Error, Generator};
 
 use super::{
     choose_or_not_ref,
@@ -20,8 +20,9 @@ pub(crate) struct ServiceCheckGenerator {
 
 impl<'a> Generator<'a> for ServiceCheckGenerator {
     type Output = ServiceCheck<'a>;
+    type Error = Error;
 
-    fn generate<R>(&'a self, mut rng: &mut R) -> Self::Output
+    fn generate<R>(&'a self, mut rng: &mut R) -> Result<Self::Output, Error>
     where
         R: rand::Rng + ?Sized,
     {
@@ -29,19 +30,19 @@ impl<'a> Generator<'a> for ServiceCheckGenerator {
         let hostname = choose_or_not_ref(&mut rng, &self.small_strings).map(String::as_str);
         let message = choose_or_not_ref(&mut rng, &self.texts_or_messages).map(String::as_str);
         let tags = if rng.gen() {
-            Some(self.tags_generator.generate(&mut rng))
+            Some(self.tags_generator.generate(&mut rng)?)
         } else {
             None
         };
 
-        ServiceCheck {
+        Ok(ServiceCheck {
             name,
             status: rng.gen(),
             timestamp_second: rng.gen(),
             hostname,
             tags,
             message,
-        }
+        })
     }
 }
 

--- a/lading_payload/src/fluent.rs
+++ b/lading_payload/src/fluent.rs
@@ -44,7 +44,7 @@ impl<'a> Generator<'a> for Fluent {
                     let key = self
                         .str_pool
                         .of_size_range(rng, 1_u8..16)
-                        .expect("failed to generate string");
+                        .ok_or(Error::StringGenerate)?;
                     let val = record_value(rng, &self.str_pool);
                     rec.insert(key, val);
                 }
@@ -52,7 +52,7 @@ impl<'a> Generator<'a> for Fluent {
                     tag: self
                         .str_pool
                         .of_size_range(rng, 1_u8..16)
-                        .expect("failed to generate string"),
+                        .ok_or(Error::StringGenerate)?,
                     time: rng.gen(),
                     record: rec,
                 }))
@@ -67,7 +67,7 @@ impl<'a> Generator<'a> for Fluent {
                         let key = self
                             .str_pool
                             .of_size_range(rng, 1_u8..16)
-                            .expect("failed to generate string");
+                            .ok_or(Error::StringGenerate)?;
                         let val = record_value(rng, &self.str_pool);
                         rec.insert(key, val);
                     }
@@ -81,7 +81,7 @@ impl<'a> Generator<'a> for Fluent {
                     tag: self
                         .str_pool
                         .of_size_range(rng, 1_u8..16)
-                        .expect("failed to generate string"),
+                        .ok_or(Error::StringGenerate)?,
                     entries,
                 }))
             }

--- a/lading_payload/src/fluent.rs
+++ b/lading_payload/src/fluent.rs
@@ -30,8 +30,9 @@ impl Fluent {
 
 impl<'a> Generator<'a> for Fluent {
     type Output = Member<'a>;
+    type Error = Error;
 
-    fn generate<R>(&'a self, rng: &mut R) -> Self::Output
+    fn generate<R>(&'a self, rng: &mut R) -> Result<Self::Output, Error>
     where
         R: rand::Rng + ?Sized,
     {
@@ -47,14 +48,14 @@ impl<'a> Generator<'a> for Fluent {
                     let val = record_value(rng, &self.str_pool);
                     rec.insert(key, val);
                 }
-                Member::Message(FluentMessage {
+                Ok(Member::Message(FluentMessage {
                     tag: self
                         .str_pool
                         .of_size_range(rng, 1_u8..16)
                         .expect("failed to generate string"),
                     time: rng.gen(),
                     record: rec,
-                })
+                }))
             }
             1 => {
                 let mut entries = Vec::with_capacity(32);
@@ -76,13 +77,13 @@ impl<'a> Generator<'a> for Fluent {
                     });
                 }
 
-                Member::Forward(FluentForward {
+                Ok(Member::Forward(FluentForward {
                     tag: self
                         .str_pool
                         .of_size_range(rng, 1_u8..16)
                         .expect("failed to generate string"),
                     entries,
-                })
+                }))
             }
             _ => unimplemented!(),
         }
@@ -165,7 +166,7 @@ impl crate::Serialize for Fluent {
         // below the limit.
 
         let mut members: Vec<Vec<u8>> = (0..10)
-            .map(|_| self.generate(&mut rng))
+            .map(|_| self.generate(&mut rng).expect("failed to generate"))
             .map(|m: Member| rmp_serde::to_vec(&m).expect("failed to serialize"))
             .collect();
 
@@ -178,7 +179,7 @@ impl crate::Serialize for Fluent {
 
             members.extend(
                 (0..10)
-                    .map(|_| self.generate(&mut rng))
+                    .map(|_| self.generate(&mut rng).expect("failed to generate"))
                     .map(|m: Member| rmp_serde::to_vec(&m).expect("failed to serialize")),
             );
         }

--- a/lading_payload/src/json.rs
+++ b/lading_payload/src/json.rs
@@ -46,12 +46,13 @@ pub struct Json;
 
 impl<'a> Generator<'a> for Json {
     type Output = Member;
+    type Error = Error;
 
-    fn generate<R>(&'a self, rng: &mut R) -> Self::Output
+    fn generate<R>(&'a self, rng: &mut R) -> Result<Self::Output, Error>
     where
         R: rand::Rng + ?Sized,
     {
-        rng.gen()
+        Ok(rng.gen())
     }
 }
 
@@ -65,7 +66,7 @@ impl crate::Serialize for Json {
 
         loop {
             let member = self.generate(&mut rng);
-            let encoding = serde_json::to_string(&member)?;
+            let encoding = serde_json::to_string(&member?)?;
             let line_length = encoding.len() + 1; // add one for the newline
 
             match bytes_remaining.checked_sub(line_length) {

--- a/lading_payload/src/lib.rs
+++ b/lading_payload/src/lib.rs
@@ -72,6 +72,12 @@ pub enum Error {
     /// IO operation failed
     #[error("IO operation failed: {0}")]
     Io(#[from] io::Error),
+    /// failed to generate string
+    #[error("Failed to generate string")]
+    StringGenerate,
+    /// Serialization failed
+    #[error("Serialization failed")]
+    Serialize,
 }
 
 /// To serialize into bytes

--- a/lading_payload/src/lib.rs
+++ b/lading_payload/src/lib.rs
@@ -25,7 +25,7 @@ use std::{
     path::PathBuf,
 };
 
-use rand::Rng;
+use rand::{distributions::WeightedError, Rng};
 use serde::Deserialize;
 
 pub mod block;
@@ -78,6 +78,9 @@ pub enum Error {
     /// Serialization failed
     #[error("Serialization failed")]
     Serialize,
+    /// See [`WeightedError`]
+    #[error(transparent)]
+    Weights(#[from] WeightedError),
 }
 
 /// To serialize into bytes
@@ -213,8 +216,9 @@ const fn div_ceil(lhs: usize, rhs: usize) -> usize {
 /// Generate instance of `I` from source of randomness `S`.
 pub(crate) trait Generator<'a> {
     type Output: 'a;
+    type Error: 'a;
 
-    fn generate<R>(&'a self, rng: &mut R) -> Self::Output
+    fn generate<R>(&'a self, rng: &mut R) -> Result<Self::Output, Self::Error>
     where
         R: rand::Rng + ?Sized;
 }

--- a/lading_payload/src/opentelemetry_log.rs
+++ b/lading_payload/src/opentelemetry_log.rs
@@ -70,7 +70,7 @@ impl<'a> Generator<'a> for OpentelemetryLogs {
         let body: String = String::from(
             self.str_pool
                 .of_size_range(&mut rng, 1_u16..16_u16)
-                .expect("failed to generate string"),
+                .ok_or(Error::StringGenerate)?,
         );
 
         Ok(

--- a/lading_payload/src/opentelemetry_log.rs
+++ b/lading_payload/src/opentelemetry_log.rs
@@ -61,8 +61,9 @@ impl OpentelemetryLogs {
 
 impl<'a> Generator<'a> for OpentelemetryLogs {
     type Output = LogRecord;
+    type Error = Error;
 
-    fn generate<R>(&'a self, mut rng: &mut R) -> Self::Output
+    fn generate<R>(&'a self, mut rng: &mut R) -> Result<Self::Output, Error>
     where
         R: rand::Rng + ?Sized,
     {
@@ -72,22 +73,24 @@ impl<'a> Generator<'a> for OpentelemetryLogs {
                 .expect("failed to generate string"),
         );
 
-        #[allow(deprecated)]
-        LogRecord(v1::LogRecord {
-            time_unix_nano: rng.gen(),
-            observed_time_unix_nano: rng.gen(),
-            severity_number: rng.gen_range(1..=24),
-            severity_text: String::new(),
-            name: String::new(),
-            body: Some(AnyValue {
-                value: Some(any_value::Value::StringValue(body)),
+        Ok(
+            #[allow(deprecated)]
+            LogRecord(v1::LogRecord {
+                time_unix_nano: rng.gen(),
+                observed_time_unix_nano: rng.gen(),
+                severity_number: rng.gen_range(1..=24),
+                severity_text: String::new(),
+                name: String::new(),
+                body: Some(AnyValue {
+                    value: Some(any_value::Value::StringValue(body)),
+                }),
+                attributes: Vec::new(),
+                dropped_attributes_count: 0,
+                flags: 0,
+                trace_id: Vec::new(),
+                span_id: Vec::new(),
             }),
-            attributes: Vec::new(),
-            dropped_attributes_count: 0,
-            flags: 0,
-            trace_id: Vec::new(),
-            span_id: Vec::new(),
-        })
+        )
     }
 }
 
@@ -107,7 +110,7 @@ impl crate::Serialize for OpentelemetryLogs {
 
         let mut acc = ExportLogsServiceRequest(Vec::new());
         loop {
-            let member: LogRecord = self.generate(&mut rng);
+            let member: LogRecord = self.generate(&mut rng)?;
             // Note: this 2 is a guessed value for an unknown size factor.
             let len = member.0.encoded_len() + 2;
             match bytes_remaining.checked_sub(len) {

--- a/lading_payload/src/opentelemetry_metric.rs
+++ b/lading_payload/src/opentelemetry_metric.rs
@@ -146,15 +146,15 @@ impl<'a> Generator<'a> for OpentelemetryMetrics {
         let name = self
             .str_pool
             .of_size_range(&mut rng, 1_u8..16)
-            .expect("failed to generate string");
+            .ok_or(Error::StringGenerate)?;
         let description = self
             .str_pool
             .of_size_range(&mut rng, 1_u8..16)
-            .expect("failed to generate string");
+            .ok_or(Error::StringGenerate)?;
         let unit = self
             .str_pool
             .of_size_range(&mut rng, 1_u8..16)
-            .expect("failed to generate string");
+            .ok_or(Error::StringGenerate)?;
 
         Ok(Metric(v1::Metric {
             name: String::from(name),

--- a/lading_payload/src/opentelemetry_metric.rs
+++ b/lading_payload/src/opentelemetry_metric.rs
@@ -129,8 +129,9 @@ impl OpentelemetryMetrics {
 
 impl<'a> Generator<'a> for OpentelemetryMetrics {
     type Output = Metric;
+    type Error = Error;
 
-    fn generate<R>(&'a self, mut rng: &mut R) -> Self::Output
+    fn generate<R>(&'a self, mut rng: &mut R) -> Result<Self::Output, Error>
     where
         R: rand::Rng + ?Sized,
     {
@@ -155,12 +156,12 @@ impl<'a> Generator<'a> for OpentelemetryMetrics {
             .of_size_range(&mut rng, 1_u8..16)
             .expect("failed to generate string");
 
-        Metric(v1::Metric {
+        Ok(Metric(v1::Metric {
             name: String::from(name),
             description: String::from(description),
             unit: String::from(unit),
             data,
-        })
+        }))
     }
 }
 
@@ -180,7 +181,7 @@ impl crate::Serialize for OpentelemetryMetrics {
 
         let mut acc = ExportMetricsServiceRequest(Vec::new());
         loop {
-            let member: Metric = self.generate(&mut rng);
+            let member: Metric = self.generate(&mut rng)?;
             let len = member.0.encoded_len() + 2;
             match bytes_remaining.checked_sub(len) {
                 Some(remainder) => {

--- a/lading_payload/src/opentelemetry_trace.rs
+++ b/lading_payload/src/opentelemetry_trace.rs
@@ -79,7 +79,7 @@ impl<'a> Generator<'a> for OpentelemetryTraces {
         let name = self
             .str_pool
             .of_size_range(&mut rng, 1_u8..16)
-            .expect("failed to generate string");
+            .ok_or(Error::StringGenerate)?;
 
         Ok(Span(v1::Span {
             trace_id,

--- a/lading_payload/src/procfs.rs
+++ b/lading_payload/src/procfs.rs
@@ -1690,7 +1690,7 @@ impl<'a> Generator<'a> for ProcessGenerator {
         let cmdline = String::from(
             self.str_pool
                 .of_size(rng, cmdline_size)
-                .expect("failed to generate process command line"),
+                .ok_or(Error::StringGenerate)?,
         );
 
         // Assume the comm name and task name are derived from `cmdline`. Note

--- a/lading_payload/src/trace_agent.rs
+++ b/lading_payload/src/trace_agent.rs
@@ -167,11 +167,11 @@ impl<'a> Generator<'a> for TraceAgent {
         let name = self
             .str_pool
             .of_size_range(&mut rng, 1_u8..16)
-            .expect("failed to generate string");
+            .ok_or(Error::StringGenerate)?;
         let resource = self
             .str_pool
             .of_size_range(&mut rng, 1_u8..8)
-            .expect("failed to generate string");
+            .ok_or(Error::StringGenerate)?;
 
         Ok(Span {
             service: SERVICES.choose(rng).expect("failed to choose service"),


### PR DESCRIPTION
### What does this PR do?

This PR is for removing expects and replacing them with errors within Lading. The purpose is to clean up the overall quality of the code base using errors instead. It rehauls a lot of generator to give us the ability to do so more easily in the future

### Motivation

We want to make the program have handleable errors in comparison to crashing with panic.

### Related issues

SMPTNG-114

### Additional Notes

Anything else we should know when reviewing?
