### PR TITLE
Enable tracing_subscriber to populate from RUST_LOG envvar

### DIFF
--- a/lading/src/bin/lading.rs
+++ b/lading/src/bin/lading.rs
@@ -31,7 +31,7 @@ use tokio::{
     time::{self, sleep, Duration},
 };
 use tracing::{debug, error, info, warn};
-use tracing_subscriber::{fmt::format::FmtSpan, util::SubscriberInitExt};
+use tracing_subscriber::{fmt::format::FmtSpan, util::SubscriberInitExt, EnvFilter};
 
 #[derive(thiserror::Error, Debug)]
 enum Error {
@@ -539,6 +539,7 @@ fn run_extra_cmds(cmds: ExtraCommands) -> Result<(), Error> {
 fn main() -> Result<(), Error> {
     tracing_subscriber::fmt()
         .with_span_events(FmtSpan::FULL)
+        .with_env_filter(EnvFilter::from_default_env())
         .with_ansi(false)
         .finish()
         .init();


### PR DESCRIPTION
### What does this PR do?

tracing_subscriber now respects the env var `RUST_LOG`

### Motivation

I expected this to work, it didn't. That was surprising.


### Related issues



### Additional Notes

