### PR TITLE
Allow for dynamic block sizes in block construction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Changed
+- Improved the block cache construction to better fill the pre-defined space.
 
 ### Changed
 - Removed streaming cache method. Fixed is now the only option.

--- a/integration/sheepdog/src/lib.rs
+++ b/integration/sheepdog/src/lib.rs
@@ -346,13 +346,11 @@ generator:
         headers: {}
         target_uri: "http://localhost:{{port_number}}/"
         bytes_per_second: "100 Mb"
-        block_sizes: ["1Mb", "0.5Mb", "0.25Mb", "0.125Mb", "128Kb"]
         parallel_connections: 5
         method:
           post:
             maximum_prebuild_cache_size_bytes: "8 Mb"
             variant: "apache_common"
-            block_cache_method: Fixed
         "#,
         )?;
 
@@ -382,13 +380,11 @@ generator:
         headers: {}
         target_uri: "http://localhost:{{port_number}}/"
         bytes_per_second: "100 Mb"
-        block_sizes: ["1Mb", "0.5Mb", "0.25Mb", "0.125Mb", "128Kb"]
         parallel_connections: 5
         method:
           post:
             maximum_prebuild_cache_size_bytes: "8 Mb"
             variant: "ascii"
-            block_cache_method: Fixed
         "#,
         )?;
 
@@ -417,13 +413,11 @@ generator:
           59, 61, 67, 71, 73, 79, 83, 89, 97, 101, 103, 107, 109, 113, 127, 131]
         target_uri: "http://localhost:{{port_number}}/v1/logs"
         bytes_per_second: "100 Mb"
-        block_sizes: ["1Mb", "0.5Mb", "0.25Mb", "0.125Mb", "128Kb"]
         parallel_connections: 5
         method:
           post:
             maximum_prebuild_cache_size_bytes: "8 Mb"
             variant: "opentelemetry_logs"
-            block_cache_method: Fixed
         headers:
             Content-Type: "application/x-protobuf"
         "#,
@@ -454,13 +448,11 @@ generator:
           59, 61, 67, 71, 73, 79, 83, 89, 97, 101, 103, 107, 109, 113, 127, 131]
         target_uri: "http://localhost:{{port_number}}/v1/traces"
         bytes_per_second: "100 Mb"
-        block_sizes: ["1Mb", "0.5Mb", "0.25Mb", "0.125Mb", "128Kb"]
         parallel_connections: 5
         method:
           post:
             maximum_prebuild_cache_size_bytes: "8 Mb"
             variant: "opentelemetry_traces"
-            block_cache_method: Fixed
         headers:
             Content-Type: "application/x-protobuf"
         "#,
@@ -491,13 +483,11 @@ generator:
           59, 61, 67, 71, 73, 79, 83, 89, 97, 101, 103, 107, 109, 113, 127, 131]
         target_uri: "http://localhost:{{port_number}}/v1/metrics"
         bytes_per_second: "100 Mb"
-        block_sizes: ["1Mb", "0.5Mb", "0.25Mb", "0.125Mb", "128Kb"]
         parallel_connections: 5
         method:
           post:
             maximum_prebuild_cache_size_bytes: "8 Mb"
             variant: "opentelemetry_metrics"
-            block_cache_method: Fixed
         headers:
             Content-Type: "application/x-protobuf"
         "#,
@@ -529,7 +519,6 @@ generator:
           59, 61, 67, 71, 73, 79, 83, 89, 97, 101, 103, 107, 109, 113, 127, 131]
         addr: "127.0.0.1:{{port_number}}"
         bytes_per_second: "100 Mb"
-        block_sizes: ["1Mb", "0.5Mb", "0.25Mb", "0.125Mb", "128Kb"]
         variant: fluent
         maximum_prebuild_cache_size_bytes: "8 Mb"
         "#,
@@ -559,7 +548,6 @@ generator:
           59, 61, 67, 71, 73, 79, 83, 89, 97, 101, 103, 107, 109, 113, 127, 131]
         addr: "127.0.0.1:{{port_number}}"
         bytes_per_second: "100 Mb"
-        block_sizes: ["1Kb"]
         variant: ascii
         maximum_prebuild_cache_size_bytes: "8 Mb"
         "#,

--- a/integration/sheepdog/src/lib.rs
+++ b/integration/sheepdog/src/lib.rs
@@ -133,8 +133,8 @@ impl IntegrationTest {
             lading_config_template: lading_config.to_string(),
             ducks_config,
             tempdir,
-            experiment_duration: Duration::from_secs(60),
-            experiment_warmup: Duration::from_secs(10),
+            experiment_duration: Duration::from_secs(30),
+            experiment_warmup: Duration::from_secs(5),
         })
     }
 

--- a/lading_payload/src/block.rs
+++ b/lading_payload/src/block.rs
@@ -486,6 +486,8 @@ fn chunk_bytes<const N: usize>(
 /// would like to propagate this error to the caller.
 #[inline]
 #[tracing::instrument(skip_all)]
+#[allow(clippy::cast_possible_truncation)]
+#[allow(clippy::cast_sign_loss)]
 fn construct_block_cache_inner<R, S>(
     mut rng: &mut R,
     serializer: &S,

--- a/lading_payload/src/block.rs
+++ b/lading_payload/src/block.rs
@@ -747,6 +747,12 @@ mod test {
 
     use crate::block::{chunk_bytes, get_blocks, MAX_CHUNKS};
 
+    macro_rules! nz_u32 {
+        ($value:expr) => {
+            NonZeroU32::new($value).expect(concat!($value, " is non-zero"))
+        };
+    }
+
     #[test]
     fn construct_block_cache_inner_fills_blocks() {
         use crate::block::construct_block_cache_inner;
@@ -754,31 +760,13 @@ mod test {
 
         let mut rng = SmallRng::seed_from_u64(0);
         let block_chunks = [100, 100, 100, 200, 300];
+        let total_bytes = block_chunks.iter().sum();
         let serializer = crate::Json;
-        let block_cache = construct_block_cache_inner(&mut rng, &serializer, &block_chunks)
-            .expect("construct_block_cache_inner should not fail");
-
-        assert_eq!(block_cache.len(), block_chunks.len());
-    }
-    proptest! {
-        #[test]
-        fn construct_block_cache_inner_fills_all_blocks(seed: u64, num_chunks in 1..=4096usize) {
-            use crate::block::construct_block_cache_inner;
-            use rand::{rngs::SmallRng, SeedableRng};
-
-            let mut rng = SmallRng::seed_from_u64(seed);
-            let block_chunks = vec![1000; num_chunks];
-            let serializer = crate::Json;
-            let block_cache = construct_block_cache_inner(&mut rng, &serializer, &block_chunks)
+        let block_cache =
+            construct_block_cache_inner(&mut rng, &serializer, &block_chunks, total_bytes)
                 .expect("construct_block_cache_inner should not fail");
 
-            assert_eq!(block_cache.len(), block_chunks.len());
-        }
-    }
-    macro_rules! nz_u32 {
-        ($value:expr) => {
-            NonZeroU32::new($value).expect(concat!($value, " is non-zero"))
-        };
+        assert!(block_cache.len() != 0);
     }
 
     /// This test ensures that `chunk_bytes` will re-use block sizes if it helps reach


### PR DESCRIPTION
### What does this PR do?

This commit improves the 'pack' of our block construction by allow for dynamic block sizes based around the user-provided block sizes. The key insight here is that users don't _really_ care about the block sizes and in practice they are not obeyed: serialized blocks vary depending on the format. They're an abstraction leak. We therefore dynamically build blocks, keeping track of the minimum floor for a given serialization format and searching both 20% more and less on either size of the user-configured blocks.

