### PR TITLE
De-duplicate block sizes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,17 +19,6 @@ checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
 name = "ahash"
-version = "0.7.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "891477e0c6a8957309ee5c45a6368af3ae14bb510732d2684ffa19af310920f9"
-dependencies = [
- "getrandom",
- "once_cell",
- "version_check",
-]
-
-[[package]]
-name = "ahash"
 version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b79b82693f705137f8fb9b37871d99e4f9a7df12b917eed79c3d3954830a60b"
@@ -75,12 +64,6 @@ checksum = "7d5a26814d8dcb93b0e5a0ff3c6d80a8843bafb21b39e8e18a6f05471870e110"
 dependencies = [
  "derive_arbitrary",
 ]
-
-[[package]]
-name = "arrayvec"
-version = "0.7.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96d30a06541fbafbc7f82ed10c06164cfbd2c401138f6addd8404629c4b16711"
 
 [[package]]
 name = "async-io"
@@ -281,42 +264,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "327762f6e5a765692301e5bb513e0d9fef63be86bbc14528052b1cd3e6f03e07"
 
 [[package]]
-name = "bitvec"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bc2832c24239b0141d5674bb9174f9d68a8b5b3f2753311927c172ca46f7e9c"
-dependencies = [
- "funty",
- "radium",
- "tap",
- "wyz",
-]
-
-[[package]]
-name = "borsh"
-version = "1.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f58b559fd6448c6e2fd0adb5720cd98a2506594cafa4737ff98c396f3e82f667"
-dependencies = [
- "borsh-derive",
- "cfg_aliases",
-]
-
-[[package]]
-name = "borsh-derive"
-version = "1.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7aadb5b6ccbd078890f6d7003694e33816e6b784358f18e15e7e6d9f065a57cd"
-dependencies = [
- "once_cell",
- "proc-macro-crate",
- "proc-macro2",
- "quote",
- "syn 2.0.43",
- "syn_derive",
-]
-
-[[package]]
 name = "bumpalo"
 version = "3.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -330,39 +277,6 @@ checksum = "da78b32057b8fdfc352504708feeba7216dcd65a2c9ab02978cbd288d1279b6c"
 dependencies = [
  "serde",
  "utf8-width",
-]
-
-[[package]]
-name = "byte-unit"
-version = "5.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33ac19bdf0b2665407c39d82dbc937e951e7e2001609f0fb32edd0af45a2d63e"
-dependencies = [
- "rust_decimal",
- "serde",
- "utf8-width",
-]
-
-[[package]]
-name = "bytecheck"
-version = "0.6.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23cdc57ce23ac53c931e88a43d06d070a6fd142f2617be5855eb75efc9beb1c2"
-dependencies = [
- "bytecheck_derive",
- "ptr_meta",
- "simdutf8",
-]
-
-[[package]]
-name = "bytecheck_derive"
-version = "0.6.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3db406d29fbcd95542e92559bed4d8ad92636d1ca8b3b72ede10b4bcc010e659"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
 ]
 
 [[package]]
@@ -397,12 +311,6 @@ name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
-
-[[package]]
-name = "cfg_aliases"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd16c4719339c4530435d38e511904438d07cce7950afa3718a84ac36c10e89e"
 
 [[package]]
 name = "cgroups-rs"
@@ -786,12 +694,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "funty"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
-
-[[package]]
 name = "futures"
 version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -942,9 +844,6 @@ name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
-dependencies = [
- "ahash 0.7.8",
-]
 
 [[package]]
 name = "hashbrown"
@@ -952,7 +851,7 @@ version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33ff8ae62cd3a9102e5637afc8452c55acf3844001bd5374e0b0bd7b6616c038"
 dependencies = [
- "ahash 0.8.10",
+ "ahash",
 ]
 
 [[package]]
@@ -1183,7 +1082,7 @@ version = "0.20.8"
 dependencies = [
  "async-pidfd",
  "average",
- "byte-unit 4.0.19",
+ "byte-unit",
  "bytes",
  "cgroups-rs",
  "clap 3.2.25",
@@ -1241,7 +1140,7 @@ name = "lading-payload"
 version = "0.1.0"
 dependencies = [
  "arbitrary",
- "byte-unit 5.1.4",
+ "byte-unit",
  "bytes",
  "criterion",
  "opentelemetry-proto",
@@ -1362,7 +1261,7 @@ version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fde3af1a009ed76a778cb84fdef9e7dbbdf5775ae3e4cc1f434a6a307f6f76c5"
 dependencies = [
- "ahash 0.8.10",
+ "ahash",
  "metrics-macros",
  "portable-atomic",
 ]
@@ -1766,15 +1665,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "proc-macro-crate"
-version = "3.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d37c51ca738a55da99dc0c4a34860fd675453b8b36209178c2249bb13651284"
-dependencies = [
- "toml_edit",
-]
-
-[[package]]
 name = "proc-macro-error"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1960,26 +1850,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ptr_meta"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0738ccf7ea06b608c10564b31debd4f5bc5e197fc8bfe088f68ae5ce81e7a4f1"
-dependencies = [
- "ptr_meta_derive",
-]
-
-[[package]]
-name = "ptr_meta_derive"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16b845dbfca988fa33db069c0e230574d15a3088f147a87b64c7589eb662c9ac"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
 name = "quanta"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2009,12 +1879,6 @@ checksum = "5267fca4496028628a95160fc423a33e8b2e6af8a5302579e322e4b520293cae"
 dependencies = [
  "proc-macro2",
 ]
-
-[[package]]
-name = "radium"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "radix_trie"
@@ -2148,15 +2012,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
 
 [[package]]
-name = "rend"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71fe3824f5629716b1589be05dacd749f6aa084c87e00e016714a8cdfccc997c"
-dependencies = [
- "bytecheck",
-]
-
-[[package]]
 name = "reqwest"
 version = "0.11.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2192,35 +2047,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rkyv"
-version = "0.7.44"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cba464629b3394fc4dbc6f940ff8f5b4ff5c7aef40f29166fd4ad12acbc99c0"
-dependencies = [
- "bitvec",
- "bytecheck",
- "bytes",
- "hashbrown 0.12.3",
- "ptr_meta",
- "rend",
- "rkyv_derive",
- "seahash",
- "tinyvec",
- "uuid",
-]
-
-[[package]]
-name = "rkyv_derive"
-version = "0.7.44"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7dddfff8de25e6f62b9d64e6e432bf1c6736c57d20323e15ee10435fbda7c65"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
 name = "rmp"
 version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2240,22 +2066,6 @@ dependencies = [
  "byteorder",
  "rmp",
  "serde",
-]
-
-[[package]]
-name = "rust_decimal"
-version = "1.34.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b39449a79f45e8da28c57c341891b69a183044b29518bb8f86dbac9df60bb7df"
-dependencies = [
- "arrayvec",
- "borsh",
- "bytes",
- "num-traits",
- "rand",
- "rkyv",
- "serde",
- "serde_json",
 ]
 
 [[package]]
@@ -2349,12 +2159,6 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
-
-[[package]]
-name = "seahash"
-version = "4.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c107b6f4780854c8b126e228ea8869f4d7b71260f962fefb57b996b8959ba6b"
 
 [[package]]
 name = "serde"
@@ -2490,12 +2294,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "simdutf8"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f27f6278552951f1f2b8cf9da965d10969b2efdea95a6ec47987ab46edfe263a"
-
-[[package]]
 name = "sketches-ddsketch"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2565,18 +2363,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "syn_derive"
-version = "0.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1329189c02ff984e9736652b1631330da25eaa6bc639089ed4915d25446cbe7b"
-dependencies = [
- "proc-macro-error",
- "proc-macro2",
- "quote",
- "syn 2.0.43",
-]
-
-[[package]]
 name = "sync_wrapper"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2602,12 +2388,6 @@ dependencies = [
  "core-foundation-sys",
  "libc",
 ]
-
-[[package]]
-name = "tap"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "tempfile"
@@ -2783,23 +2563,6 @@ dependencies = [
  "pin-project-lite",
  "tokio",
  "tracing",
-]
-
-[[package]]
-name = "toml_datetime"
-version = "0.6.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3550f4e9685620ac18a50ed434eb3aec30db8ba93b0287467bca5826ea25baf1"
-
-[[package]]
-name = "toml_edit"
-version = "0.21.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a8534fd7f78b5405e860340ad6575217ce99f38d4d5c8f2442cb5ecb50090e1"
-dependencies = [
- "indexmap 2.1.0",
- "toml_datetime",
- "winnow",
 ]
 
 [[package]]
@@ -3427,15 +3190,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dff9641d1cd4be8d1a070daf9e3773c5f67e78b4d9d42263020c057706765c04"
 
 [[package]]
-name = "winnow"
-version = "0.5.40"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f593a95398737aeed53e489c785df13f3618e41dbcd6718c6addbf1395aa6876"
-dependencies = [
- "memchr",
-]
-
-[[package]]
 name = "winreg"
 version = "0.50.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3443,15 +3197,6 @@ checksum = "524e57b2c537c0f9b1e69f1965311ec12182b4122e45035b1508cd24d2adadb1"
 dependencies = [
  "cfg-if",
  "windows-sys 0.48.0",
-]
-
-[[package]]
-name = "wyz"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
-dependencies = [
- "tap",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ members = [
 
 [workspace.dependencies]
 bytes = { version = "1.5.0", default-features = false, features = ["std"] }
+byte-unit = { version = "4.0", features = ["serde"] }
 metrics = { version = "0.21" }
 prost = "0.11"
 prost-build = { version = "0.12" }

--- a/lading/Cargo.toml
+++ b/lading/Cargo.toml
@@ -14,7 +14,7 @@ lading-capture = { version = "0.1", path = "../lading_capture" }
 lading-payload = { version = "0.1", path = "../lading_payload" }
 lading-throttle = { version = "0.1", path = "../lading_throttle" }
 
-byte-unit = { version = "4.0", features = ["serde"] }
+byte-unit = {workspace = true }
 bytes = { workspace = true, features = ["std"] }
 clap = { version = "3.2", default-features = false, features = ["std", "color", "suggestions", "derive"] }
 flate2 = { version = "1.0.27", default-features = false, features = ["rust_backend" ] }

--- a/lading/src/generator/grpc.rs
+++ b/lading/src/generator/grpc.rs
@@ -159,8 +159,6 @@ impl Grpc {
     /// values. Sharp corners.
     #[allow(clippy::cast_possible_truncation)]
     pub fn new(general: General, config: Config, shutdown: Phase) -> Result<Self, Error> {
-        
-
         let mut rng = StdRng::from_seed(config.seed);
         let block_sizes = lading_payload::block::get_blocks(&config.block_sizes);
         let mut labels = vec![

--- a/lading/src/generator/grpc.rs
+++ b/lading/src/generator/grpc.rs
@@ -162,27 +162,7 @@ impl Grpc {
         use byte_unit::{Byte, ByteUnit};
 
         let mut rng = StdRng::from_seed(config.seed);
-        let block_sizes: Vec<NonZeroU32> = config
-            .block_sizes
-            .as_ref()
-            .map_or(
-                vec![
-                    Byte::from_unit(1.0 / 32.0, ByteUnit::MB),
-                    Byte::from_unit(1.0 / 16.0, ByteUnit::MB),
-                    Byte::from_unit(1.0 / 8.0, ByteUnit::MB),
-                    Byte::from_unit(1.0 / 4.0, ByteUnit::MB),
-                    Byte::from_unit(1.0 / 2.0, ByteUnit::MB),
-                    Byte::from_unit(1_f64, ByteUnit::MB),
-                    Byte::from_unit(2_f64, ByteUnit::MB),
-                    Byte::from_unit(4_f64, ByteUnit::MB),
-                ],
-                |sizes| sizes.iter().map(|sz| Ok(*sz)).collect::<Vec<_>>(),
-            )
-            .into_iter()
-            .collect::<Result<Vec<_>, _>>()?
-            .iter()
-            .map(|sz| NonZeroU32::new(sz.get_bytes() as u32).expect("bytes must be non-zero"))
-            .collect();
+        let block_sizes = lading_payload::block::get_blocks(&config.block_sizes);
         let mut labels = vec![
             ("component".to_string(), "generator".to_string()),
             ("component_name".to_string(), "grpc".to_string()),

--- a/lading/src/generator/grpc.rs
+++ b/lading/src/generator/grpc.rs
@@ -159,7 +159,7 @@ impl Grpc {
     /// values. Sharp corners.
     #[allow(clippy::cast_possible_truncation)]
     pub fn new(general: General, config: Config, shutdown: Phase) -> Result<Self, Error> {
-        use byte_unit::{Byte, ByteUnit};
+        
 
         let mut rng = StdRng::from_seed(config.seed);
         let block_sizes = lading_payload::block::get_blocks(&config.block_sizes);

--- a/lading/src/generator/http.rs
+++ b/lading/src/generator/http.rs
@@ -13,7 +13,7 @@
 
 use std::{num::NonZeroU32, thread};
 
-use byte_unit::{ByteError};
+use byte_unit::ByteError;
 use hyper::{
     client::{Client, HttpConnector},
     header::CONTENT_LENGTH,

--- a/lading/src/generator/http.rs
+++ b/lading/src/generator/http.rs
@@ -13,7 +13,7 @@
 
 use std::{num::NonZeroU32, thread};
 
-use byte_unit::{Byte, ByteError, ByteUnit};
+use byte_unit::{ByteError};
 use hyper::{
     client::{Client, HttpConnector},
     header::CONTENT_LENGTH,

--- a/lading/src/generator/http.rs
+++ b/lading/src/generator/http.rs
@@ -129,24 +129,7 @@ impl Http {
     #[allow(clippy::cast_possible_truncation)]
     pub fn new(general: General, config: Config, shutdown: Phase) -> Result<Self, Error> {
         let mut rng = StdRng::from_seed(config.seed);
-        let block_sizes: Vec<NonZeroU32> = config
-            .block_sizes
-            .map_or(
-                vec![
-                    Byte::from_unit(1.0 / 8.0, ByteUnit::MB),
-                    Byte::from_unit(1.0 / 4.0, ByteUnit::MB),
-                    Byte::from_unit(1.0 / 2.0, ByteUnit::MB),
-                    Byte::from_unit(1_f64, ByteUnit::MB),
-                    Byte::from_unit(2_f64, ByteUnit::MB),
-                    Byte::from_unit(4_f64, ByteUnit::MB),
-                ],
-                |sizes| sizes.iter().map(|sz| Ok(*sz)).collect::<Vec<_>>(),
-            )
-            .into_iter()
-            .collect::<Result<Vec<_>, _>>()?
-            .iter()
-            .map(|sz| NonZeroU32::new(sz.get_bytes() as u32).expect("bytes must be non-zero"))
-            .collect();
+        let block_sizes = lading_payload::block::get_blocks(&config.block_sizes);
         let mut labels = vec![
             ("component".to_string(), "generator".to_string()),
             ("component_name".to_string(), "http".to_string()),

--- a/lading/src/generator/passthru_file.rs
+++ b/lading/src/generator/passthru_file.rs
@@ -13,7 +13,7 @@
 use std::{num::NonZeroU32, path::PathBuf, thread, time::Duration};
 use tokio::io::AsyncWriteExt;
 
-use byte_unit::{ByteError};
+use byte_unit::ByteError;
 use lading_throttle::Throttle;
 use metrics::{counter, gauge, register_counter};
 use rand::{rngs::StdRng, SeedableRng};

--- a/lading/src/generator/passthru_file.rs
+++ b/lading/src/generator/passthru_file.rs
@@ -13,7 +13,7 @@
 use std::{num::NonZeroU32, path::PathBuf, thread, time::Duration};
 use tokio::io::AsyncWriteExt;
 
-use byte_unit::{Byte, ByteError, ByteUnit};
+use byte_unit::{ByteError};
 use lading_throttle::Throttle;
 use metrics::{counter, gauge, register_counter};
 use rand::{rngs::StdRng, SeedableRng};

--- a/lading/src/generator/passthru_file.rs
+++ b/lading/src/generator/passthru_file.rs
@@ -90,27 +90,7 @@ impl PassthruFile {
     #[allow(clippy::cast_possible_truncation)]
     pub fn new(general: General, config: &Config, shutdown: Phase) -> Result<Self, Error> {
         let mut rng = StdRng::from_seed(config.seed);
-        let block_sizes: Vec<NonZeroU32> = config
-            .block_sizes
-            .clone()
-            .map_or(
-                vec![
-                    Byte::from_unit(1.0 / 32.0, ByteUnit::MB),
-                    Byte::from_unit(1.0 / 16.0, ByteUnit::MB),
-                    Byte::from_unit(1.0 / 8.0, ByteUnit::MB),
-                    Byte::from_unit(1.0 / 4.0, ByteUnit::MB),
-                    Byte::from_unit(1.0 / 2.0, ByteUnit::MB),
-                    Byte::from_unit(1_f64, ByteUnit::MB),
-                    Byte::from_unit(2_f64, ByteUnit::MB),
-                    Byte::from_unit(4_f64, ByteUnit::MB),
-                ],
-                |sizes| sizes.iter().map(|sz| Ok(*sz)).collect::<Vec<_>>(),
-            )
-            .into_iter()
-            .collect::<Result<Vec<_>, _>>()?
-            .iter()
-            .map(|sz| NonZeroU32::new(sz.get_bytes() as u32).expect("bytes must be non-zero"))
-            .collect();
+        let block_sizes = lading_payload::block::get_blocks(&config.block_sizes);
         let mut labels = vec![
             ("component".to_string(), "generator".to_string()),
             ("component_name".to_string(), "passthru_file".to_string()),

--- a/lading/src/generator/splunk_hec.rs
+++ b/lading/src/generator/splunk_hec.rs
@@ -19,7 +19,7 @@ mod acknowledgements;
 use std::{num::NonZeroU32, thread, time::Duration};
 
 use acknowledgements::Channels;
-use byte_unit::{Byte, ByteError, ByteUnit};
+use byte_unit::{ByteError};
 use http::{
     header::{AUTHORIZATION, CONTENT_LENGTH},
     Method, Request, Uri,

--- a/lading/src/generator/splunk_hec.rs
+++ b/lading/src/generator/splunk_hec.rs
@@ -175,24 +175,7 @@ impl SplunkHec {
     #[allow(clippy::cast_possible_truncation)]
     pub fn new(general: General, config: Config, shutdown: Phase) -> Result<Self, Error> {
         let mut rng = StdRng::from_seed(config.seed);
-        let block_sizes: Vec<NonZeroU32> = config
-            .block_sizes
-            .map_or(
-                vec![
-                    Byte::from_unit(1.0 / 8.0, ByteUnit::MB),
-                    Byte::from_unit(1.0 / 4.0, ByteUnit::MB),
-                    Byte::from_unit(1.0 / 2.0, ByteUnit::MB),
-                    Byte::from_unit(1_f64, ByteUnit::MB),
-                    Byte::from_unit(2_f64, ByteUnit::MB),
-                    Byte::from_unit(4_f64, ByteUnit::MB),
-                ],
-                |sizes| sizes.iter().map(|sz| Ok(*sz)).collect::<Vec<_>>(),
-            )
-            .into_iter()
-            .collect::<Result<Vec<_>, _>>()?
-            .iter()
-            .map(|sz| NonZeroU32::new(sz.get_bytes() as u32).expect("bytes must be non-zero"))
-            .collect();
+        let block_sizes = lading_payload::block::get_blocks(&config.block_sizes);
         let mut labels = vec![
             ("component".to_string(), "generator".to_string()),
             ("component_name".to_string(), "splunk_hec".to_string()),

--- a/lading/src/generator/splunk_hec.rs
+++ b/lading/src/generator/splunk_hec.rs
@@ -19,7 +19,7 @@ mod acknowledgements;
 use std::{num::NonZeroU32, thread, time::Duration};
 
 use acknowledgements::Channels;
-use byte_unit::{ByteError};
+use byte_unit::ByteError;
 use http::{
     header::{AUTHORIZATION, CONTENT_LENGTH},
     Method, Request, Uri,

--- a/lading/src/generator/tcp.rs
+++ b/lading/src/generator/tcp.rs
@@ -17,7 +17,7 @@ use std::{
     thread,
 };
 
-use byte_unit::{ByteError};
+use byte_unit::ByteError;
 use lading_throttle::Throttle;
 use metrics::{counter, gauge, register_counter};
 use rand::{rngs::StdRng, SeedableRng};

--- a/lading/src/generator/tcp.rs
+++ b/lading/src/generator/tcp.rs
@@ -17,13 +17,13 @@ use std::{
     thread,
 };
 
-use byte_unit::{Byte, ByteError, ByteUnit};
+use byte_unit::{ByteError};
 use lading_throttle::Throttle;
 use metrics::{counter, gauge, register_counter};
 use rand::{rngs::StdRng, SeedableRng};
 use serde::{Deserialize, Serialize};
 use tokio::{io::AsyncWriteExt, net::TcpStream, sync::mpsc};
-use tracing::{info, trace, warn};
+use tracing::{info, trace};
 
 use crate::{common::PeekableReceiver, signals::Phase};
 use lading_payload::block::{self, Block};

--- a/lading/src/generator/udp.rs
+++ b/lading/src/generator/udp.rs
@@ -18,7 +18,7 @@ use std::{
     time::Duration,
 };
 
-use byte_unit::{Byte, ByteError, ByteUnit};
+use byte_unit::ByteError;
 use lading_throttle::Throttle;
 use metrics::{counter, gauge, register_counter};
 use rand::{rngs::StdRng, SeedableRng};
@@ -95,27 +95,8 @@ impl Udp {
     #[allow(clippy::cast_possible_truncation)]
     pub fn new(general: General, config: &Config, shutdown: Phase) -> Result<Self, Error> {
         let mut rng = StdRng::from_seed(config.seed);
-        let block_sizes: Vec<NonZeroU32> = config
-            .block_sizes
-            .clone()
-            .map_or(
-                vec![
-                    Byte::from_unit(1.0 / 32.0, ByteUnit::MB),
-                    Byte::from_unit(1.0 / 16.0, ByteUnit::MB),
-                    Byte::from_unit(1.0 / 8.0, ByteUnit::MB),
-                    Byte::from_unit(1.0 / 4.0, ByteUnit::MB),
-                    Byte::from_unit(1.0 / 2.0, ByteUnit::MB),
-                    Byte::from_unit(1_f64, ByteUnit::MB),
-                    Byte::from_unit(2_f64, ByteUnit::MB),
-                    Byte::from_unit(4_f64, ByteUnit::MB),
-                ],
-                |sizes| sizes.iter().map(|sz| Ok(*sz)).collect::<Vec<_>>(),
-            )
-            .into_iter()
-            .collect::<Result<Vec<_>, _>>()?
-            .iter()
-            .map(|sz| NonZeroU32::new(sz.get_bytes() as u32).expect("bytes must be non-zero"))
-            .collect();
+        // TODO pass in datagram_friendly: true
+        let block_sizes = lading_payload::block::get_blocks(&config.block_sizes);
         let mut labels = vec![
             ("component".to_string(), "generator".to_string()),
             ("component_name".to_string(), "udp".to_string()),

--- a/lading/src/generator/unix_datagram.rs
+++ b/lading/src/generator/unix_datagram.rs
@@ -114,27 +114,8 @@ impl UnixDatagram {
     #[allow(clippy::cast_possible_truncation)]
     pub fn new(general: General, config: &Config, shutdown: Phase) -> Result<Self, Error> {
         let mut rng = StdRng::from_seed(config.seed);
-        let block_sizes: Vec<NonZeroU32> = config
-            .block_sizes
-            .as_ref()
-            .map_or(
-                vec![
-                    Byte::from_unit(1.0 / 32.0, ByteUnit::MB),
-                    Byte::from_unit(1.0 / 16.0, ByteUnit::MB),
-                    Byte::from_unit(1.0 / 8.0, ByteUnit::MB),
-                    Byte::from_unit(1.0 / 4.0, ByteUnit::MB),
-                    Byte::from_unit(1.0 / 2.0, ByteUnit::MB),
-                    Byte::from_unit(1_f64, ByteUnit::MB),
-                    Byte::from_unit(2_f64, ByteUnit::MB),
-                    Byte::from_unit(4_f64, ByteUnit::MB),
-                ],
-                |sizes| sizes.iter().map(|sz| Ok(*sz)).collect::<Vec<_>>(),
-            )
-            .into_iter()
-            .collect::<Result<Vec<_>, _>>()?
-            .iter()
-            .map(|sz| NonZeroU32::new(sz.get_bytes() as u32).expect("bytes must be non-zero"))
-            .collect();
+        // TODO pass in datagram_friendly: true
+        let block_sizes = lading_payload::block::get_blocks(&config.block_sizes);
         let mut labels = vec![
             ("component".to_string(), "generator".to_string()),
             ("component_name".to_string(), "unix_datagram".to_string()),

--- a/lading/src/generator/unix_datagram.rs
+++ b/lading/src/generator/unix_datagram.rs
@@ -12,7 +12,7 @@
 //!
 
 use crate::{common::PeekableReceiver, signals::Phase};
-use byte_unit::{ByteError};
+use byte_unit::ByteError;
 use futures::future::join_all;
 use lading_payload::block::{self, Block};
 use lading_throttle::Throttle;

--- a/lading/src/generator/unix_datagram.rs
+++ b/lading/src/generator/unix_datagram.rs
@@ -12,7 +12,7 @@
 //!
 
 use crate::{common::PeekableReceiver, signals::Phase};
-use byte_unit::{Byte, ByteError, ByteUnit};
+use byte_unit::{ByteError};
 use futures::future::join_all;
 use lading_payload::block::{self, Block};
 use lading_throttle::Throttle;

--- a/lading/src/generator/unix_stream.rs
+++ b/lading/src/generator/unix_stream.rs
@@ -12,7 +12,7 @@
 //!
 
 use crate::{common::PeekableReceiver, signals::Phase};
-use byte_unit::{Byte, ByteError, ByteUnit};
+use byte_unit::{ByteError};
 use lading_payload::block::{self, Block};
 use lading_throttle::Throttle;
 use metrics::{counter, gauge, register_counter};

--- a/lading/src/generator/unix_stream.rs
+++ b/lading/src/generator/unix_stream.rs
@@ -95,27 +95,7 @@ impl UnixStream {
     #[allow(clippy::cast_possible_truncation)]
     pub fn new(general: General, config: Config, shutdown: Phase) -> Result<Self, Error> {
         let mut rng = StdRng::from_seed(config.seed);
-        let block_sizes: Vec<NonZeroU32> = config
-            .block_sizes
-            .as_ref()
-            .map_or(
-                vec![
-                    Byte::from_unit(1.0 / 32.0, ByteUnit::MB),
-                    Byte::from_unit(1.0 / 16.0, ByteUnit::MB),
-                    Byte::from_unit(1.0 / 8.0, ByteUnit::MB),
-                    Byte::from_unit(1.0 / 4.0, ByteUnit::MB),
-                    Byte::from_unit(1.0 / 2.0, ByteUnit::MB),
-                    Byte::from_unit(1_f64, ByteUnit::MB),
-                    Byte::from_unit(2_f64, ByteUnit::MB),
-                    Byte::from_unit(4_f64, ByteUnit::MB),
-                ],
-                |sizes| sizes.iter().map(|sz| Ok(*sz)).collect::<Vec<_>>(),
-            )
-            .into_iter()
-            .collect::<Result<Vec<_>, _>>()?
-            .iter()
-            .map(|sz| NonZeroU32::new(sz.get_bytes() as u32).expect("bytes must be non-zero"))
-            .collect();
+        let block_sizes = lading_payload::block::get_blocks(&config.block_sizes);
         let mut labels = vec![
             ("component".to_string(), "generator".to_string()),
             ("component_name".to_string(), "unix_stream".to_string()),

--- a/lading/src/generator/unix_stream.rs
+++ b/lading/src/generator/unix_stream.rs
@@ -12,7 +12,7 @@
 //!
 
 use crate::{common::PeekableReceiver, signals::Phase};
-use byte_unit::{ByteError};
+use byte_unit::ByteError;
 use lading_payload::block::{self, Block};
 use lading_throttle::Throttle;
 use metrics::{counter, gauge, register_counter};

--- a/lading_payload/Cargo.toml
+++ b/lading_payload/Cargo.toml
@@ -11,7 +11,7 @@ description = "A tool for load testing daemons."
 
 [dependencies]
 bytes = { workspace = true }
-byte-unit = { version = "5.0", features = [] }
+byte-unit = { workspace = true, features = [] }
 opentelemetry-proto = { version = "0.1.0", features = ["traces", "metrics", "logs", "gen-tonic" ] }
 prost = { workspace = true }
 rand = { workspace = true, default-features = false, features = ["small_rng", "std", "std_rng" ]}


### PR DESCRIPTION
### What does this PR do?

Refactors the generators that take in `block_sizes` as an argument and extracts that logic and default to a single location in the code.

### Motivation

Simplify my next set of changes and de-duplicate the code.

### Related issues


### Additional Notes

