### PR TITLE
Streaming is the default block mechanism

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+
+## [0.21.0-rc0]
 ### Added
 ### Changed
 - Maximum datagram size in bytes for unix datagram generator is 8,192.
+- Altered default cache construction from 'fixed' to 'streaming'
 - Increased maximum DogStatsD context limit from 100k to 1M
 - Procfs generator now generates process names as long as 254 characters, up from 253.
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
-## [0.21.0-rc0]
+## [0.21.0-rc1]
 ### Added
 ### Changed
 - Maximum datagram size in bytes for unix datagram generator is 8,192.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1174,7 +1174,7 @@ dependencies = [
 
 [[package]]
 name = "lading"
-version = "0.20.10"
+version = "0.21.0-rc0"
 dependencies = [
  "async-pidfd",
  "average",

--- a/integration/sheepdog/src/lib.rs
+++ b/integration/sheepdog/src/lib.rs
@@ -352,6 +352,7 @@ generator:
           post:
             maximum_prebuild_cache_size_bytes: "8 Mb"
             variant: "apache_common"
+            block_cache_method: Fixed
         "#,
         )?;
 
@@ -387,6 +388,7 @@ generator:
           post:
             maximum_prebuild_cache_size_bytes: "8 Mb"
             variant: "ascii"
+            block_cache_method: Fixed
         "#,
         )?;
 

--- a/integration/sheepdog/src/lib.rs
+++ b/integration/sheepdog/src/lib.rs
@@ -133,8 +133,8 @@ impl IntegrationTest {
             lading_config_template: lading_config.to_string(),
             ducks_config,
             tempdir,
-            experiment_duration: Duration::from_secs(1),
-            experiment_warmup: Duration::from_secs(0),
+            experiment_duration: Duration::from_secs(60),
+            experiment_warmup: Duration::from_secs(10),
         })
     }
 

--- a/integration/sheepdog/src/lib.rs
+++ b/integration/sheepdog/src/lib.rs
@@ -423,6 +423,7 @@ generator:
           post:
             maximum_prebuild_cache_size_bytes: "8 Mb"
             variant: "opentelemetry_logs"
+            block_cache_method: Fixed
         headers:
             Content-Type: "application/x-protobuf"
         "#,
@@ -459,6 +460,7 @@ generator:
           post:
             maximum_prebuild_cache_size_bytes: "8 Mb"
             variant: "opentelemetry_traces"
+            block_cache_method: Fixed
         headers:
             Content-Type: "application/x-protobuf"
         "#,
@@ -495,6 +497,7 @@ generator:
           post:
             maximum_prebuild_cache_size_bytes: "8 Mb"
             variant: "opentelemetry_metrics"
+            block_cache_method: Fixed
         headers:
             Content-Type: "application/x-protobuf"
         "#,

--- a/lading/Cargo.toml
+++ b/lading/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lading"
-version = "0.20.10"
+version = "0.21.0-rc0"
 authors = [
     "Brian L. Troutwine <brian.troutwine@datadoghq.com>",
     "George Hahn <george.hahn@datadoghq.com>",

--- a/lading/src/config.rs
+++ b/lading/src/config.rs
@@ -137,7 +137,7 @@ blackhole:
                                 8_f64,
                                 byte_unit::ByteUnit::MB
                             )?,
-                            block_cache_method: block::CacheMethod::Fixed,
+                            block_cache_method: block::CacheMethod::Streaming,
                         },
                         headers: HeaderMap::default(),
                         bytes_per_second: byte_unit::Byte::from_unit(

--- a/lading_payload/src/block.rs
+++ b/lading_payload/src/block.rs
@@ -117,7 +117,7 @@ pub enum CacheMethod {
 /// The default cache method.
 #[must_use]
 pub fn default_cache_method() -> CacheMethod {
-    CacheMethod::Fixed
+    CacheMethod::Streaming
 }
 
 #[derive(Debug)]


### PR DESCRIPTION
### What does this PR do?

This commit adjusts the default block mechanism to be 'streaming' rather than
fixed. This resolves a problem where blocks -- needed to feed the throttle --
may not always sum up to the pre-constructed size that users configure.

REF [SMPTNG-356](https://datadoghq.atlassian.net/browse/SMPTNG-356)


[SMPTNG-356]: https://datadoghq.atlassian.net/browse/SMPTNG-356?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ