### PR TITLE
Observe cgroup information on Linux

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Added
+- Retrieve memory information from cgroup controller for every pid observed on Linux.
 
 ## [0.22.0-rc1]
 ### Fixed

--- a/lading/Cargo.toml
+++ b/lading/Cargo.toml
@@ -54,7 +54,7 @@ uuid = { workspace = true }
 zstd = "0.13.1"
 
 [target.'cfg(target_os = "linux")'.dependencies]
-cgroups-rs = "0.3"
+cgroups-rs = { version = "0.3", default-features = false, features = [] }
 procfs = { version = "0.15", default-features = false, features = [] }
 async-pidfd = "0.1"
 

--- a/lading/src/observer/linux.rs
+++ b/lading/src/observer/linux.rs
@@ -357,6 +357,9 @@ impl Sampler {
             if let Some(memory_controller) =
                 cgroup.controller_of::<cgroups_rs::memory::MemController>()
             {
+                let mut labels = Vec::from(labels);
+                labels.push(("cgroup", String::from(cgroup.path())));
+
                 let mem_stat = memory_controller.memory_stat();
 
                 let inactive_file = if cgroup.v2() {
@@ -372,7 +375,17 @@ impl Sampler {
                 };
 
                 gauge!("working_set_bytes", &labels).set(working_set as f64);
+
+                gauge!("fail_cnt", &labels).set(mem_stat.fail_cnt as f64);
+                gauge!("limit_bytes", &labels).set(mem_stat.limit_in_bytes as f64);
+                gauge!("usage_in_bytes", &labels).set(mem_stat.usage_in_bytes as f64);
+                gauge!("max_usage_in_bytes", &labels).set(mem_stat.max_usage_in_bytes as f64);
+                gauge!("soft_limit_in_bytes", &labels).set(mem_stat.soft_limit_in_bytes as f64);
             }
+            // TODO load the CPU controller and parse
+            // https://docs.rs/cgroups/latest/cgroups/cpu/struct.Cpu.html#structfield.stat.
+            // What information is tucked in there varies by kernel version et
+            // al but it's valuable information.
         }
 
         gauge!("num_processes").set(total_processes as f64);


### PR DESCRIPTION
### What does this PR do?

This commit reads the cgroup memory controller and pulls limit et al information for each observed pid. I've copied telemetry names directly from Linux without consideration; I am open to a prefix for this new data or a different scheme. I intend to follow on with pulls from the CPU controller as well.
