### PR TITLE
Clarify "registered" notion

### DIFF
--- a/lading_signal/Cargo.toml
+++ b/lading_signal/Cargo.toml
@@ -13,7 +13,7 @@ categories = ["development-tools::profiling"]
 description = "A tool for load testing daemons."
 
 [dependencies]
-tokio = { workspace = true, features = ["time", "sync"] }
+tokio = { workspace = true, features = ["time", "sync", "rt"] }
 tracing = { workspace = true }
 thiserror = { workspace = true }
 


### PR DESCRIPTION
### What does this PR do?

This commit extends the "registered" notion to have a distinct
implementation from something that is not "registered".

### Motivation

REF SMPTNG-455