### PR TITLE
Add 'no-changelog' to dependabot cargo PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,10 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "daily"
+    labels:
+      - "dependencies"   # needed to preserve default
+      - "github_actions" # needed to preserve default
+      - "no-changelog"   # CI dependencies should not require changelog entry
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:


### PR DESCRIPTION
### What does this PR do?

This commit mimics the behavior we see in github-actions PRs. It relieves a mechanical tedium on human reviewers of dependabot's PRs.

