### PR TITLE
remove block sizes from examples

### DIFF
--- a/examples/lading.yaml
+++ b/examples/lading.yaml
@@ -4,7 +4,6 @@ generator:
       addr: "0.0.0.0:8282"
       variant: "syslog5424"
       bytes_per_second: "500 Mb"
-      block_sizes: ["1Mb", "0.5Mb", "0.25Mb", "0.125Mb", "128Kb"]
       maximum_prebuild_cache_size_bytes: "256 Mb"
   - file_tree:
       seed: [2, 3, 5, 7, 11, 13, 19, 23, 29, 31, 37, 41, 43, 47, 53, 59, 61, 67, 71, 73, 79, 83, 89, 97, 101, 103, 107, 109, 113, 127, 131, 137]


### PR DESCRIPTION
### What does this PR do?

This was missed when we deprecated block_sizes from configs.

### Motivation


### Related issues


### Additional Notes

