### PR TITLE
Enable tagging of target metrics from prometheus and expvar endpoints by sub-agent name 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,11 +20,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Fixes bugs in `smaps` parsing code that can result in under-counting RSS in
   the smaps view of the data.
-### Added
-- Retrieve memory, CPU information from cgroup controller for every pid observed on Linux.
-
-## [0.22.0-rc1]
-### Fixed
 - Target observer was not exposed through CLI.
 ### Changed
 - Now built using rust 1.79.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     - prometheus: #core agent telemetry
         uri: "http://127.0.0.1:5000/telemetry"
         tags:
-          sub-agent: "core-agent"
-          any-label: "any-string-value"
+          sub_agent: "core"
+          any_label: "any-string-value"
   ```
 
 ## [0.22.0]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,26 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Added
+- Added ability to create tags for both expvar and prometheus target metrics specific to a single target_metrics configuration (example below shows prometheus metrics collected from the core agent and two additional tags created)
+  ```yaml
+  target_metrics:      
+    - prometheus: #core agent telemetry
+        uri: "http://127.0.0.1:5000/telemetry"
+        tags:
+          sub-agent: "core-agent"
+          any-label: "any-string-value"
+  ```
 
 ## [0.22.0]
 ### Fixed
 - Fixes bugs in `smaps` parsing code that can result in under-counting RSS in
   the smaps view of the data.
+### Added
+- Retrieve memory, CPU information from cgroup controller for every pid observed on Linux.
+
+## [0.22.0-rc1]
+### Fixed
 - Target observer was not exposed through CLI.
 ### Changed
 - Now built using rust 1.79.0

--- a/lading/src/target_metrics/expvar.rs
+++ b/lading/src/target_metrics/expvar.rs
@@ -96,7 +96,7 @@ impl Expvar {
                 let mut all_labels =
                     vec![("source".to_string(), "target_metrics/expvar".to_string())];
                 if let Some(tags) = &self.config.tags {
-                    for (tag_name, tag_val) in tags.iter() {
+                    for (tag_name, tag_val) in tags {
                         all_labels.push((tag_name.clone(), tag_val.clone()));
                     }
                 }

--- a/lading/src/target_metrics/expvar.rs
+++ b/lading/src/target_metrics/expvar.rs
@@ -92,8 +92,7 @@ impl Expvar {
                     continue;
                 };
 
-                // Add lading labels including user defined for this endpoint
-
+                // Add lading labels including user defined tags for this endpoint
                 let mut all_labels =
                     vec![("source".to_string(), "target_metrics/expvar".to_string())];
                 if let Some(tags) = &self.config.tags {

--- a/lading/src/target_metrics/expvar.rs
+++ b/lading/src/target_metrics/expvar.rs
@@ -93,14 +93,14 @@ impl Expvar {
                 };
 
                 // Add lading labels including user defined for this endpoint
+
                 let mut all_labels =
                     vec![("source".to_string(), "target_metrics/expvar".to_string())];
                 if let Some(tags) = &self.config.tags {
                     for (tag_name, tag_val) in tags.iter() {
-                        all_labels.push((tag_name.to_owned(), tag_val.to_owned()));
+                        all_labels.push((tag_name.clone(), tag_val.clone()));
                     }
                 }
-                let labels = Some(all_labels);
 
                 for var_name in &self.config.vars {
                     let val = json.pointer(var_name).and_then(serde_json::Value::as_f64);
@@ -108,7 +108,7 @@ impl Expvar {
                         trace!("expvar: {} = {}", var_name, val);
                         let handle = gauge!(
                             format!("target/{name}", name = var_name.trim_start_matches('/'),),
-                            all_labels
+                            &all_labels
                         );
                         handle.set(val);
                     }

--- a/lading/src/target_metrics/prometheus.rs
+++ b/lading/src/target_metrics/prometheus.rs
@@ -207,12 +207,11 @@ impl Prometheus {
                 }
             };
 
-            // Add lading labels including user defined for this endpoint
+            // Add lading labels including user defined tags for this endpoint
             let all_labels: Option<Vec<(String, String)>>;
             if let Some(tags) = &self.config.tags {
-                //let additional_labels = vec![("t".to_string(), "t".to_string())];
                 let mut additional_labels = Vec::new();
-                for (tag_name, tag_val) in tags.iter() {
+                for (tag_name, tag_val) in tags {
                     additional_labels.push((tag_name.clone(), tag_val.clone()));
                 }
                 if let Some(labels) = labels {


### PR DESCRIPTION
### What does this PR do?

This PR adds another configuration option to prometheus and expvar target metrics enabling a user to tag all the metrics coming from that configuration with optional additional labels

```
target_metrics:
  - prometheus: #process agent telemetry 
      uri: "http://127.0.0.1:6062/telemetry"
      tags:
        sub_agent: "process"
  - prometheus: #core agent telemetry
      uri: "http://127.0.0.1:5000/telemetry"
      tags:
        sub_agent: "core"
```
### Motivation

Currently in lading we could configure several prometheus endpoints to listen on to collect target metrics. In the example case of the agent being the target we could configure separate prometheus target metrics to get the internal telemetry of different sub agents. This issue is that when we do this there are some duplicate metrics across the sub agents. For example both the core agent and process agent expose workloadmeta telemetry. We want a way to differentiate not just the duplicate metrics but all of them, so that we can investigate the performance of each sub-agent on its own. This extends to any target. It would be useful to have additional labels configured to differentiate between target metric sources. The use of this applies beyond the agent target. The ability to tag metrics from specific target metrics endpoints would allow more flexibility and observability for any target. 

### Related issues

[SMPTNG-422](https://datadoghq.atlassian.net/browse/SMPTNG-422)

### Additional Notes

Anything else we should know when reviewing?

Open Questions:
-Should I include two labels in the example in the changelog? We only know of use cases at the moment using one additional tag but it is not really clear from the code that you can configure multiple. I also wanted to emphasize that the user can create the tag name by setting whatever key value they want, in addition to setting the tag value. 


[SMPTNG-422]: https://datadoghq.atlassian.net/browse/SMPTNG-422?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ