### PR TITLE
Increase the max blocks by 4x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - During payload generation, block chunks now give more feedback when the
   requested amount cannot be hit.
 ### Changed
+- Increases the amount of blocks available during payload generation.
 
 ## [0.20.8]
 ### Added

--- a/lading_payload/src/block.rs
+++ b/lading_payload/src/block.rs
@@ -13,7 +13,7 @@ use serde::{Deserialize, Serialize};
 use tokio::sync::mpsc::{self, error::SendError, Sender};
 use tracing::{error, info, span, warn, Level};
 
-const MAX_CHUNKS: usize = 4096;
+const MAX_CHUNKS: usize = 16_384;
 
 /// Error for `Cache::spin`
 #[derive(Debug, thiserror::Error)]


### PR DESCRIPTION
### What does this PR do?

Block generation is at the heart of the lading payload generation, and unfortunately it is easy to specify configurations that will not "fill" to the desired capacity.

This increases the number of "chunks" that the data is split across in an attempt to remove rough edges.

### Motivation

Specifically, this helps with a case where a user specifies a large "pre-gen-cache-size", but only small "block sizes". It is usually impossible to fill the full cache if only tiny blocks are available.

### Related issues



### Additional Notes

