### PR TITLE
Improve smaps parsing support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 ### Added
 - Retrieve memory, CPU information from cgroup controller for every pid observed on Linux.
+### Fixed
+- Fixes bugs in `smaps` parsing code that can result in under-counting RSS in
+  the smaps view of the data.
 
 ## [0.22.0-rc1]
 ### Fixed

--- a/lading/src/observer/memory.rs
+++ b/lading/src/observer/memory.rs
@@ -368,7 +368,7 @@ impl Regions {
         // regions are separated by a line like this:
         // 7fffa9f39000-7fffa9f3b000 r-xp 00000000 00:00 0                          [vdso]
         let region_start_regex =
-            Regex::new("[[:xdigit:]]+-[[:xdigit:]]+[[:space:]]").expect("Regex to be valid");
+            Regex::new("(?m)^[[:xdigit:]]+-[[:xdigit:]]+").expect("Regex to be valid");
         let mut start_indices = region_start_regex.find_iter(contents).map(|m| m.start());
 
         if let Some(mut start_index) = start_indices.next() {

--- a/lading/src/observer/memory.rs
+++ b/lading/src/observer/memory.rs
@@ -1,7 +1,6 @@
 use regex::Regex;
 use std::{collections::HashMap, io::Read};
 
-const SMAP_SIZE_HINT: usize = 128 * 1024; // 128 kB
 const BYTES_PER_KIBIBYTE: u64 = 1024;
 
 #[derive(thiserror::Error, Debug)]
@@ -56,7 +55,7 @@ impl Rollup {
     pub(crate) fn from_file(path: &str) -> Result<Self, Error> {
         let mut file: std::fs::File = std::fs::OpenOptions::new().read(true).open(path)?;
 
-        let mut contents = String::with_capacity(SMAP_SIZE_HINT);
+        let mut contents = String::new();
         file.read_to_string(&mut contents)?;
 
         Self::from_str(&contents)
@@ -354,7 +353,7 @@ impl Regions {
     fn from_file(path: &str) -> Result<Self, Error> {
         let mut file: std::fs::File = std::fs::OpenOptions::new().read(true).open(path)?;
 
-        let mut contents = String::with_capacity(SMAP_SIZE_HINT);
+        let mut contents = String::new();
         file.read_to_string(&mut contents)?;
 
         Self::from_str(&contents)

--- a/lading/src/observer/memory.rs
+++ b/lading/src/observer/memory.rs
@@ -202,8 +202,11 @@ impl Region {
             };
 
             if let (None, None) = (start, end) {
-                let start_str = &token[0..12];
-                let end_str = &token[13..25];
+                let dash_loc = token.find('-').ok_or(Error::Parsing(format!(
+                    "Could not find dash in addr: {token}"
+                )))?;
+                let start_str = &token[0..dash_loc];
+                let end_str = &token[dash_loc+1..];
                 start = Some(u64::from_str_radix(start_str, 16)?);
                 end = Some(u64::from_str_radix(end_str, 16)?);
             } else if perms.is_none() {
@@ -359,13 +362,13 @@ impl Regions {
         Self::from_str(&contents)
     }
 
-    fn from_str(contents: &str) -> Result<Self, Error> {
+    fn into_region_strs(contents: &str) -> Vec<&str> {
         let mut str_regions = Vec::new();
         // split this smaps file into regions
         // regions are separated by a line like this:
         // 7fffa9f39000-7fffa9f3b000 r-xp 00000000 00:00 0                          [vdso]
         let region_start_regex =
-            Regex::new("[[:xdigit:]]{12}-[[:xdigit:]]{12}").expect("Regex to be valid");
+            Regex::new("[[:xdigit:]]+-[[:xdigit:]]+[[:space:]]").expect("Regex to be valid");
         let mut start_indices = region_start_regex.find_iter(contents).map(|m| m.start());
 
         if let Some(mut start_index) = start_indices.next() {
@@ -377,6 +380,11 @@ impl Regions {
             str_regions.push(&contents[start_index..]);
         };
 
+        str_regions
+    }
+
+    fn from_str(contents: &str) -> Result<Self, Error> {
+        let str_regions = Self::into_region_strs(contents);
         let regions = str_regions
             .iter()
             .map(|s| Region::from_str(s))
@@ -686,5 +694,103 @@ VmFlags: rd ex mr mw me de sd";
         assert_eq!(rollup.pss_anon, None);
         assert_eq!(rollup.pss_file, None);
         assert_eq!(rollup.pss_shmem, None);
+    }
+
+    #[test]
+    fn test_varying_hex_len_mappings() {
+        let region =
+            " 7fffa9f39000-7fffa9f3b000 r-xp 00000000 00:00 0                          [vdso]
+        Size:                  8 kB
+        KernelPageSize:        4 kB
+        MMUPageSize:           4 kB
+        Rss:                   8 kB
+        Pss:                   2 kB
+        Pss_Dirty:             0 kB
+        Shared_Clean:          8 kB
+        Shared_Dirty:          0 kB
+        Private_Clean:         0 kB
+        Private_Dirty:         0 kB
+        Referenced:            8 kB
+        Anonymous:             0 kB
+        LazyFree:              0 kB
+        AnonHugePages:         0 kB
+        ShmemPmdMapped:        0 kB
+        FilePmdMapped:         0 kB
+        Shared_Hugetlb:        0 kB
+        Private_Hugetlb:       0 kB
+        Swap:                  0 kB
+        SwapPss:               0 kB
+        Locked:                0 kB
+        THPeligible:    0
+        ProtectionKey:         0
+        VmFlags: rd ex mr mw me de sd";
+        let region = Region::from_str(region).expect("Parsing failed");
+
+        assert_eq!(region.start, 0x7fffa9f39000);
+        assert_eq!(region.end, 0x7fffa9f3b000);
+
+        let region =
+            "00400000-0e8dd000 r-xp 00000000 00:00 0                          [vdso]
+        Size:                  8 kB
+        KernelPageSize:        4 kB
+        MMUPageSize:           4 kB
+        Rss:                   8 kB
+        Pss:                   2 kB
+        Pss_Dirty:             0 kB
+        Shared_Clean:          8 kB
+        Shared_Dirty:          0 kB
+        Private_Clean:         0 kB
+        Private_Dirty:         0 kB
+        Referenced:            8 kB
+        Anonymous:             0 kB
+        LazyFree:              0 kB
+        AnonHugePages:         0 kB
+        ShmemPmdMapped:        0 kB
+        FilePmdMapped:         0 kB
+        Shared_Hugetlb:        0 kB
+        Private_Hugetlb:       0 kB
+        Swap:                  0 kB
+        SwapPss:               0 kB
+        Locked:                0 kB
+        THPeligible:    0
+        ProtectionKey:         0
+        VmFlags: rd ex mr mw me de sd";
+
+        let region = Region::from_str(region).expect("Parsing failed");
+
+        assert_eq!(region.start, 0x00400000);
+        assert_eq!(region.end, 0x0e8dd000);
+
+        let region =
+            "ffffffffff600000-ffffffffff601000 r-xp 00000000 00:00 0                          [vdso]
+        Size:                  8 kB
+        KernelPageSize:        4 kB
+        MMUPageSize:           4 kB
+        Rss:                   8 kB
+        Pss:                   2 kB
+        Pss_Dirty:             0 kB
+        Shared_Clean:          8 kB
+        Shared_Dirty:          0 kB
+        Private_Clean:         0 kB
+        Private_Dirty:         0 kB
+        Referenced:            8 kB
+        Anonymous:             0 kB
+        LazyFree:              0 kB
+        AnonHugePages:         0 kB
+        ShmemPmdMapped:        0 kB
+        FilePmdMapped:         0 kB
+        Shared_Hugetlb:        0 kB
+        Private_Hugetlb:       0 kB
+        Swap:                  0 kB
+        SwapPss:               0 kB
+        Locked:                0 kB
+        THPeligible:    0
+        ProtectionKey:         0
+        VmFlags: rd ex mr mw me de sd";
+
+        let region = Region::from_str(region).expect("Parsing failed");
+
+        assert_eq!(region.start, 0xffffffffff600000);
+        assert_eq!(region.end, 0xffffffffff601000);
     }
 }


### PR DESCRIPTION
### What does this PR do?

This fixes 2 bugs in the smaps parsing logic and makes 1 simplification.
1. Simpler method of reading smaps to a string, the size-hinting should be done by stdlib
2. A smaps region (VMA) can have varying hex address lengths, this was not properly accounted for
3. The logic to split an smaps file into individual memory regions (VMAs) needs to only match address-range looking things that appear at the beginning of the line.

### Motivation

Inaccurate `/proc/[pid]/smaps` data.

### Related issues


### Additional Notes

