### PR TITLE
procfs generator: wrap `comm` in parens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Maximum datagram size in bytes for unix datagram generator is 8,192.
 - Increased maximum DogStatsD context limit from 100k to 1M
+- Procfs generator now generates process names as long as 254 characters, up from 253.
 ### Fixed
 - The capture manager will no longer panic if recording a capture and checking for a shutdown combined takes longer than one second.
 - A shutdown race was partially fixed in the capture manager which could result in truncated (invalid) json capture files.
 - Unix datagram generator will not longer 'shear' blocks across datagrams.
+- Procfs generator now generates `pid/stat` files with `comm` in parens, matching Linux behavior.
 
 ## [0.20.10]
 ### Added

--- a/lading_payload/src/procfs.rs
+++ b/lading_payload/src/procfs.rs
@@ -1683,7 +1683,7 @@ impl<'a> Generator<'a> for ProcessGenerator {
     {
         // For simplicity, assume the command line is a single string consisting
         // of a single path component and no arguments.
-        let cmdline_size: usize = rng.gen_range(1..NAME_MAX); // is this range off by one?
+        let cmdline_size: usize = rng.gen_range(1..=NAME_MAX);
 
         // SAFETY: If this call fails, then execution should panic because an
         // inability to generate process command lines is a serious bug.

--- a/lading_payload/src/procfs.rs
+++ b/lading_payload/src/procfs.rs
@@ -1392,7 +1392,7 @@ impl fmt::Display for Stat {
         write!(
             f,
             concat!(
-                "{pid} {comm} {state} {ppid} {pgrp} ",
+                "{pid} ({comm}) {state} {ppid} {pgrp} ",
                 "{session} {tty_nr} {tpgid} {flags} {minflt} ",
                 "{cminflt} {majflt} {cmajflt} {utime} {stime} ",
                 "{cutime} {cstime} {priority} {nice} {num_threads} ",
@@ -1683,7 +1683,7 @@ impl<'a> Generator<'a> for ProcessGenerator {
     {
         // For simplicity, assume the command line is a single string consisting
         // of a single path component and no arguments.
-        let cmdline_size: usize = rng.gen_range(1..NAME_MAX);
+        let cmdline_size: usize = rng.gen_range(1..NAME_MAX); // is this range off by one?
 
         // SAFETY: If this call fails, then execution should panic because an
         // inability to generate process command lines is a serious bug.


### PR DESCRIPTION
### What does this PR do?

Bugfix for the procfs generator - the `comm` field should be wrapped in parenthesis.

From the manpage:

/proc/pid/stat
...
(2) comm  %s
The filename of the executable, in parentheses. Strings longer than TASK_COMM_LEN (16) characters (including the terminating null byte) are silently truncated.  This is visible whether or not the executable is swapped out.

### Related issues

https://github.com/DataDog/smp-dogfooding/pull/13#issuecomment-2025938017

### Additional notes

It's unclear how the process agent experiments have functioned at all - this bug will reliably crash the gopsutil code. It seems likely there's a race condition or some unexpected logic that allows process agent experiments to pass enough of the time for jobs to pass. (It could also indicate something incorrect in the SMP system.)