### PR TITLE
capture_manager: avoid overflow via saturating sub

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Increased maximum DogStatsD context limit from 100k to 1M
 ### Fixed
+- The capture manager will no longer panic if recording a capture and checking for a shutdown combined takes longer than one second.
 
 ## [0.20.10]
 ### Added

--- a/lading/src/captures.rs
+++ b/lading/src/captures.rs
@@ -207,7 +207,7 @@ impl CaptureManager {
                 }
                 // Sleep for 1 second minus however long we just spent recording captures
                 // assumption here is that the time spent recording captures is consistent
-                std::thread::sleep(Duration::from_secs(1) - now.elapsed());
+                std::thread::sleep(Duration::from_secs(1).saturating_sub(now.elapsed()));
             })?;
         Ok(())
     }

--- a/lading/src/captures.rs
+++ b/lading/src/captures.rs
@@ -207,7 +207,12 @@ impl CaptureManager {
                 }
                 // Sleep for 1 second minus however long we just spent recording captures
                 // assumption here is that the time spent recording captures is consistent
-                std::thread::sleep(Duration::from_secs(1).saturating_sub(now.elapsed()));
+                let delta = now.elapsed();
+                if delta > Duration::from_secs(1) {
+                    warn!("Recording capture took more than 1s (took {delta:?})");
+                    continue;
+                }
+                std::thread::sleep(Duration::from_secs(1).saturating_sub(delta));
             })?;
         Ok(())
     }


### PR DESCRIPTION
### What does this PR do?

When `now.elapsed()` is greater than 1 second In the capture manager's call to `std::thread::sleep`, the subtraction within that call will panic with an overflow. Using a saturating subtraction should clamp negative values to zero, thus preventing such an overflow.

### Motivation

Prevent panics in the capture manager.

### Related issues

SMPTNG-317.

### Additional Notes

The log line that precipitated this investigation was

```
05:48:42 CET | service:docker
thread 'capture-manager' panicked at /rustc/82e1608dfa6e0b5569232559e3d385fea5a93112/library/core/src/time.rs:933:31:
```

See https://github.com/rust-lang/rust/blob/82e1608dfa6e0b5569232559e3d385fea5a93112/library/core/src/time.rs#L927-L935 for the code snippet in the Rust standard library that emits the panic.
