### PR TITLE
Adds max block size to block getter

### DIFF
--- a/lading/src/generator/grpc.rs
+++ b/lading/src/generator/grpc.rs
@@ -160,7 +160,7 @@ impl Grpc {
     #[allow(clippy::cast_possible_truncation)]
     pub fn new(general: General, config: Config, shutdown: Phase) -> Result<Self, Error> {
         let mut rng = StdRng::from_seed(config.seed);
-        let block_sizes = lading_payload::block::get_blocks(&config.block_sizes);
+        let block_sizes = lading_payload::block::get_blocks(&config.block_sizes, None);
         let mut labels = vec![
             ("component".to_string(), "generator".to_string()),
             ("component_name".to_string(), "grpc".to_string()),

--- a/lading/src/generator/http.rs
+++ b/lading/src/generator/http.rs
@@ -129,7 +129,7 @@ impl Http {
     #[allow(clippy::cast_possible_truncation)]
     pub fn new(general: General, config: Config, shutdown: Phase) -> Result<Self, Error> {
         let mut rng = StdRng::from_seed(config.seed);
-        let block_sizes = lading_payload::block::get_blocks(&config.block_sizes);
+        let block_sizes = lading_payload::block::get_blocks(&config.block_sizes, None);
         let mut labels = vec![
             ("component".to_string(), "generator".to_string()),
             ("component_name".to_string(), "http".to_string()),

--- a/lading/src/generator/passthru_file.rs
+++ b/lading/src/generator/passthru_file.rs
@@ -90,7 +90,7 @@ impl PassthruFile {
     #[allow(clippy::cast_possible_truncation)]
     pub fn new(general: General, config: &Config, shutdown: Phase) -> Result<Self, Error> {
         let mut rng = StdRng::from_seed(config.seed);
-        let block_sizes = lading_payload::block::get_blocks(&config.block_sizes);
+        let block_sizes = lading_payload::block::get_blocks(&config.block_sizes, None);
         let mut labels = vec![
             ("component".to_string(), "generator".to_string()),
             ("component_name".to_string(), "passthru_file".to_string()),

--- a/lading/src/generator/splunk_hec.rs
+++ b/lading/src/generator/splunk_hec.rs
@@ -175,7 +175,7 @@ impl SplunkHec {
     #[allow(clippy::cast_possible_truncation)]
     pub fn new(general: General, config: Config, shutdown: Phase) -> Result<Self, Error> {
         let mut rng = StdRng::from_seed(config.seed);
-        let block_sizes = lading_payload::block::get_blocks(&config.block_sizes);
+        let block_sizes = lading_payload::block::get_blocks(&config.block_sizes, None);
         let mut labels = vec![
             ("component".to_string(), "generator".to_string()),
             ("component_name".to_string(), "splunk_hec".to_string()),

--- a/lading/src/generator/tcp.rs
+++ b/lading/src/generator/tcp.rs
@@ -94,7 +94,7 @@ impl Tcp {
     #[allow(clippy::cast_possible_truncation)]
     pub fn new(general: General, config: &Config, shutdown: Phase) -> Result<Self, Error> {
         let mut rng = StdRng::from_seed(config.seed);
-        let block_sizes = lading_payload::block::get_blocks(&config.block_sizes);
+        let block_sizes = lading_payload::block::get_blocks(&config.block_sizes, None);
         let mut labels = vec![
             ("component".to_string(), "generator".to_string()),
             ("component_name".to_string(), "tcp".to_string()),

--- a/lading/src/generator/unix_datagram.rs
+++ b/lading/src/generator/unix_datagram.rs
@@ -115,7 +115,7 @@ impl UnixDatagram {
     pub fn new(general: General, config: &Config, shutdown: Phase) -> Result<Self, Error> {
         let mut rng = StdRng::from_seed(config.seed);
         // TODO pass in datagram_friendly: true
-        let block_sizes = lading_payload::block::get_blocks(&config.block_sizes);
+        let block_sizes = lading_payload::block::get_blocks(&config.block_sizes, None);
         let mut labels = vec![
             ("component".to_string(), "generator".to_string()),
             ("component_name".to_string(), "unix_datagram".to_string()),

--- a/lading/src/generator/unix_stream.rs
+++ b/lading/src/generator/unix_stream.rs
@@ -95,7 +95,7 @@ impl UnixStream {
     #[allow(clippy::cast_possible_truncation)]
     pub fn new(general: General, config: Config, shutdown: Phase) -> Result<Self, Error> {
         let mut rng = StdRng::from_seed(config.seed);
-        let block_sizes = lading_payload::block::get_blocks(&config.block_sizes);
+        let block_sizes = lading_payload::block::get_blocks(&config.block_sizes, None);
         let mut labels = vec![
             ("component".to_string(), "generator".to_string()),
             ("component_name".to_string(), "unix_stream".to_string()),


### PR DESCRIPTION
### What does this PR do?

When a generator is requesting the block sizes from the user's config, the given generator may now optionally specify a maximum block size.

### Motivation

UDP datagrams have a hard size limit.

### Related issues



### Additional Notes

