### PR TITLE
Adjusts inner_main test to avoid flakeyness

### DIFF
--- a/lading/src/bin/lading.rs
+++ b/lading/src/bin/lading.rs
@@ -614,7 +614,7 @@ generator: []
 
         let contents = std::fs::read_to_string(capture_path)
             .expect("File path does not already exist or does not contain valid utf-8");
-        assert_eq!(contents.rmatches("lading.running").count(), 7);
+        assert!(contents.rmatches("lading.running").count() > 5);
     }
 
     #[test]


### PR DESCRIPTION
### What does this PR do?
Loosens the assertions to account for scheduling variability in the experiment.

### Motivation

The goal of this test is to provide an "integration" level test where the core loop of `lading` gets run and the assertion is that the `lading.running` gauge is present in the capture json.

This can be accomplished by asserting that there are more than N rather than saying there must be exactly N. Due to scheduling variance, we cannot currently guarantee _exactly_ how many `fetch_indices` there will be.

### Related issues


### Additional Notes

