### PR TITLE
Remove streaming cache method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Changed
+- Removed streaming cache method. Fixed is now the only option.
+
 ## [0.21.0-rc1]
 ### Added
 ### Changed

--- a/lading/src/bin/payloadtool.rs
+++ b/lading/src/bin/payloadtool.rs
@@ -52,7 +52,6 @@ fn generate_and_check(
     let start = Instant::now();
     let blocks = match block::Cache::fixed(&mut rng, total_bytes, &block_sizes, config)? {
         block::Cache::Fixed { blocks, idx: _ } => blocks,
-        _ => unreachable!(),
     };
     info!("Payload generation took {:?}", start.elapsed());
     debug!("Payload: {:#?}", blocks);

--- a/lading/src/config.rs
+++ b/lading/src/config.rs
@@ -137,7 +137,7 @@ blackhole:
                                 8_f64,
                                 byte_unit::ByteUnit::MB
                             )?,
-                            block_cache_method: block::CacheMethod::Streaming,
+                            block_cache_method: block::CacheMethod::Fixed,
                         },
                         headers: HeaderMap::default(),
                         bytes_per_second: byte_unit::Byte::from_unit(

--- a/lading/src/generator/file_gen/logrotate.rs
+++ b/lading/src/generator/file_gen/logrotate.rs
@@ -163,12 +163,6 @@ impl Server {
                 NonZeroU32::new(config.maximum_prebuild_cache_size_bytes.get_bytes() as u32)
                     .ok_or(Error::Zero)?;
             let block_cache = match config.block_cache_method {
-                block::CacheMethod::Streaming => block::Cache::stream(
-                    config.seed,
-                    total_bytes,
-                    &block_sizes,
-                    config.variant.clone(),
-                )?,
                 block::CacheMethod::Fixed => {
                     block::Cache::fixed(&mut rng, total_bytes, &block_sizes, &config.variant)?
                 }

--- a/lading/src/generator/file_gen/traditional.rs
+++ b/lading/src/generator/file_gen/traditional.rs
@@ -184,12 +184,6 @@ impl Server {
                 NonZeroU32::new(config.maximum_prebuild_cache_size_bytes.get_bytes() as u32)
                     .ok_or(Error::Zero)?;
             let block_cache = match config.block_cache_method {
-                block::CacheMethod::Streaming => block::Cache::stream(
-                    config.seed,
-                    total_bytes,
-                    &block_sizes,
-                    config.variant.clone(),
-                )?,
                 block::CacheMethod::Fixed => {
                     block::Cache::fixed(&mut rng, total_bytes, &block_sizes, &config.variant)?
                 }

--- a/lading/src/generator/grpc.rs
+++ b/lading/src/generator/grpc.rs
@@ -181,12 +181,6 @@ impl Grpc {
             NonZeroU32::new(config.maximum_prebuild_cache_size_bytes.get_bytes() as u32)
                 .ok_or(Error::Zero)?;
         let block_cache = match config.block_cache_method {
-            block::CacheMethod::Streaming => block::Cache::stream(
-                config.seed,
-                total_bytes,
-                &block_sizes,
-                config.variant.clone(),
-            )?,
             block::CacheMethod::Fixed => {
                 block::Cache::fixed(&mut rng, total_bytes, &block_sizes, &config.variant)?
             }

--- a/lading/src/generator/http.rs
+++ b/lading/src/generator/http.rs
@@ -156,12 +156,6 @@ impl Http {
                     NonZeroU32::new(maximum_prebuild_cache_size_bytes.get_bytes() as u32)
                         .ok_or(Error::Zero)?;
                 let block_cache = match block_cache_method {
-                    block::CacheMethod::Streaming => block::Cache::stream(
-                        config.seed,
-                        total_bytes,
-                        &block_sizes,
-                        variant.clone(),
-                    )?,
                     block::CacheMethod::Fixed => {
                         block::Cache::fixed(&mut rng, total_bytes, &block_sizes, &variant)?
                     }

--- a/lading/src/generator/splunk_hec.rs
+++ b/lading/src/generator/splunk_hec.rs
@@ -201,9 +201,6 @@ impl SplunkHec {
             NonZeroU32::new(config.maximum_prebuild_cache_size_bytes.get_bytes() as u32)
                 .ok_or(Error::Zero)?;
         let block_cache = match config.block_cache_method {
-            block::CacheMethod::Streaming => {
-                block::Cache::stream(config.seed, total_bytes, &block_sizes, payload_config)?
-            }
             block::CacheMethod::Fixed => {
                 block::Cache::fixed(&mut rng, total_bytes, &block_sizes, &payload_config)?
             }

--- a/lading/src/generator/unix_datagram.rs
+++ b/lading/src/generator/unix_datagram.rs
@@ -149,12 +149,6 @@ impl UnixDatagram {
                 NonZeroU32::new(config.maximum_prebuild_cache_size_bytes.get_bytes() as u32)
                     .ok_or(Error::Zero)?;
             let block_cache = match config.block_cache_method {
-                block::CacheMethod::Streaming => block::Cache::stream(
-                    config.seed,
-                    total_bytes,
-                    &block_sizes,
-                    config.variant.clone(),
-                )?,
                 block::CacheMethod::Fixed => {
                     block::Cache::fixed(&mut rng, total_bytes, &block_sizes, &config.variant)?
                 }

--- a/lading/src/generator/unix_stream.rs
+++ b/lading/src/generator/unix_stream.rs
@@ -116,12 +116,6 @@ impl UnixStream {
             NonZeroU32::new(config.maximum_prebuild_cache_size_bytes.get_bytes() as u32)
                 .ok_or(Error::Zero)?;
         let block_cache = match config.block_cache_method {
-            block::CacheMethod::Streaming => block::Cache::stream(
-                config.seed,
-                total_bytes,
-                &block_sizes,
-                config.variant.clone(),
-            )?,
             block::CacheMethod::Fixed => {
                 block::Cache::fixed(&mut rng, total_bytes, &block_sizes, &config.variant)?
             }


### PR DESCRIPTION
### What does this PR do?

This commit removes the streaming cache method in favor of the line of work being pursued in #886. We introduced streaming to work around the inability of lading to pack its cache space but the downside of streaming is the race it requires between the generator -- fast -- and the payload creator itself -- slow. This race is always eventually lost by the payload creator and so streaming can never sustain its throughput goals, except at a very low level.

Sharp edge, that.
