### PR TITLE
prefix already contains a '.' separator, no reason to duplicate it

### DIFF
--- a/lading_payload/src/dogstatsd/metric.rs
+++ b/lading_payload/src/dogstatsd/metric.rs
@@ -63,7 +63,7 @@ impl MetricGenerator {
             let name = if metric_name_prefix.is_empty() {
                 strpool_name
             } else {
-                format!("{metric_name_prefix}.{strpool_name}")
+                format!("{metric_name_prefix}{strpool_name}")
             };
 
             let res = match metric_weights.sample(rng) {


### PR DESCRIPTION
### What does this PR do?

Removes an erroneous `.`.

### Motivation

In #845 , I added support for an optional dogstatsd metric name prefix, however I accidentally duplicated the prefix separator.

`smp..jvTFhKcDf2bjDdgf4rTQt5` is the incorrect current behavior

### Related issues


### Additional Notes

