### PR TITLE
Don't instrument `Watcher::recv()`

### DIFF
--- a/lading_signal/src/lib.rs
+++ b/lading_signal/src/lib.rs
@@ -164,7 +164,6 @@ impl Watcher {
     ///
     /// If `recv` is called multiple times after the signal has been received
     /// this function will return immediately.
-    #[tracing::instrument(skip(self))]
     pub async fn recv(&mut self) {
         if self.signal_received {
             // Once the signal is received if this function were called in a


### PR DESCRIPTION
### What does this PR do?

Optional PR. This may work around failing UDS experiments.

### Motivation

`Watcher::recv()` is cancelled and called again on every request sent by the unix datagram generator and likely others. This is incorrect for the new signaling mechanism and should be adjusted. This PR will eliminate a source of log spam that may be causing experiments to fail to complete.
