### PR TITLE
Cut lading 0.22.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,17 +5,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
-### Added
-- Retrieve memory, CPU information from cgroup controller for every pid observed on Linux.
+
+## [0.22.0]
 ### Fixed
 - Fixes bugs in `smaps` parsing code that can result in under-counting RSS in
   the smaps view of the data.
-
-## [0.22.0-rc1]
-### Fixed
 - Target observer was not exposed through CLI.
-
-## [0.22.0-rc0]
 ### Changed
 - Now built using rust 1.79.0
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1387,7 +1387,7 @@ dependencies = [
 
 [[package]]
 name = "lading"
-version = "0.22.0-rc1"
+version = "0.22.0"
 dependencies = [
  "async-pidfd",
  "average",

--- a/lading/Cargo.toml
+++ b/lading/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lading"
-version = "0.22.0-rc1"
+version = "0.22.0"
 authors = [
     "Brian L. Troutwine <brian.troutwine@datadoghq.com>",
     "George Hahn <george.hahn@datadoghq.com>",


### PR DESCRIPTION
### What does this PR do?

This commit is the release of 0.22.0 version of lading. We have improved lading's ability to operate in a container ecosystem, exposing telemetry over UDS and by allowing a target to be specified by container name and enable effectively infinite duration experiments.

### Motivation

REF SMPTNG-441
