### PR TITLE
Remove explicit blocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 ### Changed
 - Improved the block cache construction to better fill the pre-defined space.
-
-### Changed
 - Removed streaming cache method. Fixed is now the only option.
+- Users now configure a maximum block size in generators, not individual blocks.
 
 ## [0.21.0-rc1]
 ### Added

--- a/lading/src/config.rs
+++ b/lading/src/config.rs
@@ -144,7 +144,7 @@ blackhole:
                             100_f64,
                             byte_unit::ByteUnit::MB
                         )?,
-                        block_sizes: Option::default(),
+                        maximum_block_size: lading_payload::block::default_block_size(),
                         parallel_connections: 5,
                         throttle: lading_throttle::Config::default(),
                     }),

--- a/lading/src/config.rs
+++ b/lading/src/config.rs
@@ -144,7 +144,7 @@ blackhole:
                             100_f64,
                             byte_unit::ByteUnit::MB
                         )?,
-                        maximum_block_size: lading_payload::block::default_block_size(),
+                        maximum_block_size: lading_payload::block::default_maximum_block_size(),
                         parallel_connections: 5,
                         throttle: lading_throttle::Config::default(),
                     }),

--- a/lading/src/generator/file_gen/logrotate.rs
+++ b/lading/src/generator/file_gen/logrotate.rs
@@ -84,7 +84,7 @@ pub struct Config {
     /// pre-build its outputs up to the byte capacity specified here.
     maximum_prebuild_cache_size_bytes: Byte,
     /// The maximum size in bytes of the largest block in the prebuild cache.
-    #[serde(default = "lading_payload::block::default_block_size")]
+    #[serde(default = "lading_payload::block::default_maximum_block_size")]
     maximum_block_size: byte_unit::Byte,
     /// Whether to use a fixed or streaming block cache
     #[serde(default = "lading_payload::block::default_cache_method")]

--- a/lading/src/generator/file_gen/logrotate.rs
+++ b/lading/src/generator/file_gen/logrotate.rs
@@ -20,7 +20,7 @@ use std::{
     thread,
 };
 
-use byte_unit::{Byte, ByteError, ByteUnit};
+use byte_unit::{Byte, ByteError};
 use futures::future::join_all;
 use lading_throttle::Throttle;
 use metrics::{gauge, register_counter};
@@ -80,11 +80,12 @@ pub struct Config {
     pub variant: lading_payload::Config,
     /// Defines the number of bytes that written in each log file.
     bytes_per_second: Byte,
-    /// The block sizes for messages to this target
-    pub block_sizes: Option<Vec<byte_unit::Byte>>,
     /// Defines the maximum internal cache of this log target. file_gen will
     /// pre-build its outputs up to the byte capacity specified here.
     maximum_prebuild_cache_size_bytes: Byte,
+    /// The maximum size in bytes of the largest block in the prebuild cache.
+    #[serde(default = "lading_payload::block::default_block_size")]
+    maximum_block_size: byte_unit::Byte,
     /// Whether to use a fixed or streaming block cache
     #[serde(default = "lading_payload::block::default_cache_method")]
     block_cache_method: block::CacheMethod,
@@ -115,26 +116,9 @@ impl Server {
     /// Function will panic if variant is Static and the `static_path` is not
     /// set.
     #[allow(clippy::cast_possible_truncation)]
+    #[allow(clippy::needless_pass_by_value)]
     pub fn new(general: General, config: Config, shutdown: Phase) -> Result<Self, Error> {
         let mut rng = StdRng::from_seed(config.seed);
-        let block_sizes: Vec<NonZeroU32> = config
-            .block_sizes
-            .map_or(
-                vec![
-                    Byte::from_unit(1_f64, ByteUnit::MB),
-                    Byte::from_unit(2_f64, ByteUnit::MB),
-                    Byte::from_unit(4_f64, ByteUnit::MB),
-                    Byte::from_unit(8_f64, ByteUnit::MB),
-                    Byte::from_unit(16_f64, ByteUnit::MB),
-                    Byte::from_unit(32_f64, ByteUnit::MB),
-                ],
-                |sizes| sizes.iter().map(|sz| Ok(*sz)).collect::<Vec<_>>(),
-            )
-            .into_iter()
-            .collect::<Result<Vec<_>, _>>()?
-            .iter()
-            .map(|sz| NonZeroU32::new(sz.get_bytes() as u32).expect("bytes must be non-zero"))
-            .collect();
         let mut labels = vec![
             ("component".to_string(), "generator".to_string()),
             ("component_name".to_string(), "logrotate".to_string()),
@@ -163,9 +147,12 @@ impl Server {
                 NonZeroU32::new(config.maximum_prebuild_cache_size_bytes.get_bytes() as u32)
                     .ok_or(Error::Zero)?;
             let block_cache = match config.block_cache_method {
-                block::CacheMethod::Fixed => {
-                    block::Cache::fixed(&mut rng, total_bytes, &block_sizes, &config.variant)?
-                }
+                block::CacheMethod::Fixed => block::Cache::fixed(
+                    &mut rng,
+                    total_bytes,
+                    config.maximum_block_size.get_bytes(),
+                    &config.variant,
+                )?,
             };
 
             let mut basename = config.root.clone();

--- a/lading/src/generator/file_gen/traditional.rs
+++ b/lading/src/generator/file_gen/traditional.rs
@@ -99,7 +99,7 @@ pub struct Config {
     /// pre-build its outputs up to the byte capacity specified here.
     maximum_prebuild_cache_size_bytes: Byte,
     /// The maximum size in bytes of the largest block in the prebuild cache.
-    #[serde(default = "lading_payload::block::default_block_size")]
+    #[serde(default = "lading_payload::block::default_maximum_block_size")]
     maximum_block_size: byte_unit::Byte,
     /// Whether to use a fixed or streaming block cache
     #[serde(default = "lading_payload::block::default_cache_method")]

--- a/lading/src/generator/grpc.rs
+++ b/lading/src/generator/grpc.rs
@@ -73,7 +73,7 @@ pub struct Config {
     /// The maximum size in bytes of the cache of prebuilt messages
     pub maximum_prebuild_cache_size_bytes: byte_unit::Byte,
     /// The maximum size in bytes of the largest block in the prebuild cache.
-    #[serde(default = "lading_payload::block::default_block_size")]
+    #[serde(default = "lading_payload::block::default_maximum_block_size")]
     pub maximum_block_size: byte_unit::Byte,
     /// Whether to use a fixed or streaming block cache
     #[serde(default = "lading_payload::block::default_cache_method")]

--- a/lading/src/generator/http.rs
+++ b/lading/src/generator/http.rs
@@ -68,7 +68,7 @@ pub struct Config {
     /// The bytes per second to send or receive from the target
     pub bytes_per_second: byte_unit::Byte,
     /// The maximum size in bytes of the largest block in the prebuild cache.
-    #[serde(default = "lading_payload::block::default_block_size")]
+    #[serde(default = "lading_payload::block::default_maximum_block_size")]
     pub maximum_block_size: byte_unit::Byte,
     /// The total number of parallel connections to maintain
     pub parallel_connections: u16,

--- a/lading/src/generator/passthru_file.rs
+++ b/lading/src/generator/passthru_file.rs
@@ -39,7 +39,7 @@ pub struct Config {
     /// The bytes per second to send or receive from the target
     pub bytes_per_second: byte_unit::Byte,
     /// The maximum size in bytes of the largest block in the prebuild cache.
-    #[serde(default = "lading_payload::block::default_block_size")]
+    #[serde(default = "lading_payload::block::default_maximum_block_size")]
     pub maximum_block_size: byte_unit::Byte,
     /// The maximum size in bytes of the cache of prebuilt messages
     pub maximum_prebuild_cache_size_bytes: byte_unit::Byte,

--- a/lading/src/generator/passthru_file.rs
+++ b/lading/src/generator/passthru_file.rs
@@ -38,8 +38,9 @@ pub struct Config {
     pub variant: lading_payload::Config,
     /// The bytes per second to send or receive from the target
     pub bytes_per_second: byte_unit::Byte,
-    /// The block sizes for messages to this target
-    pub block_sizes: Option<Vec<byte_unit::Byte>>,
+    /// The maximum size in bytes of the largest block in the prebuild cache.
+    #[serde(default = "lading_payload::block::default_block_size")]
+    pub maximum_block_size: byte_unit::Byte,
     /// The maximum size in bytes of the cache of prebuilt messages
     pub maximum_prebuild_cache_size_bytes: byte_unit::Byte,
     /// The load throttle configuration
@@ -90,7 +91,6 @@ impl PassthruFile {
     #[allow(clippy::cast_possible_truncation)]
     pub fn new(general: General, config: &Config, shutdown: Phase) -> Result<Self, Error> {
         let mut rng = StdRng::from_seed(config.seed);
-        let block_sizes = lading_payload::block::get_blocks(&config.block_sizes, None);
         let mut labels = vec![
             ("component".to_string(), "generator".to_string()),
             ("component_name".to_string(), "passthru_file".to_string()),
@@ -111,7 +111,7 @@ impl PassthruFile {
             &mut rng,
             NonZeroU32::new(config.maximum_prebuild_cache_size_bytes.get_bytes() as u32)
                 .ok_or(Error::Zero)?,
-            &block_sizes,
+            config.maximum_block_size.get_bytes(),
             &config.variant,
         )?;
 

--- a/lading/src/generator/splunk_hec.rs
+++ b/lading/src/generator/splunk_hec.rs
@@ -78,7 +78,7 @@ pub struct Config {
     /// The maximum size in bytes of the cache of prebuilt messages
     pub maximum_prebuild_cache_size_bytes: byte_unit::Byte,
     /// The maximum size in bytes of the largest block in the prebuild cache.
-    #[serde(default = "lading_payload::block::default_block_size")]
+    #[serde(default = "lading_payload::block::default_maximum_block_size")]
     pub maximum_block_size: byte_unit::Byte,
     /// Whether to use a fixed or streaming block cache
     #[serde(default = "lading_payload::block::default_cache_method")]

--- a/lading/src/generator/tcp.rs
+++ b/lading/src/generator/tcp.rs
@@ -42,8 +42,9 @@ pub struct Config {
     pub variant: lading_payload::Config,
     /// The bytes per second to send or receive from the target
     pub bytes_per_second: byte_unit::Byte,
-    /// The block sizes for messages to this target
-    pub block_sizes: Option<Vec<byte_unit::Byte>>,
+    /// The maximum size in bytes of the largest block in the prebuild cache.
+    #[serde(default = "lading_payload::block::default_block_size")]
+    pub maximum_block_size: byte_unit::Byte,
     /// The maximum size in bytes of the cache of prebuilt messages
     pub maximum_prebuild_cache_size_bytes: byte_unit::Byte,
     /// The load throttle configuration
@@ -94,7 +95,6 @@ impl Tcp {
     #[allow(clippy::cast_possible_truncation)]
     pub fn new(general: General, config: &Config, shutdown: Phase) -> Result<Self, Error> {
         let mut rng = StdRng::from_seed(config.seed);
-        let block_sizes = lading_payload::block::get_blocks(&config.block_sizes, None);
         let mut labels = vec![
             ("component".to_string(), "generator".to_string()),
             ("component_name".to_string(), "tcp".to_string()),
@@ -115,7 +115,7 @@ impl Tcp {
             &mut rng,
             NonZeroU32::new(config.maximum_prebuild_cache_size_bytes.get_bytes() as u32)
                 .ok_or(Error::Zero)?,
-            &block_sizes,
+            config.maximum_block_size.get_bytes(),
             &config.variant,
         )?;
 

--- a/lading/src/generator/tcp.rs
+++ b/lading/src/generator/tcp.rs
@@ -43,7 +43,7 @@ pub struct Config {
     /// The bytes per second to send or receive from the target
     pub bytes_per_second: byte_unit::Byte,
     /// The maximum size in bytes of the largest block in the prebuild cache.
-    #[serde(default = "lading_payload::block::default_block_size")]
+    #[serde(default = "lading_payload::block::default_maximum_block_size")]
     pub maximum_block_size: byte_unit::Byte,
     /// The maximum size in bytes of the cache of prebuilt messages
     pub maximum_prebuild_cache_size_bytes: byte_unit::Byte,

--- a/lading/src/generator/udp.rs
+++ b/lading/src/generator/udp.rs
@@ -98,11 +98,6 @@ impl Udp {
     #[allow(clippy::cast_possible_truncation)]
     pub fn new(general: General, config: &Config, shutdown: Phase) -> Result<Self, Error> {
         let mut rng = StdRng::from_seed(config.seed);
-        let block_size_limit =
-            byte_unit::Byte::from_unit(UDP_PACKET_LIMIT_BYTES.into(), byte_unit::ByteUnit::B)
-                .expect("valid bytes");
-        let block_sizes =
-            lading_payload::block::get_blocks(&config.block_sizes, Some(block_size_limit));
         let mut labels = vec![
             ("component".to_string(), "generator".to_string()),
             ("component_name".to_string(), "udp".to_string()),
@@ -123,7 +118,7 @@ impl Udp {
             &mut rng,
             NonZeroU32::new(config.maximum_prebuild_cache_size_bytes.get_bytes() as u32)
                 .ok_or(Error::Zero)?,
-            &block_sizes,
+            UDP_PACKET_LIMIT_BYTES.into(),
             &config.variant,
         )?;
 

--- a/lading/src/generator/unix_stream.rs
+++ b/lading/src/generator/unix_stream.rs
@@ -36,10 +36,11 @@ pub struct Config {
     pub variant: lading_payload::Config,
     /// The bytes per second to send or receive from the target
     pub bytes_per_second: byte_unit::Byte,
-    /// The block sizes for messages to this target
-    pub block_sizes: Option<Vec<byte_unit::Byte>>,
     /// The maximum size in bytes of the cache of prebuilt messages
     pub maximum_prebuild_cache_size_bytes: byte_unit::Byte,
+    /// The maximum size in bytes of the largest block in the prebuild cache.
+    #[serde(default = "lading_payload::block::default_block_size")]
+    pub maximum_block_size: byte_unit::Byte,
     /// Whether to use a fixed or streaming block cache
     #[serde(default = "lading_payload::block::default_cache_method")]
     pub block_cache_method: block::CacheMethod,
@@ -95,7 +96,6 @@ impl UnixStream {
     #[allow(clippy::cast_possible_truncation)]
     pub fn new(general: General, config: Config, shutdown: Phase) -> Result<Self, Error> {
         let mut rng = StdRng::from_seed(config.seed);
-        let block_sizes = lading_payload::block::get_blocks(&config.block_sizes, None);
         let mut labels = vec![
             ("component".to_string(), "generator".to_string()),
             ("component_name".to_string(), "unix_stream".to_string()),
@@ -116,9 +116,12 @@ impl UnixStream {
             NonZeroU32::new(config.maximum_prebuild_cache_size_bytes.get_bytes() as u32)
                 .ok_or(Error::Zero)?;
         let block_cache = match config.block_cache_method {
-            block::CacheMethod::Fixed => {
-                block::Cache::fixed(&mut rng, total_bytes, &block_sizes, &config.variant)?
-            }
+            block::CacheMethod::Fixed => block::Cache::fixed(
+                &mut rng,
+                total_bytes,
+                config.maximum_block_size.get_bytes(),
+                &config.variant,
+            )?,
         };
 
         Ok(Self {

--- a/lading/src/generator/unix_stream.rs
+++ b/lading/src/generator/unix_stream.rs
@@ -39,7 +39,7 @@ pub struct Config {
     /// The maximum size in bytes of the cache of prebuilt messages
     pub maximum_prebuild_cache_size_bytes: byte_unit::Byte,
     /// The maximum size in bytes of the largest block in the prebuild cache.
-    #[serde(default = "lading_payload::block::default_block_size")]
+    #[serde(default = "lading_payload::block::default_maximum_block_size")]
     pub maximum_block_size: byte_unit::Byte,
     /// Whether to use a fixed or streaming block cache
     #[serde(default = "lading_payload::block::default_cache_method")]

--- a/lading_payload/src/block.rs
+++ b/lading_payload/src/block.rs
@@ -129,7 +129,7 @@ pub fn default_cache_method() -> CacheMethod {
 ///
 /// Function will only panic if there is a serious programming mistake.
 #[must_use]
-pub fn default_block_size() -> Byte {
+pub fn default_maximum_block_size() -> Byte {
     Byte::from_unit(1f64, ByteUnit::MiB).expect("should not fail")
 }
 

--- a/lading_payload/src/block.rs
+++ b/lading_payload/src/block.rs
@@ -7,13 +7,12 @@
 //! -- are created.
 use std::num::NonZeroU32;
 
+use byte_unit::{Byte, ByteUnit};
 use bytes::{buf::Writer, BufMut, Bytes, BytesMut};
 use rand::Rng;
 use serde::{Deserialize, Serialize};
 use tokio::sync::mpsc::{error::SendError, Sender};
 use tracing::{error, info, span, warn, Level};
-
-const MAX_CHUNKS: usize = 16_384;
 
 /// Error for `Cache::spin`
 #[derive(Debug, thiserror::Error)]
@@ -62,6 +61,9 @@ pub enum Error {
     /// Error for crate deserialization
     #[error("Deserialization error: {0}")]
     Deserialize(#[from] crate::Error),
+    /// User provided maximum block size is too large.
+    #[error("User provided maximum block size is too large.")]
+    MaximumBlock,
     /// See [`SpinError`]
     #[error(transparent)]
     Spin(#[from] SpinError),
@@ -121,6 +123,16 @@ pub fn default_cache_method() -> CacheMethod {
     CacheMethod::Fixed
 }
 
+/// The default block maximum size.
+///
+/// # Panics
+///
+/// Function will only panic if there is a serious programming mistake.
+#[must_use]
+pub fn default_block_size() -> Byte {
+    Byte::from_unit(1f64, ByteUnit::MiB).expect("should not fail")
+}
+
 #[derive(Debug)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 /// A mechanism for streaming byte blobs, 'blocks'
@@ -147,27 +159,31 @@ impl Cache {
     /// Construct a `Cache` of fixed size.
     ///
     /// This constructor makes an internal pool of `Block` instances up to
-    /// `total_bytes`, each of which are roughly the size of one of the
-    /// `block_byte_sizes`. Internally, `Blocks` are looped over in a
-    /// round-robin during peeking, iteration.
+    /// `total_bytes`, each of which are no larger than `maximum_block_bytes`.
     ///
     /// # Errors
     ///
-    /// Function will return an error if `block_byte_sizes` is empty or if a member
-    /// of `block_byte_sizes` is large than `total_bytes`.
+    /// Function will return an error if `maximum_block_bytes` is greater than
+    /// `u32::MAX` or if it is larger than `total_bytes`.
     #[allow(clippy::too_many_lines)]
+    #[allow(clippy::cast_possible_truncation)]
     pub fn fixed<R>(
         mut rng: &mut R,
         total_bytes: NonZeroU32,
-        block_byte_sizes: &[NonZeroU32],
+        maximum_block_bytes: u128,
         payload: &crate::Config,
     ) -> Result<Self, Error>
     where
         R: Rng + ?Sized,
     {
-        let mut block_chunks: [u32; MAX_CHUNKS] = [0; MAX_CHUNKS];
-        let total_chunks = chunk_bytes(total_bytes, block_byte_sizes, &mut block_chunks)?;
-        let block_chunks = block_chunks[..total_chunks].to_vec();
+        let maximum_block_bytes = if (maximum_block_bytes > u32::MAX.into())
+            || (maximum_block_bytes > total_bytes.get().into())
+        {
+            return Err(Error::MaximumBlock);
+        } else {
+            maximum_block_bytes as u32
+        };
+
         let blocks = match payload {
             crate::Config::TraceAgent(enc) => {
                 let ta = match enc {
@@ -175,29 +191,19 @@ impl Cache {
                     crate::Encoding::MsgPack => crate::TraceAgent::msg_pack(&mut rng),
                 };
 
-                let span = span!(
-                    Level::INFO,
-                    "fixed",
-                    max_chunks = total_chunks,
-                    payload = "trace-agent"
-                );
+                let span = span!(Level::INFO, "fixed", payload = "trace-agent");
                 let _guard = span.enter();
 
-                construct_block_cache_inner(&mut rng, &ta, &block_chunks, total_bytes.get())?
+                construct_block_cache_inner(&mut rng, &ta, maximum_block_bytes, total_bytes.get())?
             }
             crate::Config::Syslog5424 => {
-                let span = span!(
-                    Level::INFO,
-                    "fixed",
-                    max_chunks = total_chunks,
-                    payload = "syslog5424"
-                );
+                let span = span!(Level::INFO, "fixed", payload = "syslog5424");
                 let _guard = span.enter();
 
                 construct_block_cache_inner(
                     &mut rng,
                     &crate::Syslog5424::default(),
-                    &block_chunks,
+                    maximum_block_bytes,
                     total_bytes.get(),
                 )?
             }
@@ -211,147 +217,107 @@ impl Cache {
                 }
                 let serializer = crate::DogStatsD::new(*conf, &mut rng)?;
 
-                let span = span!(
-                    Level::INFO,
-                    "fixed",
-                    max_chunks = total_chunks,
-                    payload = "dogstatsd"
-                );
+                let span = span!(Level::INFO, "fixed", payload = "dogstatsd");
                 let _guard = span.enter();
 
                 construct_block_cache_inner(
                     &mut rng,
                     &serializer,
-                    &block_chunks,
+                    maximum_block_bytes,
                     total_bytes.get(),
                 )?
             }
             crate::Config::Fluent => {
                 let pyld = crate::Fluent::new(&mut rng);
-                let span = span!(
-                    Level::INFO,
-                    "fixed",
-                    max_chunks = total_chunks,
-                    payload = "fluent"
-                );
+                let span = span!(Level::INFO, "fixed", payload = "fluent");
                 let _guard = span.enter();
-                construct_block_cache_inner(&mut rng, &pyld, &block_chunks, total_bytes.get())?
+                construct_block_cache_inner(
+                    &mut rng,
+                    &pyld,
+                    maximum_block_bytes,
+                    total_bytes.get(),
+                )?
             }
             crate::Config::SplunkHec { encoding } => {
-                let span = span!(
-                    Level::INFO,
-                    "fixed",
-                    max_chunks = total_chunks,
-                    payload = "splunkHec"
-                );
+                let span = span!(Level::INFO, "fixed", payload = "splunkHec");
                 let _guard = span.enter();
                 construct_block_cache_inner(
                     &mut rng,
                     &crate::SplunkHec::new(*encoding),
-                    &block_chunks,
+                    maximum_block_bytes,
                     total_bytes.get(),
                 )?
             }
             crate::Config::ApacheCommon => {
                 let pyld = crate::ApacheCommon::new(&mut rng);
-                let span = span!(
-                    Level::INFO,
-                    "fixed",
-                    max_chunks = total_chunks,
-                    payload = "apache-common"
-                );
+                let span = span!(Level::INFO, "fixed", payload = "apache-common");
                 let _guard = span.enter();
-                construct_block_cache_inner(&mut rng, &pyld, &block_chunks, total_bytes.get())?
+                construct_block_cache_inner(
+                    &mut rng,
+                    &pyld,
+                    maximum_block_bytes,
+                    total_bytes.get(),
+                )?
             }
             crate::Config::Ascii => {
                 let pyld = crate::Ascii::new(&mut rng);
-                let span = span!(
-                    Level::INFO,
-                    "fixed",
-                    max_chunks = total_chunks,
-                    payload = "ascii"
-                );
+                let span = span!(Level::INFO, "fixed", payload = "ascii");
                 let _guard = span.enter();
-                construct_block_cache_inner(&mut rng, &pyld, &block_chunks, total_bytes.get())?
+                construct_block_cache_inner(
+                    &mut rng,
+                    &pyld,
+                    maximum_block_bytes,
+                    total_bytes.get(),
+                )?
             }
             crate::Config::DatadogLog => {
                 let serializer = crate::DatadogLog::new(&mut rng);
-                let span = span!(
-                    Level::INFO,
-                    "fixed",
-                    max_chunks = total_chunks,
-                    payload = "datadog-log"
-                );
+                let span = span!(Level::INFO, "fixed", payload = "datadog-log");
                 let _guard = span.enter();
                 construct_block_cache_inner(
                     &mut rng,
                     &serializer,
-                    &block_chunks,
+                    maximum_block_bytes,
                     total_bytes.get(),
                 )?
             }
             crate::Config::Json => {
-                let span = span!(
-                    Level::INFO,
-                    "fixed",
-                    max_chunks = total_chunks,
-                    payload = "json"
-                );
+                let span = span!(Level::INFO, "fixed", payload = "json");
                 let _guard = span.enter();
                 construct_block_cache_inner(
                     &mut rng,
                     &crate::Json,
-                    &block_chunks,
+                    maximum_block_bytes,
                     total_bytes.get(),
                 )?
             }
             crate::Config::Static { ref static_path } => {
-                let span = span!(
-                    Level::INFO,
-                    "fixed",
-                    max_chunks = total_chunks,
-                    payload = "static"
-                );
+                let span = span!(Level::INFO, "fixed", payload = "static");
                 let _guard = span.enter();
                 construct_block_cache_inner(
                     &mut rng,
                     &crate::Static::new(static_path)?,
-                    &block_chunks,
+                    maximum_block_bytes,
                     total_bytes.get(),
                 )?
             }
             crate::Config::OpentelemetryTraces => {
                 let pyld = crate::OpentelemetryTraces::new(&mut rng);
-                let span = span!(
-                    Level::INFO,
-                    "fixed",
-                    max_chunks = total_chunks,
-                    payload = "otel-traces"
-                );
+                let span = span!(Level::INFO, "fixed", payload = "otel-traces");
                 let _guard = span.enter();
-                construct_block_cache_inner(rng, &pyld, &block_chunks, total_bytes.get())?
+                construct_block_cache_inner(rng, &pyld, maximum_block_bytes, total_bytes.get())?
             }
             crate::Config::OpentelemetryLogs => {
                 let pyld = crate::OpentelemetryLogs::new(&mut rng);
-                let span = span!(
-                    Level::INFO,
-                    "fixed",
-                    max_chunks = total_chunks,
-                    payload = "otel-logs"
-                );
+                let span = span!(Level::INFO, "fixed", payload = "otel-logs");
                 let _guard = span.enter();
-                construct_block_cache_inner(rng, &pyld, &block_chunks, total_bytes.get())?
+                construct_block_cache_inner(rng, &pyld, maximum_block_bytes, total_bytes.get())?
             }
             crate::Config::OpentelemetryMetrics => {
                 let pyld = crate::OpentelemetryMetrics::new(&mut rng);
-                let span = span!(
-                    Level::INFO,
-                    "fixed",
-                    max_chunks = total_chunks,
-                    payload = "otel-metrics"
-                );
+                let span = span!(Level::INFO, "fixed", payload = "otel-metrics");
                 let _guard = span.enter();
-                construct_block_cache_inner(rng, &pyld, &block_chunks, total_bytes.get())?
+                construct_block_cache_inner(rng, &pyld, maximum_block_bytes, total_bytes.get())?
             }
         };
         Ok(Self::Fixed { idx: 0, blocks })
@@ -378,100 +344,6 @@ impl Cache {
     }
 }
 
-/// Construct a vec of block sizes that fit into `total_bytes`.
-///
-/// We partition `total_bytes` by `block_byte_sizes` via a round-robin method.
-/// Our goal is to terminate, more or less partition the space.
-///
-/// # Errors
-///
-/// Function will return an error if `block_byte_sizes` is empty or if a member
-/// of `block_byte_sizes` is large than `total_bytes`.
-fn chunk_bytes<const N: usize>(
-    total_bytes: NonZeroU32,
-    block_byte_sizes: &[NonZeroU32],
-    chunks: &mut [u32; N],
-) -> Result<usize, Error> {
-    if block_byte_sizes.is_empty() {
-        return Err(ChunkError::EmptyBlockBytes.into());
-    }
-    for bb in block_byte_sizes {
-        if *bb > total_bytes {
-            return Err(ChunkError::InsufficientTotalBytes.into());
-        }
-    }
-
-    let mut total_chunks = 0;
-    let mut bytes_remaining = total_bytes.get();
-
-    let mut iter = block_byte_sizes.iter().cycle();
-    while bytes_remaining > 0 {
-        if total_chunks >= N {
-            break;
-        }
-        let mut attempt_block = |block| {
-            if block <= bytes_remaining {
-                chunks[total_chunks] = block;
-                total_chunks += 1;
-                bytes_remaining -= block;
-                return true;
-            }
-            false
-        };
-
-        // SAFETY: By construction, the iterator will never terminate.
-        let block_size = iter
-            .next()
-            .expect("failed to get block size, should not fail")
-            .get();
-
-        if !attempt_block(block_size) {
-            // Block size did not fit into the remaining bytes.
-            // Try each block size one more time.
-            let mut found_fitting_block = false;
-            for block_size in block_byte_sizes {
-                if attempt_block(block_size.get()) {
-                    found_fitting_block = true;
-                    break;
-                }
-            }
-            if !found_fitting_block {
-                #[cfg(not(kani))]
-                {
-                    warn!("Failed to fill the remaining {bytes_remaining} bytes after attempting each block size again.");
-                }
-                break;
-            }
-        }
-    }
-
-    #[cfg(not(kani))]
-    {
-        let computed_chunk_capacity = total_bytes.get() - bytes_remaining;
-        let total_chunk_capacity = byte_unit::Byte::from_bytes(computed_chunk_capacity.into());
-        let total_chunk_capacity_str = total_chunk_capacity.get_appropriate_unit(false).to_string();
-
-        if bytes_remaining > 0 {
-            let total_requested_bytes = byte_unit::Byte::from_bytes(total_bytes.get().into());
-            let total_requested_bytes_str = total_requested_bytes
-                .get_appropriate_unit(false)
-                .to_string();
-
-            let bytes_remaining = byte_unit::Byte::from_bytes(bytes_remaining.into());
-            let bytes_remaining_str = bytes_remaining.get_appropriate_unit(false).to_string();
-            let extra_advice = if total_chunks == N {
-                "Max capacity of chunks was hit, consider making block sizes larger to fit more data."
-            } else {
-                "Current block sizes pack inefficiently, consider adding/changing the block sizes to better pack."
-            };
-            warn!("Failed to construct chunks adding up to {total_requested_bytes_str}. Chunks created have total capacity of {total_chunk_capacity_str}. {bytes_remaining_str} unfulfilled. {extra_advice}");
-        }
-        info!("Allocated {total_chunks} chunks with total capacity of {total_chunk_capacity_str}.");
-    }
-
-    Ok(total_chunks)
-}
-
 /// Construct a new block cache of form defined by `serializer`.
 ///
 /// A "block cache" is a pre-made vec of serialized arbitrary instances of the
@@ -491,7 +363,7 @@ fn chunk_bytes<const N: usize>(
 fn construct_block_cache_inner<R, S>(
     mut rng: &mut R,
     serializer: &S,
-    block_chunks: &[u32],
+    max_block_size: u32,
     total_bytes: u32,
 ) -> Result<Vec<Block>, SpinError>
 where
@@ -501,10 +373,6 @@ where
     let mut block_cache: Vec<Block> = Vec::with_capacity(128);
     let mut bytes_remaining = total_bytes;
     let mut min_block_size = 0;
-    let max_block_size: u32 = *block_chunks
-        .iter()
-        .max()
-        .expect("empty block chunks, catastrophic bug");
 
     // Build out the blocks.
     //
@@ -604,329 +472,5 @@ where
         )
         .ok_or(SpinError::Zero)?;
         Ok(Block { total_bytes, bytes })
-    }
-}
-
-/// Get the block sizes from the configuration.
-/// If none are present, then return the defaults.
-///
-/// # Panics
-/// - Panics if a block size is not representable as a 32bit integer
-/// - Panics if a block size is zero
-pub fn get_blocks(
-    config_block_sizes: &Option<Vec<byte_unit::Byte>>,
-    block_size_limit: Option<byte_unit::Byte>,
-) -> Vec<NonZeroU32> {
-    let block_sizes = match config_block_sizes {
-        Some(ref sizes) => {
-            info!("Generator using user-specified block sizes: {:?}", sizes);
-            sizes
-                .iter()
-                .map(|sz| {
-                    NonZeroU32::new(
-                        u32::try_from(sz.get_bytes())
-                            .expect("Block size not representable as 32bit integer"),
-                    )
-                    .expect("bytes must be non-zero")
-                })
-                .collect()
-        }
-        None => default_blocks(),
-    };
-    if let Some(block_size_limit) = block_size_limit {
-        let limit = NonZeroU32::new(
-            u32::try_from(block_size_limit.get_bytes())
-                .expect("Block size not representable as 32bit integer"),
-        )
-        .expect("block size limit must be non-zero");
-        block_sizes.into_iter().filter(|sz| sz <= &limit).collect()
-    } else {
-        block_sizes
-    }
-}
-
-#[must_use]
-/// The default block sizes.
-///
-/// Panics are not possible in practice due to these being static values.
-/// # Panics
-/// - Panics if a block size is not representable as a 32bit integer
-/// - Panics if a block size is zero
-pub fn default_blocks() -> Vec<NonZeroU32> {
-    [
-        // KB
-        byte_unit::Byte::from_unit(1f64, byte_unit::ByteUnit::KB).expect("valid bytes"),
-        byte_unit::Byte::from_unit(2f64, byte_unit::ByteUnit::KB).expect("valid bytes"),
-        byte_unit::Byte::from_unit(4f64, byte_unit::ByteUnit::KB).expect("valid bytes"),
-        byte_unit::Byte::from_unit(8f64, byte_unit::ByteUnit::KB).expect("valid bytes"),
-        byte_unit::Byte::from_unit(16f64, byte_unit::ByteUnit::KB).expect("valid bytes"),
-        byte_unit::Byte::from_unit(32f64, byte_unit::ByteUnit::KB).expect("valid bytes"),
-        byte_unit::Byte::from_unit(64f64, byte_unit::ByteUnit::KB).expect("valid bytes"),
-        byte_unit::Byte::from_unit(256f64, byte_unit::ByteUnit::KB).expect("valid bytes"),
-        byte_unit::Byte::from_unit(512f64, byte_unit::ByteUnit::KB).expect("valid bytes"),
-        // MB
-        byte_unit::Byte::from_unit(1.0, byte_unit::ByteUnit::MB).expect("valid bytes"),
-        byte_unit::Byte::from_unit(2.0, byte_unit::ByteUnit::MB).expect("valid bytes"),
-        byte_unit::Byte::from_unit(4.0, byte_unit::ByteUnit::MB).expect("valid bytes"),
-    ]
-    .iter()
-    .map(|sz| {
-        NonZeroU32::new(
-            u32::try_from(sz.get_bytes()).expect("Block size not representable as 32bit integer"),
-        )
-        .expect("Block size is non-zero")
-    })
-    .collect()
-}
-
-#[cfg(test)]
-mod test {
-    use std::num::NonZeroU32;
-
-    use proptest::prelude::*;
-
-    use crate::block::{chunk_bytes, get_blocks, MAX_CHUNKS};
-
-    macro_rules! nz_u32 {
-        ($value:expr) => {
-            NonZeroU32::new($value).expect(concat!($value, " is non-zero"))
-        };
-    }
-
-    #[test]
-    fn construct_block_cache_inner_fills_blocks() {
-        use crate::block::construct_block_cache_inner;
-        use rand::{rngs::SmallRng, SeedableRng};
-
-        let mut rng = SmallRng::seed_from_u64(0);
-        let block_chunks = [100, 100, 100, 200, 300];
-        let total_bytes = block_chunks.iter().sum();
-        let serializer = crate::Json;
-        let block_cache =
-            construct_block_cache_inner(&mut rng, &serializer, &block_chunks, total_bytes)
-                .expect("construct_block_cache_inner should not fail");
-
-        assert!(block_cache.len() != 0);
-    }
-
-    /// This test ensures that `chunk_bytes` will re-use block sizes if it helps reach
-    /// the desired total bytes.
-    #[test]
-    fn chunk_bytes_fills_using_repeated_blocks_if_needed() {
-        // 10 bytes total, [3 1 9] block sizes, 10 chunks
-        const NUM_CHUNKS: usize = 10;
-        let total_bytes = nz_u32!(10);
-        let block_byte_sizes = [nz_u32!(3), nz_u32!(1), nz_u32!(9)];
-        let mut block_chunks: [u32; NUM_CHUNKS] = [0; NUM_CHUNKS];
-
-        let res = chunk_bytes(total_bytes, &block_byte_sizes, &mut block_chunks)
-            .expect("chunk_bytes should not fail");
-        let populated_block_chunks = &block_chunks[0..res];
-        let block_chunk_sum = populated_block_chunks.iter().sum::<u32>();
-        assert_eq!(total_bytes.get(), block_chunk_sum);
-
-        // 35 bytes total, [ 3 1 9 ] block sizes
-        let total_bytes = nz_u32!(35);
-        let block_byte_sizes = [nz_u32!(3), nz_u32!(1), nz_u32!(9)];
-        let mut block_chunks: [u32; MAX_CHUNKS] = [0; MAX_CHUNKS];
-
-        let res = chunk_bytes(total_bytes, &block_byte_sizes, &mut block_chunks)
-            .expect("chunk_bytes should not fail");
-        let populated_block_chunks = &block_chunks[0..res];
-        let block_chunk_sum = populated_block_chunks.iter().sum::<u32>();
-        assert_eq!(total_bytes.get(), block_chunk_sum);
-    }
-
-    proptest! {
-        // This test does not pass! (hence the #[ignore])
-        // It is trivial to find a combination of total_bytes and `block_byte_sizes` where
-        // its not possible to reach the max amount. Consider total_bytes=5 and block_sizes=[4]
-
-        // proptest todo - figure out how to express "block_byte_sizes members must be less than total_bytes"
-        // until then, the strategy is to set the max block size to the min total_bytes
-        #[ignore]
-        #[test]
-        fn chunk_bytes_yields_total_expected_bytes( total_bytes in 1_000..=100_000_000u32, block_byte_sizes in proptest::collection::vec(any::<NonZeroU32>(), 1..1_000)) {
-            let total_bytes = NonZeroU32::new(total_bytes).expect("total_bytes is non-zero");
-            let mut block_chunks: [u32; MAX_CHUNKS] = [0; MAX_CHUNKS];
-
-            let res = chunk_bytes(total_bytes, &block_byte_sizes, &mut block_chunks)
-                .expect("chunk_bytes should not fail");
-            let populated_block_chunks = &block_chunks[0..res];
-            let block_chunk_sum = populated_block_chunks.iter().sum::<u32>();
-            let requested_bytes = total_bytes.get();
-            assert_eq!(requested_bytes, block_chunk_sum, "filled {res} chunks (max allowed is {MAX_CHUNKS}), but couldn't satisfy request for {requested_bytes} bytes");
-        }
-    }
-
-    #[test]
-    fn get_blocks_works() {
-        let config_block_sizes = Some(vec![
-            byte_unit::Byte::from_unit(1.0, byte_unit::ByteUnit::MB).expect("valid bytes"),
-            byte_unit::Byte::from_unit(2.0, byte_unit::ByteUnit::MB).expect("valid bytes"),
-        ]);
-        let block_size_limit =
-            Some(byte_unit::Byte::from_unit(3.0, byte_unit::ByteUnit::MB).expect("valid bytes"));
-
-        let result = get_blocks(&config_block_sizes, block_size_limit);
-        assert_eq!(result.len(), 2);
-
-        let block_size_limit =
-            Some(byte_unit::Byte::from_unit(1.0, byte_unit::ByteUnit::MB).expect("valid bytes"));
-        let result = get_blocks(&config_block_sizes, block_size_limit);
-        assert_eq!(result.len(), 1);
-
-        let block_size_limit =
-            Some(byte_unit::Byte::from_unit(0.1, byte_unit::ByteUnit::MB).expect("valid bytes"));
-        let result = get_blocks(&config_block_sizes, block_size_limit);
-        assert_eq!(result.len(), 0);
-
-        let result = get_blocks(&config_block_sizes, None);
-        assert_eq!(result.len(), 2);
-    }
-}
-
-#[cfg(kani)]
-mod verification {
-    use crate::block::chunk_bytes;
-    use std::num::NonZeroU32;
-
-    /// Function `chunk_bytes` will always fail with an error if the passed
-    /// `block_byte_sizes` is empty.
-    #[kani::proof]
-    #[kani::unwind(11)]
-    fn chunk_bytes_empty_sizes_error() {
-        let total_bytes: NonZeroU32 = kani::any();
-        let block_byte_sizes = [];
-        let mut block_chunks: [u32; 10] = [0; 10];
-
-        let res = chunk_bytes(total_bytes, &block_byte_sizes, &mut block_chunks);
-        kani::assert(
-            res.is_err(),
-            "chunk_bytes must always fail if block_byte_sizes is empty.",
-        );
-    }
-
-    /// Function `chunk_bytes` should not fail if no member of block sizes is
-    /// large than `total_bytes`.
-    #[kani::proof]
-    #[kani::unwind(11)]
-    fn chunk_bytes_sizes_under_under_check() {
-        let total_bytes: NonZeroU32 = kani::any_where(|x: &NonZeroU32| x.get() < 64);
-        let mut block_chunks: [u32; 10] = [0; 10];
-
-        let under: NonZeroU32 = kani::any_where(|x| *x < total_bytes);
-
-        kani::assert(
-            chunk_bytes(total_bytes, &[under, under], &mut block_chunks).is_ok(),
-            "chunk_bytes should not fail when all sizes are under limit",
-        );
-    }
-
-    /// Function `chunk_bytes` should not fail if no member of block sizes is
-    /// large than `total_bytes`.
-    #[kani::proof]
-    #[kani::unwind(11)]
-    fn chunk_bytes_sizes_under_equal_check() {
-        let total_bytes: NonZeroU32 = kani::any();
-        let mut block_chunks: [u32; 10] = [0; 10];
-
-        let under: NonZeroU32 = kani::any_where(|x| *x < total_bytes);
-        let equal = total_bytes;
-
-        kani::assert(
-            chunk_bytes(total_bytes, &[under, equal], &mut block_chunks).is_ok(),
-            "chunk_bytes should not fail when all sizes are under or equal to limit",
-        );
-    }
-
-    /// Function `chunk_bytes` will fail if any member of `block_byte_sizes` is
-    /// larger than `total_bytes`.
-    #[kani::proof]
-    #[kani::unwind(11)]
-    fn chunk_bytes_sizes_under_equal_over_check() {
-        let total_bytes: NonZeroU32 = kani::any();
-        let mut block_chunks: [u32; 10] = [0; 10];
-
-        let under: NonZeroU32 = kani::any_where(|x| *x < total_bytes);
-        let equal = total_bytes;
-        let over: NonZeroU32 = kani::any_where(|x| *x > total_bytes);
-
-        kani::assert(
-            chunk_bytes(total_bytes, &[under, equal, over], &mut block_chunks).is_err(),
-            "chunk_bytes should fail when not all sizes are under the limit",
-        );
-    }
-
-    /// Function `chunk_bytes` does not fail to return some chunks.
-    #[kani::proof]
-    #[kani::unwind(11)]
-    fn chunk_bytes_never_chunk_empty() {
-        let total_bytes: NonZeroU32 = kani::any();
-        let byte_sizes: [NonZeroU32; 5] = [
-            kani::any_where(|x| *x < total_bytes),
-            kani::any_where(|x| *x < total_bytes),
-            kani::any_where(|x| *x < total_bytes),
-            kani::any_where(|x| *x < total_bytes),
-            kani::any_where(|x| *x < total_bytes),
-        ];
-        let mut block_chunks: [u32; 10] = [0; 10];
-
-        let chunks = chunk_bytes(total_bytes, &byte_sizes, &mut block_chunks)
-            .expect("chunk_bytes should never fail");
-        kani::assert(
-            chunks > 0,
-            "chunk_bytes should never return an empty vec of chunks",
-        );
-    }
-
-    /// Function `chunk_bytes` does not return a chunk that is not present in
-    /// the byte sizes.
-    #[kani::proof]
-    #[kani::unwind(11)]
-    fn chunk_bytes_always_present() {
-        let total_bytes: NonZeroU32 = kani::any();
-        let byte_sizes: [NonZeroU32; 5] = [
-            kani::any_where(|x| *x < total_bytes),
-            kani::any_where(|x| *x < total_bytes),
-            kani::any_where(|x| *x < total_bytes),
-            kani::any_where(|x| *x < total_bytes),
-            kani::any_where(|x| *x < total_bytes),
-        ];
-        let mut block_chunks: [u32; 10] = [0; 10];
-
-        let chunks = chunk_bytes(total_bytes, &byte_sizes, &mut block_chunks)
-            .expect("chunk_bytes should never fail");
-        for chunk in &block_chunks[0..chunks] {
-            kani::assert(
-                byte_sizes.contains(&NonZeroU32::new(*chunk).expect("chunk must be non-zero")),
-                "chunk_bytes should never return a chunk that is not present in the byte sizes",
-            );
-        }
-    }
-
-    /// Function `chunk_bytes` does not populate values above the returned
-    /// index, that is, they all remain zero.
-    #[kani::proof]
-    #[kani::unwind(11)]
-    fn chunk_bytes_never_populate_above_index() {
-        let total_bytes: NonZeroU32 = kani::any();
-        let byte_sizes: [NonZeroU32; 5] = [
-            kani::any_where(|x| *x < total_bytes),
-            kani::any_where(|x| *x < total_bytes),
-            kani::any_where(|x| *x < total_bytes),
-            kani::any_where(|x| *x < total_bytes),
-            kani::any_where(|x| *x < total_bytes),
-        ];
-        let mut block_chunks: [u32; 10] = [0; 10];
-
-        let chunks = chunk_bytes(total_bytes, &byte_sizes, &mut block_chunks)
-            .expect("chunk_bytes should never fail");
-        for chunk in &block_chunks[chunks..] {
-            kani::assert(
-                *chunk == 0,
-                "chunk_bytes should never populate values above the returned index",
-            );
-        }
     }
 }


### PR DESCRIPTION
### What does this PR do?

This PR follows up from #886 and removes the block configuration entirely, preferring instead to allow the users to configure a maximum block size. This is intended to simplfy the lading implementation and drive it closer to how users make use of lading in practice.
