### PR TITLE
Avoid except in smaps implementation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## [0.20.7]
+### Fixed
+- Fix panic in memory map reading code
+
 ## [0.20.6]
 ### Added
 - Adds `/proc/<pid>/smap` parsing to add very detailed memory usage.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1065,7 +1065,7 @@ dependencies = [
 
 [[package]]
 name = "lading"
-version = "0.20.6"
+version = "0.20.7"
 dependencies = [
  "async-pidfd",
  "average",

--- a/lading/Cargo.toml
+++ b/lading/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lading"
-version = "0.20.6"
+version = "0.20.7"
 authors = ["Brian L. Troutwine <brian.troutwine@datadoghq.com>", "George Hahn <george.hahn@datadoghq.com"]
 edition = "2021"
 license = "MIT"

--- a/lading/src/observer/memory.rs
+++ b/lading/src/observer/memory.rs
@@ -57,8 +57,7 @@ impl Rollup {
         let mut file: std::fs::File = std::fs::OpenOptions::new().read(true).open(path)?;
 
         let mut contents = String::with_capacity(SMAP_SIZE_HINT);
-        file.read_to_string(&mut contents)
-            .expect("Failed to read contents into string");
+        file.read_to_string(&mut contents)?;
 
         Self::from_str(&contents)
     }


### PR DESCRIPTION
### What does this PR do?

The caller of this code handles errors gracefully but in this particular spot we panic if the smaps file cannot be read to string. This is unfortunately a race condition that we hit in practice.

