### PR TITLE
Removes incorrect assertion that tags must be present

### DIFF
--- a/lading_payload/src/dogstatsd.rs
+++ b/lading_payload/src/dogstatsd.rs
@@ -336,9 +336,6 @@ impl Config {
         if !tags_per_msg_valid {
             return Result::Err(format!("Tags per msg value is invalid: {reason}"));
         }
-        if self.tags_per_msg.start() == 0 {
-            return Result::Err("Tags per msg start value cannot be 0".to_string());
-        }
         let (multivalue_count_valid, reason) = self.multivalue_count.valid();
         if !multivalue_count_valid {
             return Result::Err(format!("Multivalue count value is invalid: {reason}"));


### PR DESCRIPTION
### What does this PR do?

In #813 I introduced new validation accidentally that asserted there must be tags present, this removes that incorrect assertion.

### Motivation


### Related issues



### Additional Notes

Anything else we should know when reviewing?
