### PR TITLE
Increase logging in Linux observer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+
+## [0.20.11-rc0]
 ### Added
 ### Changed
 - Increased maximum DogStatsD context limit from 100k to 1M

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 ### Changed
 - Increased maximum DogStatsD context limit from 100k to 1M
+- Increased logging from Linux observer mechanism
 ### Fixed
 - The capture manager will no longer panic if recording a capture and checking for a shutdown combined takes longer than one second.
 - A shutdown race was partially fixed in the capture manager which could result in truncated (invalid) json capture files.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1166,7 +1166,7 @@ dependencies = [
 
 [[package]]
 name = "lading"
-version = "0.20.10"
+version = "0.20.11-rc0"
 dependencies = [
  "async-pidfd",
  "average",

--- a/lading/Cargo.toml
+++ b/lading/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lading"
-version = "0.20.10"
+version = "0.20.11-rc0"
 authors = [
     "Brian L. Troutwine <brian.troutwine@datadoghq.com>",
     "George Hahn <george.hahn@datadoghq.com>",

--- a/lading/src/observer/linux.rs
+++ b/lading/src/observer/linux.rs
@@ -5,7 +5,7 @@ use metrics::{gauge, register_gauge};
 use nix::errno::Errno;
 use procfs::process::Process;
 use rustc_hash::{FxHashMap, FxHashSet};
-use tracing::{info, warn};
+use tracing::{debug, info, warn};
 
 use crate::observer::memory::{Regions, Rollup};
 
@@ -139,7 +139,7 @@ impl Sampler {
         let mut pids: FxHashSet<i32> = FxHashSet::default();
         let mut processes: VecDeque<Process> = VecDeque::with_capacity(16); // an arbitrary smallish number
         if !self.parent.is_alive() {
-            return Err(Error::ParentDied(self.parent));
+            return Err(Error::ParentDied(self.parent.pid()));
         }
         processes.push_back(Process::new(self.parent.pid())?);
         while let Some(process) = processes.pop_back() {
@@ -156,7 +156,7 @@ impl Sampler {
                         debug!(
                             "Discovered {n} children for PID {parent}",
                             n = children.len(),
-                            parent = self.parent
+                            parent = self.parent.pid()
                         );
                         for child in children
                             .drain(..)


### PR DESCRIPTION
### What does this PR do?

In cases where the observer does not function as expected we lack information needed to debug the problem. This commit is intended to increase the logging information we produce, potentially being chased by further improvements in the near term.
