### PR TITLE
Capture manager should check shutdown before attempting to record captures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Increased maximum DogStatsD context limit from 100k to 1M
 ### Fixed
 - The capture manager will no longer panic if recording a capture and checking for a shutdown combined takes longer than one second.
-- A shutdown race was fixed in the capture manager which could result in truncated (invalid) json capture files.
+- A shutdown race was partially fixed in the capture manager which could result in truncated (invalid) json capture files.
 
 ## [0.20.10]
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Increased maximum DogStatsD context limit from 100k to 1M
 ### Fixed
 - The capture manager will no longer panic if recording a capture and checking for a shutdown combined takes longer than one second.
+- A shutdown race was fixed in the capture manager which could result in truncated (invalid) json capture files.
 
 ## [0.20.10]
 ### Added

--- a/lading/src/captures.rs
+++ b/lading/src/captures.rs
@@ -194,6 +194,7 @@ impl CaptureManager {
             .name("capture-manager".into())
             .spawn(move || loop {
                 if self.shutdown.try_recv() {
+                    // TODO - see SMPTNG-340 for details about more synchronization needed here
                     info!("shutdown signal received");
                     return;
                 }

--- a/lading/src/captures.rs
+++ b/lading/src/captures.rs
@@ -193,6 +193,10 @@ impl CaptureManager {
         std::thread::Builder::new()
             .name("capture-manager".into())
             .spawn(move || loop {
+                if self.shutdown.try_recv() {
+                    info!("shutdown signal received");
+                    return;
+                }
                 let now = Instant::now();
                 if let Err(e) = self.record_captures() {
                     warn!(
@@ -201,10 +205,6 @@ impl CaptureManager {
                     );
                 }
                 self.fetch_index += 1;
-                if self.shutdown.try_recv() {
-                    info!("shutdown signal received");
-                    return;
-                }
                 // Sleep for 1 second minus however long we just spent recording captures
                 // assumption here is that the time spent recording captures is consistent
                 let delta = now.elapsed();


### PR DESCRIPTION
### What does this PR do?

Addresses a shutdown race that can occur where `record_captures` is called incorrectly after the experiment has shut down.
This can result in truncated `capture.json` result files.

### Motivation

Fixing a bug in capture writing.

### Related issues



### Additional Notes

