### PR TITLE
Migrate peer logic management fully into `decrease_peer_count`.

### DIFF
--- a/lading_signal/src/lib.rs
+++ b/lading_signal/src/lib.rs
@@ -139,6 +139,10 @@ impl Watcher {
     /// unblock if waiting for peers. See `Broadcaster::signal_and_wait`.
     #[tracing::instrument(skip(self))]
     fn decrease_peer_count(&mut self) {
+        if self.peer_count_decreased {
+            return;
+        }
+
         // Why not use fetch_sub? That function overflows at the zero boundary
         // and we don't want the peer count to suddenly be u32::MAX.
         let mut old = self.peers.load(Ordering::Relaxed);
@@ -237,9 +241,7 @@ impl Watcher {
 
 impl Drop for Watcher {
     fn drop(&mut self) {
-        if !self.peer_count_decreased {
-            self.decrease_peer_count();
-        }
+        self.decrease_peer_count();
     }
 }
 


### PR DESCRIPTION
### What does this PR do?

It's my goal to re-introduce the distinction between registered and unregistered `Watcher` instances. I want to be very careful about the order of changes, else it will be hard to debug when the loom models ding us.

### Motivation

REF SMPTNG-455
