### PR TITLE
dependabot actions update: add no-changelog label

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,3 +14,7 @@ updates:
     schedule:
       # Check for updates to GitHub Actions every week
       interval: "weekly"
+    labels:
+      - "dependencies"   # needed to preserve default
+      - "github_actions" # needed to preserve default
+      - "no-changelog"   # CI dependencies should not require changelog entry


### PR DESCRIPTION
### What does this PR do?

For `dependabot` pull requests updating GitHub Actions (not `cargo` crates), a changelog entry should not be required. Adding a `no-changelog` label to such pull requests should make merging those pull requests easier. This commit automatically adds `no-changelog` label to those pull requests.

### Motivation

Make it easier to approve & merge some `dependabot` pull requests.

### Related issues

Lack of a `no-changelog` label has caused pull requests #847, #849, #850, #851, and #858 to fail the changelog check in CI, so that label needed to be added to those pull requests.

### Additional Notes

I could see a counterargument to merging this pull request for some of the GitHub Actions we use to build `lading` in CI and package releases because updates to some of the Actions we use might affect the binaries we release (e.g., changes to cross-compilation).
