### PR TITLE
Cut lading 0.23.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+
+## [0.23.0]
 ### Added
 - Added ability to create tags for both expvar and prometheus target metrics specific to a single target_metrics configuration (example below shows prometheus metrics collected from the core agent and two additional tags created)
   ```yaml

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1387,7 +1387,7 @@ dependencies = [
 
 [[package]]
 name = "lading"
-version = "0.22.0"
+version = "0.23.0"
 dependencies = [
  "async-pidfd",
  "average",

--- a/lading/Cargo.toml
+++ b/lading/Cargo.toml
@@ -1,10 +1,11 @@
 [package]
 name = "lading"
-version = "0.22.0"
+version = "0.23.0"
 authors = [
     "Brian L. Troutwine <brian.troutwine@datadoghq.com>",
     "George Hahn <george.hahn@datadoghq.com>",
-    "Scott Opell <scott.opell@datadoghq.com>"
+    "Scott Opell <scott.opell@datadoghq.com>",
+    "Caleb Metz <caleb.metz@datadoghq.com>"
 ]
 edition = "2021"
 license = "MIT"


### PR DESCRIPTION
### What does this PR do?

This commit is the release of 0.23.0 version of lading. We have added the ability to tag prometheus and expvar metrics with user defined tags.

### Motivation

[SMPTNG-422](https://datadoghq.atlassian.net/browse/SMPTNG-422)
https://github.com/DataDog/lading/pull/941


[SMPTNG-422]: https://datadoghq.atlassian.net/browse/SMPTNG-422?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ