### PR TITLE
Observer errors are now fatal

### DIFF
--- a/lading/src/bin/lading.rs
+++ b/lading/src/bin/lading.rs
@@ -421,6 +421,7 @@ async fn inner_main(
     }
 
     let mut tsrv_joinset = tokio::task::JoinSet::new();
+    let mut osrv_joinset = tokio::task::JoinSet::new();
     //
     // OBSERVER
     //
@@ -428,12 +429,7 @@ async fn inner_main(
     if let Some(target) = config.target {
         let obs_rcv = tgt_snd.subscribe();
         let observer_server = observer::Server::new(config.observer, shutdown.clone())?;
-        let _osrv = tokio::spawn(async {
-            match observer_server.run(obs_rcv).await {
-                Ok(()) => debug!("observer shut down successfully"),
-                Err(err) => warn!("observer failed with {:?}", err),
-            }
-        });
+        osrv_joinset.spawn(observer_server.run(obs_rcv));
 
         //
         // TARGET
@@ -471,6 +467,19 @@ async fn inner_main(
                 info!("shutdown signal received.");
                 break Ok(());
             }
+            Some(res) = osrv_joinset.join_next() => {
+                match res {
+                    Ok(observer_result) => match observer_result {
+                        Ok(()) => { /* Observer shut down successfully */ }
+                        Err(err) => {
+                            error!("Observer shut down unexpectedly: {err}");
+                            shutdown.signal();
+                            break Err(Error::LadingObserver(err));
+                        }
+                    }
+                    Err(err) => error!("Could not join the spawned observer task: {}", err),
+                }
+            },
             Some(res) = gsrv_joinset.join_next() => {
                 match res {
                     Ok(generator_result) => match generator_result {

--- a/lading/src/bin/lading.rs
+++ b/lading/src/bin/lading.rs
@@ -428,7 +428,12 @@ async fn inner_main(
     if let Some(target) = config.target {
         let obs_rcv = tgt_snd.subscribe();
         let observer_server = observer::Server::new(config.observer, shutdown.clone())?;
-        let _osrv = tokio::spawn(observer_server.run(obs_rcv));
+        let _osrv = tokio::spawn(async {
+            match observer_server.run(obs_rcv).await {
+                Ok(()) => debug!("observer shut down successfully"),
+                Err(err) => warn!("observer failed with {:?}", err),
+            }
+        });
 
         //
         // TARGET


### PR DESCRIPTION
### What does this PR do?
Adds error handling by exiting lading when the `Observer` hits an error condition

### Motivation


### Related issues



### Additional Notes

