### PR TITLE
Truncates file while opening instead of appending

### DIFF
--- a/lading/src/generator/passthru_file.rs
+++ b/lading/src/generator/passthru_file.rs
@@ -170,7 +170,8 @@ impl PassthruFile {
             let Some(ref mut current_file) = current_file else {
                 match tokio::fs::OpenOptions::new()
                     .create(true)
-                    .append(true)
+                    .write(true)
+                    .truncate(true)
                     .open(&self.path)
                     .await
                 {


### PR DESCRIPTION
### What does this PR do?

Follow up to the passthrough file generator that was implemented in #824 

### Motivation

This file can get real big if we append to it, I got up to 24gb before I realized my mistake.

### Related issues


### Additional Notes

