### PR TITLE
Allow for effectively infinite experiment duration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 ### Added
 - Target observer now allows a docker target, identified by name.
+- Lading experiment duration may now be (effectively) infinite.
 
 ## [0.21.1]
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 ### Added
 - Target observer now allows a docker target, identified by name.
-- Lading experiment duration may now be (effectively) infinite.
+- Lading experiment duration may be set to (effectively) infinite via `--experiment-duration-infinite`.
 
 ## [0.21.1]
 ### Changed

--- a/lading/src/bin/lading.rs
+++ b/lading/src/bin/lading.rs
@@ -186,7 +186,7 @@ struct Opts {
     #[clap(long, default_value_t = 120)]
     experiment_duration_seconds: u32,
     /// flag to allow infinite experiment duration
-    #[clap(long, default_value_t = false)]
+    #[clap(long)]
     experiment_duration_infinite: bool,
     /// the time, in seconds, to allow the target to run without collecting
     /// samples
@@ -567,6 +567,7 @@ fn main() -> Result<(), Error> {
     } else {
         Duration::from_secs(opts.experiment_duration_seconds.into())
     };
+
     let warmup_duration = Duration::from_secs(opts.warmup_duration_seconds.into());
     // The maximum shutdown delay is shared between `inner_main` and this
     // function, hence the divide by two.

--- a/lading/src/bin/lading.rs
+++ b/lading/src/bin/lading.rs
@@ -134,7 +134,7 @@ impl FromStr for CliKeyValues {
 #[clap(group(
      ArgGroup::new("experiment-duration")
            .required(true)
-           .args(&["experiment_duration_seconds", "experiment_duration_infinite"]),
+           .args(&["experiment-duration-seconds", "experiment-duration-infinite"]),
 ))]
 struct Opts {
     /// path on disk to the configuration file

--- a/lading/src/bin/lading.rs
+++ b/lading/src/bin/lading.rs
@@ -133,7 +133,7 @@ impl FromStr for CliKeyValues {
 ))]
 #[clap(group(
      ArgGroup::new("experiment-duration")
-           .required(true)
+           .required(false)
            .args(&["experiment-duration-seconds", "experiment-duration-infinite"]),
 ))]
 struct Opts {
@@ -186,7 +186,7 @@ struct Opts {
     #[clap(long, default_value_t = 120)]
     experiment_duration_seconds: u32,
     /// flag to allow infinite experiment duration
-    #[clap(long)]
+    #[clap(long, default_value_t = false)]
     experiment_duration_infinite: bool,
     /// the time, in seconds, to allow the target to run without collecting
     /// samples

--- a/lading/src/bin/lading.rs
+++ b/lading/src/bin/lading.rs
@@ -131,6 +131,11 @@ impl FromStr for CliKeyValues {
         .required(true)
         .args(&["target-path", "target-pid", "no-target"]),
 ))]
+#[clap(group(
+     ArgGroup::new("experiment-duration")
+           .required(true)
+           .args(&["experiment_duration_seconds", "experiment_duration_infinite"]),
+))]
 struct Opts {
     /// path on disk to the configuration file
     #[clap(long, default_value_t = default_config_path())]
@@ -180,6 +185,9 @@ struct Opts {
     /// the time, in seconds, to run the target and collect samples about it
     #[clap(long, default_value_t = 120)]
     experiment_duration_seconds: u32,
+    /// flag to allow infinite experiment duration
+    #[clap(long)]
+    experiment_duration_infinite: bool,
     /// the time, in seconds, to allow the target to run without collecting
     /// samples
     #[clap(long, default_value_t = 30)]
@@ -554,7 +562,11 @@ fn main() -> Result<(), Error> {
 
     let config = get_config(&opts, None);
 
-    let experiment_duration = Duration::from_secs(opts.experiment_duration_seconds.into());
+    let experiment_duration = if opts.experiment_duration_infinite {
+        Duration::MAX
+    } else {
+        Duration::from_secs(opts.experiment_duration_seconds.into())
+    };
     let warmup_duration = Duration::from_secs(opts.warmup_duration_seconds.into());
     // The maximum shutdown delay is shared between `inner_main` and this
     // function, hence the divide by two.


### PR DESCRIPTION
### What does this PR do?

This commit adds a new flag that allows the user to specify an effectively infinite experiment duration. The exact value will vary by system but 584,942,417,355 years should be the more common value on modern systems.
