### PR TITLE
Dogstatsd: generate values that include the max of inclusive config ranges

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Fixed
+- Range values in the dogstatsd payload will now generate the full inclusive
+  range. Previously, values were generated up to but not including the `max`
+  value.
 
 ## [0.21.0]
 ### Changed

--- a/lading_payload/src/dogstatsd.rs
+++ b/lading_payload/src/dogstatsd.rs
@@ -203,7 +203,7 @@ where
     {
         match self {
             ConfRange::Constant(c) => *c,
-            ConfRange::Inclusive { min, max } => rng.gen_range(*min..*max),
+            ConfRange::Inclusive { min, max } => rng.gen_range(*min..=*max),
         }
     }
 }


### PR DESCRIPTION
### What does this PR do?

Bugfix; dogstatsd config ranges generated values using an exclusive range rather than inclusive range.
