### PR TITLE
[SMPTNG-183] Compute and report working set for each process

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## [0.20.8-rc1]
+### Added
+- Parse working set memory from cgroups on Linux, opens the door to future
+  cgroups inspection.
+
 ## [0.20.7]
 ### Fixed
 - Fix panic in memory map reading code

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -313,6 +313,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "cgroups-rs"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6db7c2f5545da4c12c5701455d9471da5f07db52e49b9cccb4f5512226dd0836"
+dependencies = [
+ "libc",
+ "log",
+ "nix 0.25.1",
+ "regex",
+ "thiserror",
+]
+
+[[package]]
 name = "ciborium"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -944,7 +957,7 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "socket2 0.4.10",
+ "socket2 0.5.5",
  "tokio",
  "tower-service",
  "tracing",
@@ -1071,6 +1084,7 @@ dependencies = [
  "average",
  "byte-unit",
  "bytes",
+ "cgroups-rs",
  "clap 3.2.25",
  "flate2",
  "futures",
@@ -1084,7 +1098,7 @@ dependencies = [
  "metrics",
  "metrics-exporter-prometheus",
  "metrics-util",
- "nix",
+ "nix 0.27.1",
  "num_cpus",
  "once_cell",
  "procfs",
@@ -1337,6 +1351,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77a5d83df9f36fe23f0c3648c6bbb8b0298bb5f1939c8f2704431371f4b84d43"
 dependencies = [
  "smallvec",
+]
+
+[[package]]
+name = "nix"
+version = "0.25.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f346ff70e7dbfd675fe90590b92d59ef2de15a8779ae305ebcbfd3f0caf59be4"
+dependencies = [
+ "autocfg",
+ "bitflags 1.3.2",
+ "cfg-if",
+ "libc",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1078,7 +1078,7 @@ dependencies = [
 
 [[package]]
 name = "lading"
-version = "0.20.7"
+version = "0.20.8-rc1"
 dependencies = [
  "async-pidfd",
  "average",

--- a/lading/Cargo.toml
+++ b/lading/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lading"
-version = "0.20.7"
+version = "0.20.8-rc1"
 authors = ["Brian L. Troutwine <brian.troutwine@datadoghq.com>", "George Hahn <george.hahn@datadoghq.com"]
 edition = "2021"
 license = "MIT"

--- a/lading/Cargo.toml
+++ b/lading/Cargo.toml
@@ -48,6 +48,7 @@ uuid = { workspace = true }
 average = { version = "0.14.1", default-features = false, features = [] }
 
 [target.'cfg(target_os = "linux")'.dependencies]
+cgroups-rs = "0.3"
 procfs = { version = "0.15", default-features = false, features = [] }
 async-pidfd = "0.1"
 


### PR DESCRIPTION
### What does this PR do?

In the linux observer, in addition to the rss and similar memory metrics we already compute, now compute the working set of the matching cgroup. The value is computed using a similar heuristic as kubernetes.

### Motivation

Better understand of the impact of agent changes (especially related to the single agent binary project).

### Related issues

A list of issues either fixed, containing architectural discussions, otherwise relevant
for this Pull Request.

### Additional Notes

Anything else we should know when reviewing?
