### PR TITLE
Block construction cleanup

### DIFF
--- a/lading_payload/src/block.rs
+++ b/lading_payload/src/block.rs
@@ -625,12 +625,19 @@ where
     } else {
         let capacity_sum = block_chunks.iter().sum::<u32>();
         let filled_sum = block_cache.iter().map(|b| b.total_bytes.get()).sum::<u32>();
-        info!(
-            num_blocks = block_cache.len(),
-            filled_byte_sum = filled_sum,
-            capacity_sum = capacity_sum,
-            "Block cache constructed."
-        );
+        if filled_sum == capacity_sum {
+            info!(
+                num_blocks = block_cache.len(),
+                filled_byte_sum = filled_sum,
+                capacity_sum = capacity_sum,
+                "Block cache constructed."
+            );
+        } else {
+            let perc = (filled_sum as f64 / capacity_sum as f64) * 100.0;
+            warn!(
+                "Could not fill block cache, only {perc:.2}% full. Filled: {filled_sum}, Requested: {capacity_sum}."
+            );
+        }
         Ok(block_cache)
     }
 }
@@ -731,7 +738,7 @@ where
 pub fn get_blocks(config_block_sizes: &Option<Vec<byte_unit::Byte>>) -> Vec<NonZeroU32> {
     match config_block_sizes {
         Some(ref sizes) => {
-            info!("Generator using user-specified block sizes: {:#?}", sizes);
+            info!("Generator using user-specified block sizes: {:?}", sizes);
             sizes
                 .iter()
                 .map(|sz| {

--- a/lading_payload/src/block.rs
+++ b/lading_payload/src/block.rs
@@ -623,8 +623,12 @@ where
             ConstructBlockCacheError::InsufficientBlockSizes,
         ))
     } else {
+        // "Capacity" here refers to how much data the block_chunks can hold.
+        // Note that this may not match the end-user's requested pregen-cache-size.
+        // This function is only concerned with filling up the chunks requested.
         let capacity_sum = block_chunks.iter().sum::<u32>();
         let filled_sum = block_cache.iter().map(|b| b.total_bytes.get()).sum::<u32>();
+
         if filled_sum == capacity_sum {
             info!(
                 num_blocks = block_cache.len(),
@@ -633,9 +637,14 @@ where
                 "Block cache constructed."
             );
         } else {
-            let perc = (filled_sum as f64 / capacity_sum as f64) * 100.0;
+            let filled_sum_str = byte_unit::Byte::from_bytes(filled_sum.into())
+                .get_appropriate_unit(false)
+                .to_string();
+            let capacity_sum_str = byte_unit::Byte::from_bytes(capacity_sum.into())
+                .get_appropriate_unit(false)
+                .to_string();
             warn!(
-                "Could not fill block cache, only {perc:.2}% full. Filled: {filled_sum}, Requested: {capacity_sum}."
+                "Filled {filled_sum_str} only. Could not fill up to the chunk capacity of {capacity_sum_str}."
             );
         }
         Ok(block_cache)


### PR DESCRIPTION
### What does this PR do?

Changes how block sizes are printed to logs.
Also pushes the verbosity to `WARN` for an incomplete block cache generation.


### Motivation

Before:
```
2024-03-05T22:35:50.596725Z  INFO lading_payload::block: Generator using user-specified block sizes: [
    Byte(
        1000,
    ),
    Byte(
        2000,
    ),
    Byte(
        3000,
    ),
]

2024-03-05T22:42:46.910944Z  INFO fixed{max_chunks=16384 payload="dogstatsd"}:construct_block_cache_inner: lading_payload::block: Block cache constructed. num_blocks=16384 filled_byte_sum=20428667 capacity_sum=32767000

```
After:
```
2024-03-05T22:44:33.696084Z  INFO lading_payload::block: Generator using user-specified block sizes: [Byte(1000), Byte(2000), Byte(3000)]

2024-03-05T23:03:34.836494Z  WARN fixed{max_chunks=16384 payload="dogstatsd"}:construct_block_cache_inner: lading_payload::block: Filled 20.43 MB only. Could not fill up to the chunk capacity of 32.77 MB.
```

### Related issues



### Additional Notes

