### PR TITLE
Allow peers to signal Phase hold

### DIFF
--- a/lading/src/bin/lading.rs
+++ b/lading/src/bin/lading.rs
@@ -489,7 +489,7 @@ async fn inner_main(
             },
         }
     };
-    drop(shutdown);
+    shutdown.wait_for_peers().await;
     res
 }
 

--- a/lading/src/captures.rs
+++ b/lading/src/captures.rs
@@ -196,7 +196,6 @@ impl CaptureManager {
                 let token = self.shutdown.register();
                 loop {
                     if self.shutdown.try_recv() {
-                        // TODO - see SMPTNG-340 for details about more synchronization needed here
                         info!("shutdown signal received");
                         drop(token);
                         return;

--- a/lading/src/signals.rs
+++ b/lading/src/signals.rs
@@ -29,7 +29,7 @@ pub struct Phase {
     /// The mechanism by which we will 'ack' receipt of phase change to the `Phase` creator.
     ack_sem: Arc<Semaphore>,
 
-    /// The total number of peers, incremented only by `clone`.
+    /// The total number of peers, incremented only by `register`.
     peers: Arc<AtomicU32>,
 
     /// `true` if the current phase has been entered.
@@ -108,11 +108,11 @@ impl Phase {
         let _ = self.ack_sem.acquire_many(peers).await;
     }
 
-    /// Register with the `Phase` owner to avoid the call to `signal` from
+    /// Register with the `Phase` creator to avoid the call to `signal` from
     /// proceeding without the token returned here being dropped.
     #[tracing::instrument]
     pub fn register(&self) -> Token {
-        // Increment the peers. We are careful to to AcqRel this fetch and store
+        // Increment the peers. We are careful to AcqRel this fetch and store
         // to avoid the parent from being unable to read the correct number of
         // peers later.
         self.peers.fetch_add(1, Ordering::AcqRel);


### PR DESCRIPTION
### What does this PR do?

This commit allows peers of the `Phase` to signal to the signaler that they have not yet completed their work. We achieve this by keeping a tally of the total number of peers that have called `register` -- a new function -- and require that each peer maintain a `Token` which on drop adds permits to a new semaphore. On the signaler side if the number of peers equals the number of permits in the ack'ing semaphore all registered peers have exited.

### Related issues

REF SMPTNG-356

