### PR TITLE
Adds serde Serialize derive to lading_payload::config and lading::config

### DIFF
--- a/lading/src/blackhole.rs
+++ b/lading/src/blackhole.rs
@@ -5,7 +5,7 @@
 //! as little as possible with them and respond as minimally as possible in
 //! order to avoid overhead.
 
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 
 use crate::signals::Phase;
 
@@ -43,7 +43,7 @@ pub enum Error {
     Sqs(sqs::Error),
 }
 
-#[derive(Debug, Deserialize, Clone, PartialEq, Eq)]
+#[derive(Debug, Deserialize, Serialize, Clone, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 #[serde(deny_unknown_fields)]
 /// Configuration for [`Server`]
@@ -56,7 +56,7 @@ pub struct Config {
     pub inner: Inner,
 }
 
-#[derive(Debug, Deserialize, Clone, PartialEq, Eq)]
+#[derive(Debug, Deserialize, Serialize, Clone, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 #[serde(deny_unknown_fields)]
 /// Configurations common to all [`Server`] variants
@@ -65,7 +65,7 @@ pub struct General {
     pub id: Option<String>,
 }
 
-#[derive(Debug, Deserialize, Clone, PartialEq, Eq)]
+#[derive(Debug, Deserialize, Serialize, Clone, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 #[serde(deny_unknown_fields)]
 /// Configuration for [`Server`]

--- a/lading/src/blackhole/http.rs
+++ b/lading/src/blackhole/http.rs
@@ -43,7 +43,7 @@ pub enum Error {
 }
 
 /// Body variant supported by this blackhole.
-#[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 #[serde(deny_unknown_fields)]
 pub enum BodyVariant {
@@ -76,7 +76,7 @@ fn default_headers() -> HeaderMap {
     map
 }
 
-#[derive(Debug, Deserialize, Clone, PartialEq, Eq)]
+#[derive(Debug, Deserialize, Serialize, Clone, PartialEq, Eq)]
 #[serde(deny_unknown_fields)]
 /// Configuration for [`Http`]
 pub struct Config {

--- a/lading/src/blackhole/splunk_hec.rs
+++ b/lading/src/blackhole/splunk_hec.rs
@@ -44,7 +44,7 @@ pub enum Error {
     Hyper(hyper::Error),
 }
 
-#[derive(Debug, Deserialize, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Deserialize, Serialize, Clone, Copy, PartialEq, Eq)]
 #[serde(deny_unknown_fields)]
 /// Configuration for [`SplunkHec`].
 pub struct Config {

--- a/lading/src/blackhole/sqs.rs
+++ b/lading/src/blackhole/sqs.rs
@@ -16,7 +16,7 @@ use hyper::{
 };
 use metrics::{register_counter, Counter};
 use rand::{distributions::Alphanumeric, thread_rng, Rng};
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use tokio::time::Duration;
 use tower::ServiceBuilder;
 use tracing::{debug, error, info};
@@ -46,7 +46,7 @@ fn default_concurrent_requests_max() -> usize {
     100
 }
 
-#[derive(Debug, Deserialize, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Deserialize, Serialize, Clone, Copy, PartialEq, Eq)]
 #[serde(deny_unknown_fields)]
 /// Configuration for [`Sqs`]
 pub struct Config {

--- a/lading/src/blackhole/tcp.rs
+++ b/lading/src/blackhole/tcp.rs
@@ -11,7 +11,7 @@ use std::{io, net::SocketAddr};
 
 use futures::stream::StreamExt;
 use metrics::register_counter;
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use tokio::net::{TcpListener, TcpStream};
 use tokio_util::io::ReaderStream;
 use tracing::info;
@@ -28,7 +28,7 @@ pub enum Error {
     Io(io::Error),
 }
 
-#[derive(Debug, Deserialize, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Deserialize, Serialize, Clone, Copy, PartialEq, Eq)]
 #[serde(deny_unknown_fields)]
 /// Configuration for [`Tcp`]
 pub struct Config {

--- a/lading/src/blackhole/udp.rs
+++ b/lading/src/blackhole/udp.rs
@@ -9,7 +9,7 @@
 use std::{io, net::SocketAddr};
 
 use metrics::register_counter;
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use tokio::net::UdpSocket;
 use tracing::info;
 
@@ -25,7 +25,7 @@ pub enum Error {
     Io(io::Error),
 }
 
-#[derive(Debug, Deserialize, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Deserialize, Serialize, Clone, Copy, PartialEq, Eq)]
 #[serde(deny_unknown_fields)]
 /// Configuration for [`Udp`].
 pub struct Config {

--- a/lading/src/blackhole/unix_datagram.rs
+++ b/lading/src/blackhole/unix_datagram.rs
@@ -9,7 +9,7 @@ use std::{io, path::PathBuf};
 
 use futures::TryFutureExt;
 use metrics::register_counter;
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use tokio::net;
 use tracing::info;
 
@@ -25,7 +25,7 @@ pub enum Error {
     Io(io::Error),
 }
 
-#[derive(Debug, Deserialize, Clone, PartialEq, Eq)]
+#[derive(Debug, Deserialize, Serialize, Clone, PartialEq, Eq)]
 #[serde(deny_unknown_fields)]
 /// Configuration for [`UnixDatagram`].
 pub struct Config {

--- a/lading/src/blackhole/unix_stream.rs
+++ b/lading/src/blackhole/unix_stream.rs
@@ -11,7 +11,7 @@ use std::{io, path::PathBuf};
 
 use futures::StreamExt;
 use metrics::register_counter;
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use tokio::net;
 use tokio_util::io::ReaderStream;
 use tracing::info;
@@ -28,7 +28,7 @@ pub enum Error {
     Io(io::Error),
 }
 
-#[derive(Debug, Deserialize, Clone, PartialEq, Eq)]
+#[derive(Debug, Deserialize, Serialize, Clone, PartialEq, Eq)]
 #[serde(deny_unknown_fields)]
 /// Configuration for [`UnixStream`].
 pub struct Config {

--- a/lading/src/generator.rs
+++ b/lading/src/generator.rs
@@ -10,7 +10,7 @@
 //! indefinitely, paying higher memory and longer startup for better
 //! experimental control.
 
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use tracing::{error, warn};
 
 use crate::{signals::Phase, target::TargetPidReceiver};
@@ -65,7 +65,7 @@ pub enum Error {
     ProcFs(#[from] procfs::Error),
 }
 
-#[derive(Debug, Deserialize, PartialEq)]
+#[derive(Debug, Deserialize, Serialize, PartialEq)]
 #[serde(rename_all = "snake_case")]
 #[serde(deny_unknown_fields)]
 /// Configuration for [`Server`]
@@ -78,7 +78,7 @@ pub struct Config {
     pub inner: Inner,
 }
 
-#[derive(Debug, Deserialize, PartialEq)]
+#[derive(Debug, Deserialize, Serialize, PartialEq)]
 #[serde(rename_all = "snake_case")]
 #[serde(deny_unknown_fields)]
 /// Configurations common to all [`Server`] variants
@@ -87,7 +87,7 @@ pub struct General {
     pub id: Option<String>,
 }
 
-#[derive(Debug, Deserialize, PartialEq)]
+#[derive(Debug, Deserialize, Serialize, PartialEq)]
 #[serde(rename_all = "snake_case")]
 #[serde(deny_unknown_fields)]
 /// Configuration for [`Server`]

--- a/lading/src/generator/file_gen.rs
+++ b/lading/src/generator/file_gen.rs
@@ -17,7 +17,7 @@ pub mod traditional;
 
 use std::str;
 
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 
 use crate::signals::Phase;
 
@@ -35,7 +35,7 @@ pub enum Error {
 }
 
 /// Configuration of [`FileGen`]
-#[derive(Debug, Deserialize, PartialEq)]
+#[derive(Debug, Deserialize, Serialize, PartialEq)]
 #[serde(rename_all = "snake_case")]
 #[serde(deny_unknown_fields)]
 pub enum Config {

--- a/lading/src/generator/file_gen/logrotate.rs
+++ b/lading/src/generator/file_gen/logrotate.rs
@@ -25,7 +25,7 @@ use futures::future::join_all;
 use lading_throttle::Throttle;
 use metrics::{gauge, register_counter};
 use rand::{prelude::StdRng, Rng, SeedableRng};
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use tokio::{
     fs,
     io::{AsyncWriteExt, BufWriter},
@@ -59,7 +59,7 @@ pub enum Error {
     Zero,
 }
 
-#[derive(Debug, Deserialize, PartialEq)]
+#[derive(Debug, Deserialize, Serialize, PartialEq)]
 #[serde(deny_unknown_fields)]
 /// Configuration of [`FileGen`]
 pub struct Config {

--- a/lading/src/generator/file_gen/traditional.rs
+++ b/lading/src/generator/file_gen/traditional.rs
@@ -28,7 +28,7 @@ use futures::future::join_all;
 use lading_throttle::Throttle;
 use metrics::{gauge, register_counter};
 use rand::{prelude::StdRng, SeedableRng};
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use tokio::{
     fs,
     io::{AsyncWriteExt, BufWriter},
@@ -69,7 +69,7 @@ fn default_rotation() -> bool {
     true
 }
 
-#[derive(Debug, Deserialize, PartialEq)]
+#[derive(Debug, Deserialize, Serialize, PartialEq)]
 #[serde(deny_unknown_fields)]
 /// Configuration of [`FileGen`]
 pub struct Config {

--- a/lading/src/generator/file_tree.rs
+++ b/lading/src/generator/file_tree.rs
@@ -25,7 +25,7 @@ use std::{
 };
 
 use rand::{prelude::StdRng, SeedableRng};
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use tokio::{fs::create_dir, fs::rename, fs::File};
 use tracing::info;
 
@@ -81,7 +81,7 @@ fn default_rename_per_name() -> NonZeroU32 {
     NonZeroU32::new(1).expect("default rename per second given was 0")
 }
 
-#[derive(Debug, Deserialize, PartialEq, Clone)]
+#[derive(Debug, Deserialize, Serialize, PartialEq, Clone)]
 #[serde(deny_unknown_fields)]
 /// Configuration of [`FileTree`]
 pub struct Config {

--- a/lading/src/generator/grpc.rs
+++ b/lading/src/generator/grpc.rs
@@ -21,7 +21,7 @@ use lading_throttle::Throttle;
 use metrics::{counter, gauge, register_counter};
 use rand::rngs::StdRng;
 use rand::SeedableRng;
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use tokio::sync::mpsc;
 use tonic::{
     codec::{DecodeBuf, Decoder, EncodeBuf, Encoder},
@@ -58,7 +58,7 @@ pub enum Error {
 }
 
 /// Config for [`Grpc`]
-#[derive(Debug, Deserialize, PartialEq)]
+#[derive(Debug, Deserialize, Serialize, PartialEq)]
 #[serde(deny_unknown_fields)]
 pub struct Config {
     /// The gRPC URI. Looks like http://host/service.path/endpoint

--- a/lading/src/generator/http.rs
+++ b/lading/src/generator/http.rs
@@ -23,7 +23,7 @@ use lading_throttle::Throttle;
 use metrics::{counter, gauge};
 use once_cell::sync::OnceCell;
 use rand::{prelude::StdRng, SeedableRng};
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use tokio::sync::{mpsc, Semaphore};
 use tracing::info;
 
@@ -35,7 +35,7 @@ use super::General;
 static CONNECTION_SEMAPHORE: OnceCell<Semaphore> = OnceCell::new();
 
 /// The HTTP method to be used in requests
-#[derive(Debug, Deserialize, PartialEq)]
+#[derive(Debug, Deserialize, Serialize, PartialEq)]
 #[serde(rename_all = "snake_case")]
 #[serde(deny_unknown_fields)]
 pub enum Method {
@@ -51,7 +51,7 @@ pub enum Method {
     },
 }
 
-#[derive(Debug, Deserialize, PartialEq)]
+#[derive(Debug, Deserialize, Serialize, PartialEq)]
 #[serde(deny_unknown_fields)]
 /// Configuration of this generator.
 pub struct Config {

--- a/lading/src/generator/procfs.rs
+++ b/lading/src/generator/procfs.rs
@@ -15,7 +15,7 @@ use std::{fs::File, io::Write, num::NonZeroU32, path::PathBuf};
 use lading_payload::procfs;
 use rand::rngs::StdRng;
 use rand::SeedableRng;
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 
 use crate::signals::Phase;
 
@@ -40,7 +40,7 @@ fn default_copy_from_host() -> Vec<PathBuf> {
     ]
 }
 
-#[derive(Debug, Deserialize, PartialEq)]
+#[derive(Debug, Deserialize, Serialize, PartialEq)]
 /// Configuration of [`Procfs`]
 pub struct Config {
     /// Seed for random operations against this target

--- a/lading/src/generator/splunk_hec.rs
+++ b/lading/src/generator/splunk_hec.rs
@@ -29,7 +29,7 @@ use lading_throttle::Throttle;
 use metrics::{counter, gauge};
 use once_cell::sync::OnceCell;
 use rand::{prelude::StdRng, SeedableRng};
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use tokio::{
     sync::{mpsc, Semaphore, SemaphorePermit},
     time::timeout,
@@ -50,7 +50,7 @@ const SPLUNK_HEC_TEXT_PATH: &str = "/services/collector/raw";
 const SPLUNK_HEC_CHANNEL_HEADER: &str = "x-splunk-request-channel";
 
 /// Optional Splunk HEC indexer acknowledgements configuration
-#[derive(Deserialize, Debug, Clone, Copy, PartialEq)]
+#[derive(Deserialize, Serialize, Debug, Clone, Copy, PartialEq)]
 #[serde(deny_unknown_fields)]
 pub struct AckSettings {
     /// The time in seconds between queries to /services/collector/ack
@@ -61,7 +61,7 @@ pub struct AckSettings {
 }
 
 /// Configuration for [`SplunkHec`]
-#[derive(Deserialize, Debug, PartialEq)]
+#[derive(Deserialize, Serialize, Debug, PartialEq)]
 #[serde(deny_unknown_fields)]
 pub struct Config {
     /// The seed for random operations against this target
@@ -382,7 +382,7 @@ async fn send_hec_request(
     drop(permit);
 }
 
-#[derive(Deserialize, Debug)]
+#[derive(Deserialize, Serialize, Debug)]
 #[serde(deny_unknown_fields)]
 struct HecAckResponse {
     #[allow(dead_code)]

--- a/lading/src/generator/tcp.rs
+++ b/lading/src/generator/tcp.rs
@@ -21,7 +21,7 @@ use byte_unit::{Byte, ByteError, ByteUnit};
 use lading_throttle::Throttle;
 use metrics::{counter, gauge, register_counter};
 use rand::{rngs::StdRng, SeedableRng};
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use tokio::{io::AsyncWriteExt, net::TcpStream, sync::mpsc};
 use tracing::{info, trace};
 
@@ -30,7 +30,7 @@ use lading_payload::block::{self, Block};
 
 use super::General;
 
-#[derive(Debug, Deserialize, PartialEq)]
+#[derive(Debug, Deserialize, Serialize, PartialEq)]
 #[serde(deny_unknown_fields)]
 /// Configuration of this generator.
 pub struct Config {

--- a/lading/src/generator/udp.rs
+++ b/lading/src/generator/udp.rs
@@ -22,7 +22,7 @@ use byte_unit::{Byte, ByteError, ByteUnit};
 use lading_throttle::Throttle;
 use metrics::{counter, gauge, register_counter};
 use rand::{rngs::StdRng, SeedableRng};
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use tokio::{net::UdpSocket, sync::mpsc};
 use tracing::{debug, info, trace};
 
@@ -31,7 +31,7 @@ use lading_payload::block::{self, Block};
 
 use super::General;
 
-#[derive(Debug, Deserialize, PartialEq)]
+#[derive(Debug, Deserialize, Serialize, PartialEq)]
 #[serde(deny_unknown_fields)]
 /// Configuration of this generator.
 pub struct Config {

--- a/lading/src/generator/unix_datagram.rs
+++ b/lading/src/generator/unix_datagram.rs
@@ -18,7 +18,7 @@ use lading_payload::block::{self, Block};
 use lading_throttle::Throttle;
 use metrics::{counter, gauge, register_counter};
 use rand::{rngs::StdRng, SeedableRng};
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use std::{num::NonZeroU32, path::PathBuf, thread};
 use tokio::{
     net,
@@ -33,7 +33,7 @@ fn default_parallel_connections() -> u16 {
     1
 }
 
-#[derive(Debug, Deserialize, PartialEq)]
+#[derive(Debug, Deserialize, Serialize, PartialEq)]
 #[serde(deny_unknown_fields)]
 /// Configuration of this generator.
 pub struct Config {

--- a/lading/src/generator/unix_stream.rs
+++ b/lading/src/generator/unix_stream.rs
@@ -17,14 +17,14 @@ use lading_payload::block::{self, Block};
 use lading_throttle::Throttle;
 use metrics::{counter, gauge, register_counter};
 use rand::{rngs::StdRng, SeedableRng};
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use std::{num::NonZeroU32, path::PathBuf, thread};
 use tokio::{net, sync::mpsc, task::JoinError};
 use tracing::{debug, error, info, warn};
 
 use super::General;
 
-#[derive(Debug, Deserialize, PartialEq)]
+#[derive(Debug, Deserialize, Serialize, PartialEq)]
 #[serde(deny_unknown_fields)]
 /// Configuration of this generator.
 pub struct Config {

--- a/lading_payload/src/block.rs
+++ b/lading_payload/src/block.rs
@@ -9,7 +9,7 @@ use std::{collections::VecDeque, num::NonZeroU32};
 
 use bytes::{buf::Writer, BufMut, Bytes, BytesMut};
 use rand::{prelude::SliceRandom, rngs::StdRng, Rng, SeedableRng};
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use tokio::sync::mpsc::{self, error::SendError, Sender};
 use tracing::{error, info, span, Level};
 
@@ -95,7 +95,7 @@ impl<'a> arbitrary::Arbitrary<'a> for Block {
     }
 }
 
-#[derive(Debug, Deserialize, PartialEq, Clone, Copy)]
+#[derive(Debug, Deserialize, Serialize, PartialEq, Clone, Copy)]
 #[serde(deny_unknown_fields)]
 /// The method for which caching will be configure
 pub enum CacheMethod {

--- a/lading_payload/src/lib.rs
+++ b/lading_payload/src/lib.rs
@@ -26,7 +26,7 @@ use std::{
 };
 
 use rand::{distributions::WeightedError, Rng};
-use serde::Deserialize;
+use serde::{Deserialize, Serialize as SerdeSerialize};
 
 pub mod block;
 
@@ -98,7 +98,7 @@ pub trait Serialize {
 }
 
 /// Sub-configuration for `TraceAgent` format
-#[derive(Debug, Deserialize, Clone, Copy, PartialEq)]
+#[derive(Debug, Deserialize, SerdeSerialize, Clone, Copy, PartialEq)]
 #[serde(deny_unknown_fields)]
 #[serde(rename_all = "snake_case")]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
@@ -111,7 +111,7 @@ pub enum Encoding {
 }
 
 /// Configuration for `Payload`
-#[derive(Debug, Deserialize, Clone, PartialEq)]
+#[derive(Debug, Deserialize, SerdeSerialize, Clone, PartialEq)]
 #[serde(rename_all = "snake_case")]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[serde(deny_unknown_fields)]

--- a/lading_payload/src/splunk_hec.rs
+++ b/lading_payload/src/splunk_hec.rs
@@ -3,7 +3,7 @@
 use std::io::Write;
 
 use rand::{distributions::Standard, prelude::Distribution, seq::SliceRandom, Rng};
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 
 use crate::Error;
 
@@ -118,7 +118,7 @@ impl Distribution<Member> for Standard {
 }
 
 ///
-#[derive(Deserialize, Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Deserialize, Serialize, Debug, Clone, Copy, PartialEq, Eq)]
 #[serde(deny_unknown_fields)]
 #[serde(rename_all = "snake_case")]
 #[cfg_attr(test, derive(proptest_derive::Arbitrary))]


### PR DESCRIPTION
### What does this PR do?

This allows `lading::config` and `lading_payload::config` to be `Serialize`d.

### Motivation

I configure lading in code, want yaml.

### Related issues



### Additional Notes

