### PR TITLE
Fix for PropTest failure in block construction

### DIFF
--- a/lading_payload/src/block.rs
+++ b/lading_payload/src/block.rs
@@ -831,7 +831,7 @@ mod test {
             use rand::{rngs::SmallRng, SeedableRng};
 
             let mut rng = SmallRng::seed_from_u64(seed);
-            let block_chunks = vec![100; num_chunks];
+            let block_chunks = vec![1000; num_chunks];
             let serializer = crate::Json;
             let block_cache = construct_block_cache_inner(&mut rng, &serializer, &block_chunks)
                 .expect("construct_block_cache_inner should not fail");


### PR DESCRIPTION
### What does this PR do?

Provides a fix for the issue that proptest found in https://github.com/DataDog/lading/pull/861

### Motivation

The issue here lies with the fact that this test is trying to fill a 100byte block using the `json` generator, however the json generator randomly generates messages, so if they are too big, it simply tries again.
The threshold for "trying again" is quite low and therefore this issue is hit regularly with a 100byte block.

Increasing the block size to 1000 preserves the intent of the test while recognizing that small blocks are hard to generate JSON for.

### Related issues



### Additional Notes

