### PR TITLE
Split lading::signals::Phase into lading_signals, split interface

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -911,6 +911,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "generator"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5cc16584ff22b460a382b7feec54b23d2908d858152e5739a120b949293bd74e"
+dependencies = [
+ "cc",
+ "libc",
+ "log",
+ "rustversion",
+ "windows",
+]
+
+[[package]]
 name = "generic-array"
 version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1404,6 +1417,7 @@ dependencies = [
  "is_executable",
  "lading-capture",
  "lading-payload",
+ "lading-signal",
  "lading-throttle",
  "metrics",
  "metrics-exporter-prometheus",
@@ -1467,6 +1481,15 @@ dependencies = [
  "serde_tuple",
  "thiserror",
  "time",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "lading-signal"
+version = "0.1.0"
+dependencies = [
+ "loom",
  "tokio",
  "tracing",
 ]
@@ -1536,6 +1559,19 @@ name = "log"
 version = "0.4.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
+
+[[package]]
+name = "loom"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff50ecb28bb86013e935fb6683ab1f6d3a20016f123c76fd4c27470076ac30f5"
+dependencies = [
+ "cfg-if",
+ "generator",
+ "scoped-tls",
+ "tracing",
+ "tracing-subscriber",
+]
 
 [[package]]
 name = "matchers"
@@ -3449,6 +3485,15 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e686886bc078bc1b0b600cac0147aadb815089b6e4da64016cbd754b6342700f"
+dependencies = [
+ "windows-targets 0.48.5",
+]
 
 [[package]]
 name = "windows-core"

--- a/lading/Cargo.toml
+++ b/lading/Cargo.toml
@@ -17,6 +17,7 @@ description = "A tool for load testing daemons."
 lading-capture = { version = "0.1", path = "../lading_capture" }
 lading-payload = { version = "0.1", path = "../lading_payload" }
 lading-throttle = { version = "0.1", path = "../lading_throttle" }
+lading-signal = { version = "0.1", path = "../lading_signal" }
 
 average = { version = "0.15", default-features = false, features = [] }
 bollard ={ version = "0.17", default-features = false, features = [] }

--- a/lading/src/bin/lading.rs
+++ b/lading/src/bin/lading.rs
@@ -14,10 +14,10 @@ use lading::{
     config::{Config, Telemetry},
     generator::{self, process_tree},
     inspector, observer,
-    signals::Phase,
     target::{self, Behavior, Output},
     target_metrics,
 };
+use lading_signal::Phase;
 use metrics::gauge;
 use metrics_exporter_prometheus::PrometheusBuilder;
 use once_cell::sync::Lazy;

--- a/lading/src/blackhole.rs
+++ b/lading/src/blackhole.rs
@@ -7,7 +7,7 @@
 
 use serde::{Deserialize, Serialize};
 
-use crate::signals::Phase;
+use lading_signal::Phase;
 
 pub mod http;
 pub mod splunk_hec;

--- a/lading/src/blackhole/http.rs
+++ b/lading/src/blackhole/http.rs
@@ -20,7 +20,7 @@ use serde::{Deserialize, Serialize};
 use tower::ServiceBuilder;
 use tracing::{debug, error, info};
 
-use crate::signals::Phase;
+use lading_signal::Phase;
 
 use super::General;
 

--- a/lading/src/blackhole/splunk_hec.rs
+++ b/lading/src/blackhole/splunk_hec.rs
@@ -26,7 +26,7 @@ use serde::{Deserialize, Serialize};
 use tower::ServiceBuilder;
 use tracing::{error, info};
 
-use crate::signals::Phase;
+use lading_signal::Phase;
 
 use super::General;
 

--- a/lading/src/blackhole/sqs.rs
+++ b/lading/src/blackhole/sqs.rs
@@ -21,7 +21,7 @@ use tokio::time::Duration;
 use tower::ServiceBuilder;
 use tracing::{debug, error, info};
 
-use crate::signals::Phase;
+use lading_signal::Phase;
 
 use super::General;
 

--- a/lading/src/blackhole/tcp.rs
+++ b/lading/src/blackhole/tcp.rs
@@ -16,7 +16,7 @@ use tokio::net::{TcpListener, TcpStream};
 use tokio_util::io::ReaderStream;
 use tracing::info;
 
-use crate::signals::Phase;
+use lading_signal::Phase;
 
 use super::General;
 

--- a/lading/src/blackhole/udp.rs
+++ b/lading/src/blackhole/udp.rs
@@ -13,7 +13,7 @@ use serde::{Deserialize, Serialize};
 use tokio::net::UdpSocket;
 use tracing::info;
 
-use crate::signals::Phase;
+use lading_signal::Phase;
 
 use super::General;
 

--- a/lading/src/blackhole/unix_datagram.rs
+++ b/lading/src/blackhole/unix_datagram.rs
@@ -13,7 +13,7 @@ use serde::{Deserialize, Serialize};
 use tokio::net;
 use tracing::info;
 
-use crate::signals::Phase;
+use lading_signal::Phase;
 
 use super::General;
 

--- a/lading/src/blackhole/unix_stream.rs
+++ b/lading/src/blackhole/unix_stream.rs
@@ -16,7 +16,7 @@ use tokio::net;
 use tokio_util::io::ReaderStream;
 use tracing::info;
 
-use crate::signals::Phase;
+use lading_signal::Phase;
 
 use super::General;
 

--- a/lading/src/captures.rs
+++ b/lading/src/captures.rs
@@ -22,7 +22,7 @@ use rustc_hash::FxHashMap;
 use tracing::{debug, info, warn};
 use uuid::Uuid;
 
-use crate::signals::Phase;
+use lading_signal::Phase;
 
 /// Errors produced by [`CaptureManager`]
 #[derive(thiserror::Error, Debug)]

--- a/lading/src/generator.rs
+++ b/lading/src/generator.rs
@@ -13,7 +13,8 @@
 use serde::{Deserialize, Serialize};
 use tracing::{error, warn};
 
-use crate::{signals::Phase, target::TargetPidReceiver};
+use crate::target::TargetPidReceiver;
+use lading_signal::Phase;
 
 pub mod file_gen;
 pub mod file_tree;

--- a/lading/src/generator/file_gen.rs
+++ b/lading/src/generator/file_gen.rs
@@ -19,7 +19,7 @@ use std::str;
 
 use serde::{Deserialize, Serialize};
 
-use crate::signals::Phase;
+use lading_signal::Phase;
 
 use super::General;
 

--- a/lading/src/generator/file_gen/logrotate.rs
+++ b/lading/src/generator/file_gen/logrotate.rs
@@ -34,8 +34,9 @@ use tokio::{
 };
 use tracing::info;
 
-use crate::{common::PeekableReceiver, signals::Phase};
+use crate::common::PeekableReceiver;
 use lading_payload::block::{self, Block};
+use lading_signal::Phase;
 
 use super::General;
 

--- a/lading/src/generator/file_gen/traditional.rs
+++ b/lading/src/generator/file_gen/traditional.rs
@@ -37,11 +37,12 @@ use tokio::{
 };
 use tracing::info;
 
-use crate::{common::PeekableReceiver, signals::Phase};
+use crate::common::PeekableReceiver;
 use lading_payload::{
     self,
     block::{self, Block},
 };
+use lading_signal::Phase;
 
 use super::General;
 

--- a/lading/src/generator/file_tree.rs
+++ b/lading/src/generator/file_tree.rs
@@ -29,7 +29,7 @@ use serde::{Deserialize, Serialize};
 use tokio::{fs::create_dir, fs::rename, fs::File};
 use tracing::info;
 
-use crate::signals::Phase;
+use lading_signal::Phase;
 
 static FILE_EXTENSION: &str = "txt";
 
@@ -141,8 +141,10 @@ impl FileTree {
         let mut rng = StdRng::from_seed(config.seed);
         let (nodes, _total_files, total_folder) = generate_tree(&mut rng, config)?;
 
-        let _labels = [("component".to_string(), "generator".to_string()),
-            ("component_name".to_string(), "file_tree".to_string())];
+        let _labels = [
+            ("component".to_string(), "generator".to_string()),
+            ("component_name".to_string(), "file_tree".to_string()),
+        ];
 
         let open_throttle = Throttle::new_with_config(config.throttle, config.open_per_second);
         let rename_throttle = Throttle::new_with_config(config.throttle, config.rename_per_second);

--- a/lading/src/generator/grpc.rs
+++ b/lading/src/generator/grpc.rs
@@ -29,8 +29,9 @@ use tonic::{
 };
 use tracing::{debug, info};
 
-use crate::{common::PeekableReceiver, signals::Phase};
+use crate::common::PeekableReceiver;
 use lading_payload::block::{self, Block};
+use lading_signal::Phase;
 
 use super::General;
 

--- a/lading/src/generator/http.rs
+++ b/lading/src/generator/http.rs
@@ -27,8 +27,9 @@ use serde::{Deserialize, Serialize};
 use tokio::sync::{mpsc, Semaphore};
 use tracing::info;
 
-use crate::{common::PeekableReceiver, signals::Phase};
+use crate::common::PeekableReceiver;
 use lading_payload::block::{self, Block};
+use lading_signal::Phase;
 
 use super::General;
 

--- a/lading/src/generator/passthru_file.rs
+++ b/lading/src/generator/passthru_file.rs
@@ -21,8 +21,9 @@ use serde::{Deserialize, Serialize};
 use tokio::sync::mpsc;
 use tracing::{info, warn};
 
-use crate::{common::PeekableReceiver, signals::Phase};
+use crate::common::PeekableReceiver;
 use lading_payload::block::{self, Block};
+use lading_signal::Phase;
 
 use super::General;
 

--- a/lading/src/generator/process_tree.rs
+++ b/lading/src/generator/process_tree.rs
@@ -10,8 +10,8 @@
 //! configured [throttle].
 //!
 
-use crate::signals::Phase;
 use is_executable::IsExecutable;
+use lading_signal::Phase;
 use lading_throttle::Throttle;
 use nix::{
     sys::wait::{waitpid, WaitPidFlag, WaitStatus},
@@ -284,8 +284,10 @@ impl ProcessTree {
             Err(e) => return Err(Error::from(e)),
         };
 
-        let _labels = [("component".to_string(), "generator".to_string()),
-            ("component_name".to_string(), "process_tree".to_string())];
+        let _labels = [
+            ("component".to_string(), "generator".to_string()),
+            ("component_name".to_string(), "process_tree".to_string()),
+        ];
 
         let throttle = Throttle::new_with_config(config.throttle, config.max_tree_per_second);
         match serde_yaml::to_string(config) {

--- a/lading/src/generator/procfs.rs
+++ b/lading/src/generator/procfs.rs
@@ -17,7 +17,7 @@ use rand::rngs::StdRng;
 use rand::SeedableRng;
 use serde::{Deserialize, Serialize};
 
-use crate::signals::Phase;
+use lading_signal::Phase;
 
 #[derive(::thiserror::Error, Debug)]
 /// Errors emitted by [`Procfs`]

--- a/lading/src/generator/splunk_hec.rs
+++ b/lading/src/generator/splunk_hec.rs
@@ -36,10 +36,9 @@ use tokio::{
 };
 use tracing::info;
 
-use crate::{
-    common::PeekableReceiver, generator::splunk_hec::acknowledgements::Channel, signals::Phase,
-};
+use crate::{common::PeekableReceiver, generator::splunk_hec::acknowledgements::Channel};
 use lading_payload::block::{self, Block};
+use lading_signal::Phase;
 
 use super::General;
 

--- a/lading/src/generator/tcp.rs
+++ b/lading/src/generator/tcp.rs
@@ -25,8 +25,9 @@ use serde::{Deserialize, Serialize};
 use tokio::{io::AsyncWriteExt, net::TcpStream, sync::mpsc};
 use tracing::{info, trace};
 
-use crate::{common::PeekableReceiver, signals::Phase};
+use crate::common::PeekableReceiver;
 use lading_payload::block::{self, Block};
+use lading_signal::Phase;
 
 use super::General;
 

--- a/lading/src/generator/udp.rs
+++ b/lading/src/generator/udp.rs
@@ -26,8 +26,9 @@ use serde::{Deserialize, Serialize};
 use tokio::{net::UdpSocket, sync::mpsc};
 use tracing::{debug, info, trace};
 
-use crate::{common::PeekableReceiver, signals::Phase};
+use crate::common::PeekableReceiver;
 use lading_payload::block::{self, Block};
+use lading_signal::Phase;
 
 use super::General;
 

--- a/lading/src/generator/unix_datagram.rs
+++ b/lading/src/generator/unix_datagram.rs
@@ -11,10 +11,11 @@
 //! Additional metrics may be emitted by this generator's [throttle].
 //!
 
-use crate::{common::PeekableReceiver, signals::Phase};
+use crate::common::PeekableReceiver;
 use byte_unit::{Byte, ByteError, ByteUnit};
 use futures::future::join_all;
 use lading_payload::block::{self, Block};
+use lading_signal::Phase;
 use lading_throttle::Throttle;
 use metrics::{counter, gauge};
 use rand::{rngs::StdRng, SeedableRng};

--- a/lading/src/generator/unix_stream.rs
+++ b/lading/src/generator/unix_stream.rs
@@ -11,9 +11,10 @@
 //! Additional metrics may be emitted by this generator's [throttle].
 //!
 
-use crate::{common::PeekableReceiver, signals::Phase};
+use crate::common::PeekableReceiver;
 use byte_unit::ByteError;
 use lading_payload::block::{self, Block};
+use lading_signal::Phase;
 use lading_throttle::Throttle;
 use metrics::{counter, gauge};
 use rand::{rngs::StdRng, SeedableRng};

--- a/lading/src/inspector.rs
+++ b/lading/src/inspector.rs
@@ -26,9 +26,9 @@ use tracing::{error, info};
 
 use crate::{
     common::{stdio, Output},
-    signals::Phase,
     target::TargetPidReceiver,
 };
+use lading_signal::Phase;
 
 #[derive(thiserror::Error, Debug)]
 /// Errors produced by [`Server`]

--- a/lading/src/lib.rs
+++ b/lading/src/lib.rs
@@ -31,6 +31,5 @@ pub mod config;
 pub mod generator;
 pub mod inspector;
 pub mod observer;
-pub mod signals;
 pub mod target;
 pub mod target_metrics;

--- a/lading/src/observer.rs
+++ b/lading/src/observer.rs
@@ -13,7 +13,7 @@ use std::{io, sync::atomic::AtomicU64};
 use crate::target::TargetPidReceiver;
 use serde::Deserialize;
 
-use crate::signals::Phase;
+use lading_signal::Phase;
 
 #[cfg(target_os = "linux")]
 mod linux;

--- a/lading/src/target.rs
+++ b/lading/src/target.rs
@@ -36,7 +36,8 @@ use tokio::{process::Command, time};
 use tracing::{error, info};
 
 pub use crate::common::{Behavior, Output};
-use crate::{common::stdio, observer::RSS_BYTES, signals::Phase};
+use crate::{common::stdio, observer::RSS_BYTES};
+use lading_signal::Phase;
 
 /// Expose the process' current RSS consumption, allowing abstractions to be
 /// built on top in the Target implementation.

--- a/lading/src/target_metrics.rs
+++ b/lading/src/target_metrics.rs
@@ -6,7 +6,7 @@
 
 use serde::Deserialize;
 
-use crate::signals::Phase;
+use lading_signal::Phase;
 
 pub mod expvar;
 pub mod prometheus;

--- a/lading/src/target_metrics/expvar.rs
+++ b/lading/src/target_metrics/expvar.rs
@@ -10,7 +10,7 @@ use serde::Deserialize;
 use serde_json::Value;
 use tracing::{error, info, trace};
 
-use crate::signals::Phase;
+use lading_signal::Phase;
 
 #[derive(Debug, Clone, Copy, thiserror::Error)]
 /// Errors produced by [`Expvar`]

--- a/lading/src/target_metrics/prometheus.rs
+++ b/lading/src/target_metrics/prometheus.rs
@@ -11,7 +11,7 @@ use rustc_hash::FxHashMap;
 use serde::Deserialize;
 use tracing::{error, info, trace, warn};
 
-use crate::signals::Phase;
+use lading_signal::Phase;
 
 #[derive(Debug, Clone, Copy, thiserror::Error)]
 /// Errors produced by [`Prometheus`]

--- a/lading_signal/Cargo.toml
+++ b/lading_signal/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "lading-signal"
+version = "0.1.0"
+authors = ["Brian L. Troutwine <brian.troutwine@datadoghq.com>", "George Hahn <george.hahn@datadoghq.com"]
+edition = "2021"
+license = "MIT"
+repository = "https://github.com/datadog/lading/"
+keywords = ["random_test", "generator"]
+categories = ["development-tools::profiling"]
+description = "A tool for load testing daemons."
+
+[dependencies]
+tokio = { workspace = true, features = ["rt", "sync"] }
+tracing = { workspace = true }
+
+[dev-dependencies]
+loom = "0.5"
+
+[lib]
+doctest = false


### PR DESCRIPTION
### What does this PR do?

This commit moves the Phase mechanism to its own signals crate and introduces loom tests for the Phase structure. We believe there is an overflow bug present in this structure but we are unsure of how to reproduce. This commit introduces three loom tests, one of which fails, so we hope to have a reproduction case.

### Motivation

REF SMPTNG-455
