### PR TITLE
Uses perf_event to grab the instruction and cycle count for target process

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## [0.22.0-rc2]
+### Added
+- Incorporate perf-event telemetry on Linux for CPU data.
+
 ## [0.22.0-rc1]
 ### Fixed
-- Target observer was not exposed through CLI.
+- Target observer was not exposed through CLI, eg `--target-container my-container-name`
 
 ## [0.22.0-rc0]
 ### Changed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1393,7 +1393,7 @@ dependencies = [
 
 [[package]]
 name = "lading"
-version = "0.22.0-rc1"
+version = "0.22.0-rc2"
 dependencies = [
  "async-pidfd",
  "average",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -361,6 +361,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "514de17de45fdb8dc022b1a7975556c53c86f9f0aa5f534b98977b171857c2c9"
 
 [[package]]
+name = "c-enum"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd17eb909a8c6a894926bfcc3400a4bb0e732f5a57d37b1f14e8b29e329bace8"
+
+[[package]]
 name = "cast"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1411,6 +1417,7 @@ dependencies = [
  "nix 0.29.0",
  "num_cpus",
  "once_cell",
+ "perf-event2",
  "procfs",
  "proptest",
  "proptest-derive",
@@ -1557,6 +1564,24 @@ name = "memchr"
 version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
+
+[[package]]
+name = "memmap2"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe751422e4a8caa417e13c3ea66452215d7d63e19e604f4980461212f3ae1322"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "memoffset"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
+dependencies = [
+ "autocfg",
+]
 
 [[package]]
 name = "metrics"
@@ -1874,6 +1899,41 @@ name = "percent-encoding"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
+
+[[package]]
+name = "perf-event-data"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d84c4d28ab20b2fd15c9e9378ec2dc2bb5766caf1d480fe6bea2ce110f5e7357"
+dependencies = [
+ "bitflags 2.6.0",
+ "c-enum",
+ "perf-event-open-sys2",
+]
+
+[[package]]
+name = "perf-event-open-sys2"
+version = "5.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01faf900461427584dbfffee2d09df93fc633ca23cae4ddd6787002340735fd4"
+dependencies = [
+ "libc",
+ "memoffset",
+]
+
+[[package]]
+name = "perf-event2"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0939b8fad77dfaeb29ebbd35faaeaadbf833167f30975f1b8993bbba09ea0a0f"
+dependencies = [
+ "bitflags 2.6.0",
+ "c-enum",
+ "libc",
+ "memmap2",
+ "perf-event-data",
+ "perf-event-open-sys2",
+]
 
 [[package]]
 name = "petgraph"

--- a/lading/Cargo.toml
+++ b/lading/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lading"
-version = "0.22.0-rc1"
+version = "0.22.0-rc2"
 authors = [
     "Brian L. Troutwine <brian.troutwine@datadoghq.com>",
     "George Hahn <george.hahn@datadoghq.com>",
@@ -52,12 +52,12 @@ tracing = { workspace = true }
 tracing-subscriber = { version = "0.3", features = ["std", "env-filter"] }
 uuid = { workspace = true }
 zstd = "0.13.1"
-perf-event2 = "0.7.4"
 
 [target.'cfg(target_os = "linux")'.dependencies]
 cgroups-rs = "0.3"
 procfs = { version = "0.15", default-features = false, features = [] }
 async-pidfd = "0.1"
+perf-event2 = "0.7.4"
 
 [dev-dependencies]
 proptest = "1.4"

--- a/lading/Cargo.toml
+++ b/lading/Cargo.toml
@@ -52,6 +52,7 @@ tracing = { workspace = true }
 tracing-subscriber = { version = "0.3", features = ["std", "env-filter"] }
 uuid = { workspace = true }
 zstd = "0.13.1"
+perf-event2 = "0.7.4"
 
 [target.'cfg(target_os = "linux")'.dependencies]
 cgroups-rs = "0.3"

--- a/lading/src/observer/linux.rs
+++ b/lading/src/observer/linux.rs
@@ -82,7 +82,7 @@ impl Gauge {
     }
 }
 
-/// Attempts to initialize perf_event counters.
+/// Attempts to initialize `perf_event` counters.
 /// If either fail, then (None, None) is returned and errors are logged.
 fn init_perf_counters(parent_pid: i32) -> (Option<Counter>, Option<Counter>) {
     let mut cycles = match Builder::new(Hardware::CPU_CYCLES)


### PR DESCRIPTION
### What does this PR do?

Adds 3 additional telemetry gauges for the target software:
- instruction count
- cycle count
- Cycles Per Instruction

### Motivation

https://research.google.com/pubs/archive/40737.pdf

### Related issues


### Additional Notes

