### PR TITLE
Release lading 0.20.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
-## [0.20.8-rc1]
+## [0.20.8]
 ### Added
 - Parse working set memory from cgroups on Linux, opens the door to future
   cgroups inspection.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1078,7 +1078,7 @@ dependencies = [
 
 [[package]]
 name = "lading"
-version = "0.20.8-rc1"
+version = "0.20.8"
 dependencies = [
  "async-pidfd",
  "average",

--- a/lading/Cargo.toml
+++ b/lading/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lading"
-version = "0.20.8-rc1"
+version = "0.20.8"
 authors = ["Brian L. Troutwine <brian.troutwine@datadoghq.com>", "George Hahn <george.hahn@datadoghq.com"]
 edition = "2021"
 license = "MIT"


### PR DESCRIPTION
### What does this PR do?

This release includes parsing of cgroup data to get working set memory. See #808 for details.
