### PR TITLE
Removes incorrect pause before installing prom metrics registry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Added lading version to initial welcome print msg.
 ### Fixed
+- Prometheus metric exporter did not include some internal metrics (generator
+  metrics)
 - Range values in the dogstatsd payload will now generate the full inclusive
   range. Previously, values were generated up to but not including the `max`
   value.

--- a/lading/src/bin/lading.rs
+++ b/lading/src/bin/lading.rs
@@ -322,9 +322,7 @@ async fn inner_main(
             for (k, v) in global_labels {
                 builder = builder.add_global_label(k, v);
             }
-            let mut prom_experiment_started = experiment_started.clone();
             tokio::spawn(async move {
-                prom_experiment_started.recv().await; // block until experimental phase entered
                 builder
                     .install()
                     .expect("failed to install prometheus recorder");


### PR DESCRIPTION
### What does this PR do?

Removes the `experiment_started` pause before installing the prometheus metrics registry.

### Motivation

We never noticed because capture files don't have this, and prometheus is basically only used in local development.

### Related issues


### Additional Notes

