### PR TITLE
Adds generator that writes to a file on disk instead of socket/stream/etc

### DIFF
--- a/lading/src/generator.rs
+++ b/lading/src/generator.rs
@@ -19,6 +19,7 @@ pub mod file_gen;
 pub mod file_tree;
 pub mod grpc;
 pub mod http;
+pub mod passthru_file;
 pub mod process_tree;
 pub mod procfs;
 pub mod splunk_hec;
@@ -57,6 +58,9 @@ pub enum Error {
     /// See [`crate::generator::unix_datagram::Error`] for details.
     #[error(transparent)]
     UnixDatagram(#[from] unix_datagram::Error),
+    /// See [`crate::generator::passthru_file::Error`] for details.
+    #[error(transparent)]
+    PassthruFile(#[from] passthru_file::Error),
     /// See [`crate::generator::process_tree::Error`] for details.
     #[error(transparent)]
     ProcessTree(#[from] process_tree::Error),
@@ -110,6 +114,8 @@ pub enum Inner {
     UnixStream(unix_stream::Config),
     /// See [`crate::generator::unix_datagram::Config`] for details.
     UnixDatagram(unix_datagram::Config),
+    /// See [`crate::generator::passthru_file::Config`] for details.
+    PassthruFile(passthru_file::Config),
     /// See [`crate::generator::process_tree::Config`] for details.
     ProcessTree(process_tree::Config),
     /// See [`crate::generator::procfs::Config`] for details.
@@ -140,6 +146,8 @@ pub enum Server {
     UnixStream(unix_stream::UnixStream),
     /// See [`crate::generator::unix_datagram::UnixDatagram`] for details.
     UnixDatagram(unix_datagram::UnixDatagram),
+    /// See [`crate::generator::passthru_file::PassthruFile`] for details.
+    PassthruFile(passthru_file::PassthruFile),
     /// See [`crate::generator::process_tree::ProcessTree`] for details.
     ProcessTree(process_tree::ProcessTree),
     /// See [`crate::generator::procfs::Procfs`] for details.
@@ -182,6 +190,11 @@ impl Server {
                     shutdown,
                 )?)
             }
+            Inner::PassthruFile(conf) => Self::PassthruFile(passthru_file::PassthruFile::new(
+                config.general,
+                &conf,
+                shutdown,
+            )?),
             Inner::UnixDatagram(conf) => Self::UnixDatagram(unix_datagram::UnixDatagram::new(
                 config.general,
                 &conf,
@@ -221,6 +234,7 @@ impl Server {
             Server::Grpc(inner) => inner.spin().await?,
             Server::UnixStream(inner) => inner.spin().await?,
             Server::UnixDatagram(inner) => inner.spin().await?,
+            Server::PassthruFile(inner) => inner.spin().await?,
             Server::ProcessTree(inner) => inner.spin().await?,
             Server::ProcFs(inner) => inner.spin().await?,
         };

--- a/lading/src/generator/passthru_file.rs
+++ b/lading/src/generator/passthru_file.rs
@@ -150,6 +150,7 @@ impl PassthruFile {
     ///
     /// # Errors
     ///
+    /// If the underlying block cache fails to spin, an error will be returned.
     ///
     /// # Panics
     ///

--- a/lading/src/generator/passthru_file.rs
+++ b/lading/src/generator/passthru_file.rs
@@ -1,0 +1,217 @@
+//! The passthru-file generator
+//!
+//! ## Metrics
+//!
+//! `bytes_written`: Bytes written successfully
+//! `bytes_per_second`: Configured rate to send data
+//! `file_open_failure`: Number of failed file opens
+//! `file_write_failure`: Number of failed file writes
+//!
+//! Additional metrics may be emitted by this generator's [throttle].
+//!
+
+use std::{num::NonZeroU32, path::PathBuf, thread, time::Duration};
+use tokio::io::AsyncWriteExt;
+
+use byte_unit::{Byte, ByteError, ByteUnit};
+use lading_throttle::Throttle;
+use metrics::{counter, gauge, register_counter};
+use rand::{rngs::StdRng, SeedableRng};
+use serde::{Deserialize, Serialize};
+use tokio::sync::mpsc;
+use tracing::{info, warn};
+
+use crate::{common::PeekableReceiver, signals::Phase};
+use lading_payload::block::{self, Block};
+
+use super::General;
+
+#[derive(Debug, Deserialize, Serialize, PartialEq)]
+#[serde(deny_unknown_fields)]
+/// Configuration of this generator.
+pub struct Config {
+    /// The seed for random operations against this target
+    pub seed: [u8; 32],
+    /// The local filesystem path to write data to
+    pub path: String,
+    /// The payload variant
+    pub variant: lading_payload::Config,
+    /// The bytes per second to send or receive from the target
+    pub bytes_per_second: byte_unit::Byte,
+    /// The block sizes for messages to this target
+    pub block_sizes: Option<Vec<byte_unit::Byte>>,
+    /// The maximum size in bytes of the cache of prebuilt messages
+    pub maximum_prebuild_cache_size_bytes: byte_unit::Byte,
+    /// The load throttle configuration
+    #[serde(default)]
+    pub throttle: lading_throttle::Config,
+}
+
+/// Errors produced by [`PassthruFile`].
+#[derive(thiserror::Error, Debug)]
+pub enum Error {
+    /// Creation of payload blocks failed.
+    #[error("Creation of payload blocks failed: {0}")]
+    Block(#[from] block::Error),
+    /// Generic IO error
+    #[error("IO error: {0}")]
+    Io(#[from] std::io::Error),
+    /// Byte error
+    #[error("Bytes must not be negative: {0}")]
+    Byte(#[from] ByteError),
+    /// Failed to convert, value is 0
+    #[error("Value provided is zero")]
+    Zero,
+}
+
+#[derive(Debug)]
+/// The passthru file generator.
+///
+/// This generator is responsible for sending data to a file on disk.
+pub struct PassthruFile {
+    path: PathBuf,
+    throttle: Throttle,
+    block_cache: block::Cache,
+    metric_labels: Vec<(String, String)>,
+    shutdown: Phase,
+}
+
+impl PassthruFile {
+    /// Create a new [`PassthruFile`] instance
+    ///
+    /// # Errors
+    ///
+    /// Creation will fail if the underlying governor capacity exceeds u32.
+    ///
+    /// # Panics
+    ///
+    /// Function will panic if user has passed zero values for any byte
+    /// values. Sharp corners.
+    #[allow(clippy::cast_possible_truncation)]
+    pub fn new(general: General, config: &Config, shutdown: Phase) -> Result<Self, Error> {
+        let mut rng = StdRng::from_seed(config.seed);
+        let block_sizes: Vec<NonZeroU32> = config
+            .block_sizes
+            .clone()
+            .map_or(
+                vec![
+                    Byte::from_unit(1.0 / 32.0, ByteUnit::MB),
+                    Byte::from_unit(1.0 / 16.0, ByteUnit::MB),
+                    Byte::from_unit(1.0 / 8.0, ByteUnit::MB),
+                    Byte::from_unit(1.0 / 4.0, ByteUnit::MB),
+                    Byte::from_unit(1.0 / 2.0, ByteUnit::MB),
+                    Byte::from_unit(1_f64, ByteUnit::MB),
+                    Byte::from_unit(2_f64, ByteUnit::MB),
+                    Byte::from_unit(4_f64, ByteUnit::MB),
+                ],
+                |sizes| sizes.iter().map(|sz| Ok(*sz)).collect::<Vec<_>>(),
+            )
+            .into_iter()
+            .collect::<Result<Vec<_>, _>>()?
+            .iter()
+            .map(|sz| NonZeroU32::new(sz.get_bytes() as u32).expect("bytes must be non-zero"))
+            .collect();
+        let mut labels = vec![
+            ("component".to_string(), "generator".to_string()),
+            ("component_name".to_string(), "passthru_file".to_string()),
+        ];
+        if let Some(id) = general.id {
+            labels.push(("id".to_string(), id));
+        }
+
+        let bytes_per_second =
+            NonZeroU32::new(config.bytes_per_second.get_bytes() as u32).ok_or(Error::Zero)?;
+        gauge!(
+            "bytes_per_second",
+            f64::from(bytes_per_second.get()),
+            &labels
+        );
+
+        let block_cache = block::Cache::fixed(
+            &mut rng,
+            NonZeroU32::new(config.maximum_prebuild_cache_size_bytes.get_bytes() as u32)
+                .ok_or(Error::Zero)?,
+            &block_sizes,
+            &config.variant,
+        )?;
+
+        let path = PathBuf::from(&config.path);
+
+        Ok(Self {
+            path,
+            block_cache,
+            throttle: Throttle::new_with_config(config.throttle, bytes_per_second),
+            metric_labels: labels,
+            shutdown,
+        })
+    }
+
+    /// Run [`PassthruFile`] to completion or until a shutdown signal is received.
+    ///
+    /// # Errors
+    ///
+    ///
+    /// # Panics
+    ///
+    /// Function will panic if underlying byte capacity is not available.
+    pub async fn spin(mut self) -> Result<(), Error> {
+        info!("PassthruFile generator running");
+
+        let block_cache = self.block_cache;
+        let (snd, rcv) = mpsc::channel(1024);
+        let mut rcv: PeekableReceiver<Block> = PeekableReceiver::new(rcv);
+        thread::Builder::new().spawn(|| block_cache.spin(snd))?;
+
+        let bytes_written = register_counter!("bytes_written", &self.metric_labels);
+
+        let mut current_file = None;
+        loop {
+            let Some(ref mut current_file) = current_file else {
+                match tokio::fs::OpenOptions::new()
+                    .create(true)
+                    .append(true)
+                    .open(&self.path)
+                    .await
+                {
+                    Ok(file) => {
+                        info!("PassthruFile opened {path}", path = self.path.display());
+                        current_file = Some(file);
+                    }
+                    Err(err) => {
+                        warn!("file open failed: {}", err);
+
+                        let mut error_labels = self.metric_labels.clone();
+                        error_labels.push(("error".to_string(), err.to_string()));
+                        counter!("file_open_failure", 1, &error_labels);
+                        tokio::time::sleep(Duration::from_secs(1)).await;
+                    }
+                }
+                continue;
+            };
+
+            let blk = rcv.peek().await.expect("block cache should never be empty");
+            let total_bytes = blk.total_bytes;
+            tokio::select! {
+                _ = self.throttle.wait_for(total_bytes) => {
+                    let blk = rcv.next().await.expect("failed to advance through the blocks"); // actually advance through the blocks
+                    match current_file.write_all(&blk.bytes).await {
+                        Ok(()) => {
+                            bytes_written.increment(u64::from(blk.total_bytes.get()));
+                        }
+                        Err(err) => {
+                            warn!("write failed: {}", err);
+
+                            let mut error_labels = self.metric_labels.clone();
+                            error_labels.push(("error".to_string(), err.to_string()));
+                            counter!("file_write_failure", 1, &error_labels);
+                        }
+                    }
+                }
+                () = self.shutdown.recv() => {
+                    info!("shutdown signal received");
+                    return Ok(());
+                },
+            }
+        }
+    }
+}


### PR DESCRIPTION
### What does this PR do?

This adds a new type of generator that takes the configured payload variant and writes the data out to a file on disk.
That's it.


### Motivation

Helpful to see the final payload output without having to pipe through `socat` or similar.

### Related issues


### Additional Notes

