### PR TITLE
Prepares the release of lading 0.20.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 ### Added
+### Changed
+### Fixed
+
+## [0.20.10]
+### Added
 - Optional new feature for DogStatsD generation -- metric name prefixing.
 - Musl builds are now available for aarch64 and x86-64
 ### Changed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1078,7 +1078,7 @@ dependencies = [
 
 [[package]]
 name = "lading"
-version = "0.20.9"
+version = "0.20.10"
 dependencies = [
  "async-pidfd",
  "average",

--- a/lading/Cargo.toml
+++ b/lading/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lading"
-version = "0.20.9"
+version = "0.20.10"
 authors = [
     "Brian L. Troutwine <brian.troutwine@datadoghq.com>",
     "George Hahn <george.hahn@datadoghq.com>",


### PR DESCRIPTION
### What does this PR do?

Updates changelog and cargo version for lading 0.20.10

### Motivation

Very small release, main motivation is to have a proper `latest` container build now that #844 has gone in.

### Related issues



### Additional Notes

