### PR TITLE
Lading 0.20.9-rc0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## [0.20.9-rc0]
+### Fixed
+- Do not crash on prometheus export that includes blank lines.
+
 ## [0.20.8]
 ### Added
 - Parse working set memory from cgroups on Linux, opens the door to future

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1078,7 +1078,7 @@ dependencies = [
 
 [[package]]
 name = "lading"
-version = "0.20.8"
+version = "0.20.9-rc0"
 dependencies = [
  "async-pidfd",
  "average",

--- a/lading/Cargo.toml
+++ b/lading/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lading"
-version = "0.20.8"
+version = "0.20.9-rc0"
 authors = ["Brian L. Troutwine <brian.troutwine@datadoghq.com>", "George Hahn <george.hahn@datadoghq.com"]
 edition = "2021"
 license = "MIT"


### PR DESCRIPTION
### What does this PR do?

This commit addresses an issue with the prometheus target metrics where a blank line in the target output may cause a panic.
