### PR TITLE
SMPTNG-83: Removes shim for now-standard lib func

### DIFF
--- a/lading_payload/src/lib.rs
+++ b/lading_payload/src/lib.rs
@@ -194,25 +194,6 @@ impl Serialize for Payload {
     }
 }
 
-/// Calculates the quotient of `lhs` and `rhs`, rounding the result towards
-/// positive infinity.
-///
-/// Adapted from rustc `int_roundings` implementation. Replace upon
-/// stabilization: <https://github.com/rust-lang/rust/issues/88581>
-///
-/// # Panics
-///
-/// This function will panic if `rhs` is 0 or the division results in overflow.
-const fn div_ceil(lhs: usize, rhs: usize) -> usize {
-    let d = lhs / rhs;
-    let r = lhs % rhs;
-    if r > 0 && rhs > 0 {
-        d + 1
-    } else {
-        d
-    }
-}
-
 /// Generate instance of `I` from source of randomness `S`.
 pub(crate) trait Generator<'a> {
     type Output: 'a;

--- a/lading_payload/src/opentelemetry_log.rs
+++ b/lading_payload/src/opentelemetry_log.rs
@@ -103,7 +103,7 @@ impl crate::Serialize for OpentelemetryLogs {
         // An Export*ServiceRequest message has 5 bytes of fixed values plus
         // a varint-encoded message length field. The worst case for the message
         // length field is the max message size divided by 0x7F.
-        let bytes_remaining = max_bytes.checked_sub(5 + super::div_ceil(max_bytes, 0x7F));
+        let bytes_remaining = max_bytes.checked_sub(5 + max_bytes.div_ceil(0x7F));
         let Some(mut bytes_remaining) = bytes_remaining else {
             return Ok(());
         };

--- a/lading_payload/src/opentelemetry_metric.rs
+++ b/lading_payload/src/opentelemetry_metric.rs
@@ -174,7 +174,7 @@ impl crate::Serialize for OpentelemetryMetrics {
         // An Export*ServiceRequest message has 5 bytes of fixed values plus
         // a varint-encoded message length field. The worst case for the message
         // length field is the max message size divided by 0x7F.
-        let bytes_remaining = max_bytes.checked_sub(5 + super::div_ceil(max_bytes, 0x7F));
+        let bytes_remaining = max_bytes.checked_sub(5 + max_bytes.div_ceil(0x7F));
         let Some(mut bytes_remaining) = bytes_remaining else {
             return Ok(());
         };

--- a/lading_payload/src/opentelemetry_trace.rs
+++ b/lading_payload/src/opentelemetry_trace.rs
@@ -112,7 +112,7 @@ impl crate::Serialize for OpentelemetryTraces {
         // An Export*ServiceRequest message has 5 bytes of fixed values plus
         // a varint-encoded message length field. The worst case for the message
         // length field is the max message size divided by 0x7F.
-        let bytes_remaining = max_bytes.checked_sub(5 + super::div_ceil(max_bytes, 0x7F));
+        let bytes_remaining = max_bytes.checked_sub(5 + max_bytes.div_ceil(0x7F));
         let Some(mut bytes_remaining) = bytes_remaining else {
             return Ok(());
         };


### PR DESCRIPTION
### What does this PR do?


### Motivation


### Related issues



### Additional Notes

