### PR TITLE
Update rust to 1.80

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Changed
+- Now built using rust 1.80.0
 
 ## [0.23.1]
 ### Fixed

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ WORKDIR /app
 COPY . /app
 RUN cargo build --release --locked --bin lading
 
-FROM docker.io/debian:bullseye-20240701-slim
+FROM docker.io/debian:bullseye-20240812-slim
 COPY --from=builder /app/target/release/lading /usr/bin/lading
 
 # smoke test

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Update the rust version in-sync with the version in rust-toolchain.toml
-FROM docker.io/rust:1.80.0-bullseye as builder
+FROM docker.io/rust:1.80.1-bullseye as builder
 
 RUN apt-get update && apt-get install -y \
     protobuf-compiler \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Update the rust version in-sync with the version in rust-toolchain.toml
-FROM docker.io/rust:1.79.0-bullseye as builder
+FROM docker.io/rust:1.80.0-bullseye as builder
 
 RUN apt-get update && apt-get install -y \
     protobuf-compiler \

--- a/lading_payload/src/block.rs
+++ b/lading_payload/src/block.rs
@@ -445,17 +445,13 @@ where
 /// Function will panic if the `serializer` signals an error. In the future we
 /// would like to propagate this error to the caller.
 #[inline]
-fn construct_block<R, S>(
-    mut rng: &mut R,
-    serializer: &S,
-    chunk_size: u32,
-) -> Result<Block, SpinError>
+fn construct_block<R, S>(rng: &mut R, serializer: &S, chunk_size: u32) -> Result<Block, SpinError>
 where
     S: crate::Serialize,
     R: Rng + ?Sized,
 {
     let mut block: Writer<BytesMut> = BytesMut::with_capacity(chunk_size as usize).writer();
-    serializer.to_bytes(&mut rng, chunk_size as usize, &mut block)?;
+    serializer.to_bytes(rng, chunk_size as usize, &mut block)?;
     let bytes: Bytes = block.into_inner().freeze();
     if bytes.is_empty() {
         // Blocks should not be empty and if they are empty this is an

--- a/lading_signal/Cargo.toml
+++ b/lading_signal/Cargo.toml
@@ -22,3 +22,6 @@ loom = { version = "0.7", features = ["futures", "checkpoint"] }
 
 [lib]
 doctest = false
+
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(loom)'] }

--- a/lading_throttle/Cargo.toml
+++ b/lading_throttle/Cargo.toml
@@ -26,3 +26,6 @@ proptest-derive = "0.5.0"
 
 [lib]
 doctest = false
+
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(kani)'] }

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
 # Update the rust version in-sync with the version in Dockerfile
-channel = "1.79.0"
+channel = "1.80.0"
 profile = "minimal"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
 # Update the rust version in-sync with the version in Dockerfile
-channel = "1.80.0"
+channel = "1.80.1"
 profile = "minimal"

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,6 +1,6 @@
 edition = "2021"
 normalize_comments = true
-newline_style = "unix"
+newline_style = "Unix"
 
 # Nightly only features
 # unstable_features = true


### PR DESCRIPTION
### What does this PR do?

Updates the version of rust used to build lading to 1.80. Also updates the debian-slim version.

### Motivation

Primary motivation is to be able to use `LazyLock` and friends.

### Related issues


### Additional Notes

