### PR TITLE
Do not shear datagrams

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - The capture manager will no longer panic if recording a capture and checking for a shutdown combined takes longer than one second.
 - A shutdown race was partially fixed in the capture manager which could result in truncated (invalid) json capture files.
-- Unix datagram generator will not longer 'sheer' blocks across datagrams.
+- Unix datagram generator will not longer 'shear' blocks across datagrams.
 
 ## [0.20.10]
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 ### Added
 ### Changed
+- Maximum datagram size in bytes for unix datagram generator is 8,192.
 - Increased maximum DogStatsD context limit from 100k to 1M
 ### Fixed
 - The capture manager will no longer panic if recording a capture and checking for a shutdown combined takes longer than one second.
 - A shutdown race was partially fixed in the capture manager which could result in truncated (invalid) json capture files.
+- Unix datagram generator will not longer 'sheer' blocks across datagrams.
 
 ## [0.20.10]
 ### Added

--- a/lading/src/generator/unix_datagram.rs
+++ b/lading/src/generator/unix_datagram.rs
@@ -254,7 +254,7 @@ impl Child {
                     // NOTE When we write into a unix socket it may be that only
                     // some of the written bytes make it through in which case
                     // we DO NOT cycle back around and try to write the
-                    // remainder of the buffer. To do so would be to sheer the
+                    // remainder of the buffer. To do so would be to shear the
                     // block across multiple datagrams which we cannot do
                     // without cooperation of the client, which we are not
                     // guaranteed.

--- a/lading_payload/src/block.rs
+++ b/lading_payload/src/block.rs
@@ -785,10 +785,17 @@ pub fn get_blocks(
 /// - Panics if a block size is zero
 pub fn default_blocks() -> Vec<NonZeroU32> {
     [
-        byte_unit::Byte::from_unit(1.0 / 32.0, byte_unit::ByteUnit::MB).expect("valid bytes"),
-        byte_unit::Byte::from_unit(1.0 / 16.0, byte_unit::ByteUnit::MB).expect("valid bytes"),
-        byte_unit::Byte::from_unit(1.0 / 4.0, byte_unit::ByteUnit::MB).expect("valid bytes"),
-        byte_unit::Byte::from_unit(1.0 / 2.0, byte_unit::ByteUnit::MB).expect("valid bytes"),
+        // KB
+        byte_unit::Byte::from_unit(1f64, byte_unit::ByteUnit::KB).expect("valid bytes"),
+        byte_unit::Byte::from_unit(2f64, byte_unit::ByteUnit::KB).expect("valid bytes"),
+        byte_unit::Byte::from_unit(4f64, byte_unit::ByteUnit::KB).expect("valid bytes"),
+        byte_unit::Byte::from_unit(8f64, byte_unit::ByteUnit::KB).expect("valid bytes"),
+        byte_unit::Byte::from_unit(16f64, byte_unit::ByteUnit::KB).expect("valid bytes"),
+        byte_unit::Byte::from_unit(32f64, byte_unit::ByteUnit::KB).expect("valid bytes"),
+        byte_unit::Byte::from_unit(64f64, byte_unit::ByteUnit::KB).expect("valid bytes"),
+        byte_unit::Byte::from_unit(256f64, byte_unit::ByteUnit::KB).expect("valid bytes"),
+        byte_unit::Byte::from_unit(512f64, byte_unit::ByteUnit::KB).expect("valid bytes"),
+        // MB
         byte_unit::Byte::from_unit(1.0, byte_unit::ByteUnit::MB).expect("valid bytes"),
         byte_unit::Byte::from_unit(2.0, byte_unit::ByteUnit::MB).expect("valid bytes"),
         byte_unit::Byte::from_unit(4.0, byte_unit::ByteUnit::MB).expect("valid bytes"),


### PR DESCRIPTION
### What does this PR do?

This commit avoids shearing Unix datagrams if they are not able to transmit in one shot. Likewise we limit the size of each datagram to 8,192 bytes, received wisdom from Datadog Agent.

### Related issues

REF SMPTNG-356
