### PR TITLE
Removes expect from memory file region reading

### DIFF
--- a/lading/src/observer/memory.rs
+++ b/lading/src/observer/memory.rs
@@ -355,8 +355,7 @@ impl Regions {
         let mut file: std::fs::File = std::fs::OpenOptions::new().read(true).open(path)?;
 
         let mut contents = String::with_capacity(SMAP_SIZE_HINT);
-        file.read_to_string(&mut contents)
-            .expect("Failed to read contents into string");
+        file.read_to_string(&mut contents)?;
 
         Self::from_str(&contents)
     }


### PR DESCRIPTION
### What does this PR do?
Removes `expect` in favor of `?` for situation where `/proc` file could go away due to process exiting.

### Motivation

Fixing this panic
```
thread 'tokio-runtime-worker' panicked at lading/src/observer/memory.rs:359:14:
Failed to read contents into string: Os { code: 3, kind: Uncategorized, message: "No such process" }
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

### Related issues



### Additional Notes

