### PR TITLE
Cut 0.22.0-rc4 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+
+## [0.22.0-rc4]
 ### Added
 - Retrieve memory, CPU information from cgroup controller for every pid observed on Linux.
 - Added ability to create tags for both expvar and prometheus target metrics specific to a single target_metrics configuration (example below shows prometheus metrics collected from the core agent and two additional tags created)
@@ -16,7 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
           sub-agent: "core-agent"
           any-label: "any-string-value"
   ```
-  
+
 ### Fixed
 - Fixes bugs in `smaps` parsing code that can result in under-counting RSS in
   the smaps view of the data.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1387,7 +1387,7 @@ dependencies = [
 
 [[package]]
 name = "lading"
-version = "0.22.0-rc1"
+version = "0.22.0-rc4"
 dependencies = [
  "async-pidfd",
  "average",

--- a/lading/Cargo.toml
+++ b/lading/Cargo.toml
@@ -1,10 +1,11 @@
 [package]
 name = "lading"
-version = "0.22.0-rc1"
+version = "0.22.0-rc4"
 authors = [
     "Brian L. Troutwine <brian.troutwine@datadoghq.com>",
     "George Hahn <george.hahn@datadoghq.com>",
-    "Scott Opell <scott.opell@datadoghq.com>"
+    "Scott Opell <scott.opell@datadoghq.com>",
+    "Caleb Metz <caleb.metz@datadoghq.com>"
 ]
 edition = "2021"
 license = "MIT"


### PR DESCRIPTION
### What does this PR do?

Cuts a release with changes made in [941](https://github.com/DataDog/lading/pull/941) that enable tagging of target metrics

### Related issues

https://github.com/DataDog/lading/pull/941

https://datadoghq.atlassian.net/browse/SMPTNG-422

