### PR TITLE
Adds an optional way to prefix metrics with a special string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 ### Added
+- Optional new feature for DogStatsD generation -- metric name prefixing.
 ### Changed
 ### Fixed
 

--- a/lading_payload/src/dogstatsd/metric.rs
+++ b/lading_payload/src/dogstatsd/metric.rs
@@ -43,6 +43,7 @@ impl MetricGenerator {
         tags_generator: &mut common::tags::Generator,
         str_pool: &strings::Pool,
         value_conf: ValueConf,
+        metric_name_prefix: &'static str,
         mut rng: &mut R,
     ) -> Result<Self, Error>
     where
@@ -54,11 +55,16 @@ impl MetricGenerator {
         for _ in 0..num_contexts {
             let tags = tags_generator.generate(&mut rng);
             let name_sz = name_length.sample(&mut rng) as usize;
-            let name = String::from(
+            let strpool_name = String::from(
                 str_pool
                     .of_size(&mut rng, name_sz)
                     .ok_or(Error::StringGenerate)?,
             );
+            let name = if metric_name_prefix.is_empty() {
+                strpool_name
+            } else {
+                format!("{metric_name_prefix}.{strpool_name}")
+            };
 
             let res = match metric_weights.sample(rng) {
                 0 => Template::Count(template::Count { name, tags: tags? }),


### PR DESCRIPTION
### What does this PR do?

Adds a config option to the dogstatsd generator to prepend a fixed string to each metric name.

### Motivation

Compatibility with an older benchmarking platform that needs this to filter things out.

### Related issues

### Additional Notes

