### PR TITLE
Add zstd blackhole support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Range values in the dogstatsd payload will now generate the full inclusive
   range. Previously, values were generated up to but not including the `max`
   value.
+- HTTP Blackhole now supports ZSTD encoded requests
 
 ## [0.21.0]
 ### Changed

--- a/lading/src/codec.rs
+++ b/lading/src/codec.rs
@@ -49,6 +49,15 @@ pub(crate) fn decode(
                         .map_err(|error| encoding_error_to_response(&encoding, error))?;
                     decoded.into()
                 }
+                "zstd" => {
+                    let mut decoded = Vec::new();
+                    zstd::Decoder::new(body.reader())
+                        .map_err(|error| encoding_error_to_response(&encoding, error))?
+                        .read_to_end(&mut decoded)
+                        .map_err(|error| encoding_error_to_response(&encoding, error))?;
+
+                    decoded.into()
+                }
                 encoding => {
                     return Err(hyper::Response::builder()
                         .status(StatusCode::UNSUPPORTED_MEDIA_TYPE)


### PR DESCRIPTION
### What does this PR do?

Adds support for `zstd` encoded payloads in the HTTP blackhole

### Motivation

Support load generated by Agent's new zstd compressor.

### Related issues


### Additional Notes

