### PR TITLE
More work on sheering in lading

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1354,6 +1354,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c8640c5d730cb13ebd907d8d04b52f55ac9a2eec55b440c8892f40d56c76c1d"
 
 [[package]]
+name = "memoffset"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a634b1c61a95585bd15607c6ab0c4e5b226e695ff2800ba0cdccddf208c406c"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "metrics"
 version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1507,6 +1516,7 @@ dependencies = [
  "bitflags 2.5.0",
  "cfg-if",
  "libc",
+ "memoffset",
 ]
 
 [[package]]

--- a/lading/Cargo.toml
+++ b/lading/Cargo.toml
@@ -30,7 +30,7 @@ is_executable = "1.0.1"
 metrics = { workspace = true }
 metrics-exporter-prometheus = { version = "0.12.1", default-features = false, features = ["http-listener"]}
 metrics-util = { version = "0.15" }
-nix = { version = "0.27", default-features = false, features = ["process", "signal"] }
+nix = { version = "0.27", default-features = false, features = ["process", "signal", "socket"] }
 num_cpus = { version = "1.16" }
 once_cell = { version = "1.18" }
 rand = { workspace = true, default-features = false, features = ["small_rng", "std", "std_rng" ]}

--- a/lading_payload/src/dogstatsd.rs
+++ b/lading_payload/src/dogstatsd.rs
@@ -9,7 +9,7 @@ use rand::{
     Rng,
 };
 use serde::{Deserialize, Serialize as SerdeSerialize};
-use tracing::{debug, warn};
+use tracing::{debug, trace, warn};
 
 use crate::{common::strings, Serialize};
 
@@ -725,7 +725,7 @@ impl DogStatsD {
 
         // write prefix
         writer.write_all(&length.to_le_bytes())?;
-        debug!(
+        trace!(
             "Filling block. Requested: {max_bytes} bytes. Actual: {} bytes.",
             length
         );


### PR DESCRIPTION
### What does this PR do?

Lading UDS continues to sheer datagrams which shouldn't be possible but is happening when we run with dogstatsd load. This chain of commits is an attempt to nail the problem down finally.
