### PR TITLE
Updates metrics-rs crates to latest released versions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1561,7 +1561,8 @@ checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 [[package]]
 name = "metrics"
 version = "0.23.0"
-source = "git+https://github.com/metrics-rs/metrics.git?rev=a65dde95476558b862245d2bd7089de91f33a1bd#a65dde95476558b862245d2bd7089de91f33a1bd"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "884adb57038347dfbaf2d5065887b6cf4312330dc8e94bc30a1a839bd79d3261"
 dependencies = [
  "ahash",
  "portable-atomic",
@@ -1569,8 +1570,9 @@ dependencies = [
 
 [[package]]
 name = "metrics-exporter-prometheus"
-version = "0.15.1"
-source = "git+https://github.com/metrics-rs/metrics.git?rev=a65dde95476558b862245d2bd7089de91f33a1bd#a65dde95476558b862245d2bd7089de91f33a1bd"
+version = "0.15.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4f0c8427b39666bf970460908b213ec09b3b350f20c0c2eabcbba51704a08e6"
 dependencies = [
  "base64 0.22.1",
  "http-body-util",
@@ -1589,7 +1591,8 @@ dependencies = [
 [[package]]
 name = "metrics-util"
 version = "0.17.0"
-source = "git+https://github.com/metrics-rs/metrics.git?rev=a65dde95476558b862245d2bd7089de91f33a1bd#a65dde95476558b862245d2bd7089de91f33a1bd"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4259040465c955f9f2f1a4a8a16dc46726169bca0f88e8fb2dbeced487c3e828"
 dependencies = [
  "aho-corasick",
  "crossbeam-epoch",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,11 +12,9 @@ members = [
 [workspace.dependencies]
 bytes = { version = "1.5", default-features = false, features = ["std"] }
 byte-unit = { version = "4.0", features = ["serde"] }
-# Metrics-rs crates are pinned to a65dde95476558b862245d2bd7089de91f33a1bd until
-# a release is cut that contains https://github.com/metrics-rs/metrics/pull/498
-metrics = { git = "https://github.com/metrics-rs/metrics.git", rev = "a65dde95476558b862245d2bd7089de91f33a1bd" }
-metrics-util = { git = "https://github.com/metrics-rs/metrics.git", rev = "a65dde95476558b862245d2bd7089de91f33a1bd" }
-metrics-exporter-prometheus = { git = "https://github.com/metrics-rs/metrics.git", rev = "a65dde95476558b862245d2bd7089de91f33a1bd", default-features = false, features = ["http-listener", "uds-listener"]}
+metrics = { version = "0.23.0" }
+metrics-util = { version = "0.17.0" }
+metrics-exporter-prometheus = {  version = "0.15.3", default-features = false, features = ["http-listener", "uds-listener"]}
 prost = "0.11"
 prost-build = { version = "0.12" }
 rand = { version = "0.8", default-features = false }


### PR DESCRIPTION
### What does this PR do?

Switches metrics-rs family crates to a released version instead of pinning to a git commit.

### Motivation

The UDS-based prometheus exporter was released in a stable version.

### Related issues


### Additional Notes

