### PR TITLE
Adds the specific path that caused a failure

### DIFF
--- a/lading/src/common.rs
+++ b/lading/src/common.rs
@@ -56,7 +56,12 @@ pub(crate) fn stdio(behavior: &Behavior) -> Stdio {
     match behavior {
         Behavior::Quiet => Stdio::null(),
         Behavior::Log(path) => {
-            let fp = fs::File::create(path).expect("Full directory path does not exist");
+            let fp = fs::File::create(path).unwrap_or_else(|_| {
+                panic!(
+                    "Full directory path does not exist: {path}",
+                    path = path.display()
+                );
+            });
             Stdio::from(fp)
         }
     }


### PR DESCRIPTION
### What does this PR do?

Adds the path that caused an `expect` to fail.

### Motivation

After:
```
thread 'tokio-runtime-worker' panicked at lading/src/common.rs:60:17:
Full directory path does not exist: /captures/target.stdout.log
stack backtrace:
   0: rust_begin_unwind
```

(before the path was not present)
### Related issues

A list of issues either fixed, containing architectural discussions, otherwise relevant
for this Pull Request.

### Additional Notes

Anything else we should know when reviewing?
