### PR TITLE
Prints version of lading in startup msg

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Changed
+- Added lading version to initial welcome print msg.
 ### Fixed
 - Range values in the dogstatsd payload will now generate the full inclusive
   range. Previously, values were generated up to but not including the `max`

--- a/lading/src/bin/lading.rs
+++ b/lading/src/bin/lading.rs
@@ -544,7 +544,8 @@ fn main() -> Result<(), Error> {
         .finish()
         .init();
 
-    info!("Starting lading run.");
+    let version = env!("CARGO_PKG_VERSION");
+    info!("Starting lading {version} run.");
     let opts: Opts = Opts::parse();
 
     // handle extra commands


### PR DESCRIPTION
### What does this PR do?

During startup, lading now prints what version it is. 

### Motivation

Disambiguate logs from clusters that may be running different versions of the SW.

### Related issues


### Additional Notes

