### PR TITLE
block: add failing case to proptest cases

### DIFF
--- a/lading_payload/proptest-regressions/block.txt
+++ b/lading_payload/proptest-regressions/block.txt
@@ -1,0 +1,7 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+cc 2b0d6d175b1488dc4c09caff469d54a43517f51a61c45ff965a99165da98401a # shrinks to seed = 2494543245988303026, num_chunks = 1


### PR DESCRIPTION
### What does this PR do?

This commit adds a failing case to the `proptest` cases for `block::test::construct_block_cache_inner_fills_all_blocks` in `lading_payload`.

### Motivation

Test failure occurred in testing of #847; see https://github.com/DataDog/lading/actions/runs/8336453710/job/22813606919?pr=847.

### Related issues

See above.

### Additional Notes

n/a