### PR TITLE
Sopell/anyhow alt

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -52,9 +52,12 @@ checksum = "7079075b41f533b8c61d2a4d073c4676e1f8b249ff94a393b0595db304e0dd87"
 
 [[package]]
 name = "anyhow"
-version = "1.0.77"
+version = "1.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9d19de80eff169429ac1e9f48fffb163916b448a44e8e046186232046d9e1f9"
+checksum = "080e9890a082662b09c1ad45f567faeeb47f22b5fb23895fbe1e651e718e25ca"
+dependencies = [
+ "backtrace",
+]
 
 [[package]]
 name = "arbitrary"
@@ -944,7 +947,7 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "socket2 0.4.10",
+ "socket2 0.5.5",
  "tokio",
  "tower-service",
  "tracing",
@@ -1067,6 +1070,7 @@ dependencies = [
 name = "lading"
 version = "0.20.7"
 dependencies = [
+ "anyhow",
  "async-pidfd",
  "average",
  "byte-unit",

--- a/lading/Cargo.toml
+++ b/lading/Cargo.toml
@@ -46,6 +46,7 @@ tracing = { workspace = true }
 tracing-subscriber = { version = "0.3", features = ["std", "env-filter"] }
 uuid = { workspace = true }
 average = { version = "0.14.1", default-features = false, features = [] }
+anyhow = { version = "1.0.79", features = ["backtrace"] }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 procfs = { version = "0.15", default-features = false, features = [] }


### PR DESCRIPTION
### What does this PR do?


### Motivation
Before:
```
Error: SerdeYaml(Error("generator[0].unix_datagram.variant: invalid type: enum, expected any value", line: 7, column: 16))
```

After: 
```
Error: Anyhow(generator[0].unix_datagram.variant: invalid type: enum, expected any value at line 7 column 16

Stack backtrace:
   0: anyhow::error::<impl anyhow::Error>::new
             at ./home/ubuntu/.cargo/registry/src/index.crates.io-6f17d22bba15001f/anyhow-1.0.79/src/error.rs:36:25
   1: core::ops::function::FnOnce::call_once
             at ./rustc/82e1608dfa6e0b5569232559e3d385fea5a93112/library/core/src/ops/function.rs:250:5
   2: core::result::Result<T,E>::map_err
             at ./rustc/82e1608dfa6e0b5569232559e3d385fea5a93112/library/core/src/result.rs:829:27
   3: lading::get_config
             at ./home/ubuntu/dev/lading/lading/src/bin/lading.rs:243:30
   4: lading::main
             at ./home/ubuntu/dev/lading/lading/src/bin/lading.rs:559:18
   5: core::ops::function::FnOnce::call_once
             at ./rustc/82e1608dfa6e0b5569232559e3d385fea5a93112/library/core/src/ops/function.rs:250:5
   6: std::sys_common::backtrace::__rust_begin_short_backtrace
             at ./rustc/82e1608dfa6e0b5569232559e3d385fea5a93112/library/std/src/sys_common/backtrace.rs:154:18)
```
### Related issues

A list of issues either fixed, containing architectural discussions, otherwise relevant
for this Pull Request.

### Additional Notes

Anything else we should know when reviewing?
