### PR TITLE
Update to rust 1.79.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 
 ## [0.22.0-rc0]
+### Changed
+- Now built using rust 1.79.0
 ### Added
 - Target observer now allows a docker target, identified by name.
 - Lading experiment duration may be set to (effectively) infinite via `--experiment-duration-infinite`.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-FROM docker.io/rust:1.75.0-bullseye as builder
+# Update the rust version in-sync with the version in rust-toolchain.toml
+FROM docker.io/rust:1.79.0-bullseye as builder
 
 RUN apt-get update && apt-get install -y \
     protobuf-compiler \
@@ -8,7 +9,7 @@ WORKDIR /app
 COPY . /app
 RUN cargo build --release --locked --bin lading
 
-FROM docker.io/debian:bullseye-20240211-slim
+FROM docker.io/debian:bullseye-20240701-slim
 COPY --from=builder /app/target/release/lading /usr/bin/lading
 
 # smoke test

--- a/lading/src/blackhole/http.rs
+++ b/lading/src/blackhole/http.rs
@@ -97,7 +97,7 @@ pub struct Config {
     /// the content-type header to respond with, defaults to 200
     #[serde(default = "default_status_code")]
     pub status: u16,
-    /// raw array of bytes if the raw_bytes body variant is selected
+    /// raw array of bytes if the `raw_bytes` body variant is selected
     #[serde(default)]
     pub raw_bytes: Vec<u8>,
 }

--- a/lading/src/config.rs
+++ b/lading/src/config.rs
@@ -43,7 +43,7 @@ pub struct Config {
     #[serde(default)]
     #[serde(with = "serde_yaml::with::singleton_map_recursive")]
     pub blackhole: Option<Vec<blackhole::Config>>,
-    /// The target_metrics to scrape from the target
+    /// The `target_metrics` to scrape from the target
     #[serde(default)]
     #[serde(with = "serde_yaml::with::singleton_map_recursive")]
     pub target_metrics: Option<Vec<target_metrics::Config>>,

--- a/lading/src/generator/file_gen/logrotate.rs
+++ b/lading/src/generator/file_gen/logrotate.rs
@@ -80,7 +80,7 @@ pub struct Config {
     pub variant: lading_payload::Config,
     /// Defines the number of bytes that written in each log file.
     bytes_per_second: Byte,
-    /// Defines the maximum internal cache of this log target. file_gen will
+    /// Defines the maximum internal cache of this log target. `file_gen` will
     /// pre-build its outputs up to the byte capacity specified here.
     maximum_prebuild_cache_size_bytes: Byte,
     /// The maximum size in bytes of the largest block in the prebuild cache.

--- a/lading/src/generator/file_gen/traditional.rs
+++ b/lading/src/generator/file_gen/traditional.rs
@@ -95,7 +95,7 @@ pub struct Config {
     /// possible as the internal governor accumulates, up to
     /// `maximum_bytes_burst`.
     bytes_per_second: Byte,
-    /// Defines the maximum internal cache of this log target. file_gen will
+    /// Defines the maximum internal cache of this log target. `file_gen` will
     /// pre-build its outputs up to the byte capacity specified here.
     maximum_prebuild_cache_size_bytes: Byte,
     /// The maximum size in bytes of the largest block in the prebuild cache.

--- a/lading/src/generator/file_tree.rs
+++ b/lading/src/generator/file_tree.rs
@@ -141,10 +141,8 @@ impl FileTree {
         let mut rng = StdRng::from_seed(config.seed);
         let (nodes, _total_files, total_folder) = generate_tree(&mut rng, config)?;
 
-        let _labels = vec![
-            ("component".to_string(), "generator".to_string()),
-            ("component_name".to_string(), "file_tree".to_string()),
-        ];
+        let _labels = [("component".to_string(), "generator".to_string()),
+            ("component_name".to_string(), "file_tree".to_string())];
 
         let open_throttle = Throttle::new_with_config(config.throttle, config.open_per_second);
         let rename_throttle = Throttle::new_with_config(config.throttle, config.rename_per_second);

--- a/lading/src/generator/grpc.rs
+++ b/lading/src/generator/grpc.rs
@@ -61,7 +61,7 @@ pub enum Error {
 #[derive(Debug, Deserialize, Serialize, PartialEq)]
 #[serde(deny_unknown_fields)]
 pub struct Config {
-    /// The gRPC URI. Looks like http://host/service.path/endpoint
+    /// The gRPC URI. Looks like `http://<host>/<service path>/<endpoint>`
     pub target_uri: String,
     /// The seed for random operations against this target
     pub seed: [u8; 32],

--- a/lading/src/generator/process_tree.rs
+++ b/lading/src/generator/process_tree.rs
@@ -284,10 +284,8 @@ impl ProcessTree {
             Err(e) => return Err(Error::from(e)),
         };
 
-        let _labels = vec![
-            ("component".to_string(), "generator".to_string()),
-            ("component_name".to_string(), "process_tree".to_string()),
-        ];
+        let _labels = [("component".to_string(), "generator".to_string()),
+            ("component_name".to_string(), "process_tree".to_string())];
 
         let throttle = Throttle::new_with_config(config.throttle, config.max_tree_per_second);
         match serde_yaml::to_string(config) {

--- a/lading/src/generator/splunk_hec/acknowledgements.rs
+++ b/lading/src/generator/splunk_hec/acknowledgements.rs
@@ -34,7 +34,7 @@ pub enum Error {
 
 #[derive(Debug, Clone)]
 pub(crate) enum Channel {
-    /// Variant that communicates acks to underlying AckService.
+    /// Variant that communicates acks to underlying `AckService`.
     Ack { id: String, tx: Sender<AckId> },
     /// Variant that does no ack'ing.
     NoAck { id: String },

--- a/lading/src/generator/tcp.rs
+++ b/lading/src/generator/tcp.rs
@@ -36,7 +36,7 @@ use super::General;
 pub struct Config {
     /// The seed for random operations against this target
     pub seed: [u8; 32],
-    /// The address for the target, must be a valid SocketAddr
+    /// The address for the target, must be a valid `SocketAddr`
     pub addr: String,
     /// The payload variant
     pub variant: lading_payload::Config,

--- a/lading/src/generator/udp.rs
+++ b/lading/src/generator/udp.rs
@@ -42,7 +42,7 @@ fn maximum_block_size() -> Byte {
 pub struct Config {
     /// The seed for random operations against this target
     pub seed: [u8; 32],
-    /// The address for the target, must be a valid SocketAddr
+    /// The address for the target, must be a valid `SocketAddr`
     pub addr: String,
     /// The payload variant
     pub variant: lading_payload::Config,

--- a/lading/src/observer/linux.rs
+++ b/lading/src/observer/linux.rs
@@ -140,8 +140,7 @@ impl Sampler {
             // itself as a child so we reference the pid hashset above to avoid
             // infinite loops.
             if let Ok(tasks) = process.tasks() {
-                for task in tasks.filter(std::result::Result::is_ok) {
-                    let task = task.expect("failed to read task"); // SAFETY: filter on iterator
+                for task in tasks.flatten() {
                     if let Ok(mut children) = task.children() {
                         for child in children
                             .drain(..)

--- a/lading/src/target.rs
+++ b/lading/src/target.rs
@@ -52,7 +52,7 @@ type TargetPidSender = tokio::sync::broadcast::Sender<Option<u32>>;
 /// Errors produced by [`Meta`]
 #[derive(thiserror::Error, Debug, Clone, Copy)]
 pub enum MetaError {
-    /// Unable to support byte limits greater than u64::MAX
+    /// Unable to support byte limits greater than `u64::MAX`
     #[error("unable to support bytes greater than u64::MAX")]
     ByteLimitTooLarge,
 }
@@ -103,7 +103,7 @@ pub enum Error {
     /// Unable to await target exit
     #[error("unable to wait for target exit: {0}")]
     TargetWait(io::Error),
-    /// Unable to create PidFd from raw PID
+    /// Unable to create `PidFd` from raw PID
     #[error("unable to create PidFd: {0}")]
     PidConversion(io::Error),
     /// SIGTERM error

--- a/lading_payload/proptest-regressions/dogstatsd/common/tags.txt
+++ b/lading_payload/proptest-regressions/dogstatsd/common/tags.txt
@@ -1,0 +1,7 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+cc 9c7455b354ddc3d731190002edf0877dd19bf97e09f4bb0450ec2306334b07ff # shrinks to seed = 0, desired_num_tagsets = 1

--- a/lading_payload/src/dogstatsd.rs
+++ b/lading_payload/src/dogstatsd.rs
@@ -245,11 +245,11 @@ pub struct Config {
     /// The sampling rate is chosen from `sampling_range`
     pub sampling_probability: f32,
 
-    /// Defines the relative probability of each kind of DogStatsD kinds of
+    /// Defines the relative probability of each kind of `DogStatsD` kinds of
     /// payload.
     pub kind_weights: KindWeights,
 
-    /// Defines the relative probability of each kind of DogStatsD metric.
+    /// Defines the relative probability of each kind of `DogStatsD` metric.
     pub metric_weights: MetricWeights,
 
     /// The configuration of values that appear in all metrics.

--- a/lading_payload/src/lib.rs
+++ b/lading_payload/src/lib.rs
@@ -63,7 +63,7 @@ pub mod trace_agent;
 /// Errors related to serialization
 #[derive(thiserror::Error, Debug)]
 pub enum Error {
-    /// MsgPack payload could not be encoded
+    /// `MsgPack` payload could not be encoded
     #[error("MsgPack payload could not be encoded: {0}")]
     MsgPack(#[from] rmp_serde::encode::Error),
     /// Json payload could not be encoded
@@ -105,7 +105,7 @@ pub trait Serialize {
 pub enum Encoding {
     /// Use JSON format
     Json,
-    /// Use MsgPack binary format
+    /// Use `MsgPack` binary format
     #[serde(alias = "msgpack")]
     MsgPack,
 }
@@ -145,10 +145,10 @@ pub enum Config {
     OpentelemetryLogs,
     /// Generates OpenTelemetry metrics
     OpentelemetryMetrics,
-    /// Generates DogStatsD
+    /// Generates `DogStatsD`
     #[serde(rename = "dogstatsd")]
     DogStatsD(crate::dogstatsd::Config),
-    /// Generates TraceAgent payloads in JSON format
+    /// Generates `TraceAgent` payloads in JSON format
     TraceAgent(Encoding),
 }
 

--- a/lading_payload/src/procfs.rs
+++ b/lading_payload/src/procfs.rs
@@ -81,14 +81,14 @@ const ASSUMED_NGROUPS_MAX: usize = 32;
 /// are ignored for ease of implementation.
 #[derive(Debug, Clone, Copy)]
 pub struct Statm {
-    /// Total program size (pages). Same as VmSize in
+    /// Total program size (pages). Same as `VmSize` in
     /// `/proc/{pid}/status`.
     size: u64,
-    /// Size of memory portions (pages). Same as VmRSS in
+    /// Size of memory portions (pages). Same as `VmRSS` in
     /// `/proc/{pid}/status`.
     resident: u64,
     /// Number of pages that are shared (i.e., backed by a file, same as
-    /// `RssFile` + `RssShmem`` in `/proc/{pid}/status`).
+    /// `RssFile` + `RssShmem` in `/proc/{pid}/status`).
     shared: u64,
     /// Number of pages that are 'code' (not including libs; broken,
     /// includes data segment). Looks to be the same as `VmExe` + `VmLib` in
@@ -765,7 +765,7 @@ pub struct Status {
     /// Peak resident set size (in bytes). Present only if task has non-null
     /// memory management pointer.
     vm_hwm: MemSize,
-    /// Resident set size (in bytes) = rss_anon + rss_file + rss_shmem. Present
+    /// Resident set size (in bytes) = `rss_anon` + `rss_file` + `rss_shmem`. Present
     /// only if task has non-null memory management pointer.
     vm_rss: MemSize,
     /// Resident anonymous memory size (in bytes). Present only if task has
@@ -774,7 +774,7 @@ pub struct Status {
     /// Resident file mappings size (in bytes). Present only if task has
     /// non-null memory management pointer.
     rss_file: MemSize,
-    /// Resident shmem memory size (in bytes; includes SysV shm, tmpfs mapping,
+    /// Resident shmem memory size (in bytes; includes `SysV` shm, tmpfs mapping,
     /// shared anonymous mappings). Present only if task has non-null memory
     /// management pointer.
     rss_shmem: MemSize,

--- a/lading_payload/src/splunk_hec.rs
+++ b/lading_payload/src/splunk_hec.rs
@@ -117,7 +117,7 @@ impl Distribution<Member> for Standard {
     }
 }
 
-///
+/// Encoding to be used
 #[derive(Deserialize, Serialize, Debug, Clone, Copy, PartialEq, Eq)]
 #[serde(deny_unknown_fields)]
 #[serde(rename_all = "snake_case")]

--- a/lading_payload/src/trace_agent.rs
+++ b/lading_payload/src/trace_agent.rs
@@ -100,7 +100,7 @@ pub(crate) struct Span<'a> {
     /// type is the type of the service with which this span is associated.  Example values: web, db, lambda.
     #[serde(alias = "type")]
     kind: &'a str,
-    /// meta_struct is a registry of structured "other" data used by, e.g., AppSec.
+    /// `meta_struct` is a registry of structured "other" data used by, e.g., `AppSec`.
     meta_struct: FxHashMap<&'a str, Vec<u8>>,
 }
 
@@ -108,9 +108,9 @@ pub(crate) struct Span<'a> {
 #[cfg_attr(test, derive(proptest_derive::Arbitrary))]
 /// Encoding options for the trace-agent
 pub enum Encoding {
-    /// Encode TraceAgent payload in JSON format
+    /// Encode `TraceAgent` payload in JSON format
     Json,
-    /// Encode TraceAgent payload in MsgPack format
+    /// Encode `TraceAgent` payload in `MsgPack` format
     #[default]
     MsgPack,
 }

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.75.0"
+channel = "1.79.0"
 profile = "minimal"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,4 @@
 [toolchain]
+# Update the rust version in-sync with the version in Dockerfile
 channel = "1.79.0"
 profile = "minimal"


### PR DESCRIPTION
### What does this PR do?

Updates the rust version used in this project. 
Also updates the debian base-image version for the docker base.

### Motivation


### Related issues

### Additional Notes

