### PR TITLE
Adjust only CaptureManger to register a Watcher

### DIFF
--- a/lading/src/captures.rs
+++ b/lading/src/captures.rs
@@ -190,11 +190,9 @@ impl CaptureManager {
         std::thread::Builder::new()
             .name("capture-manager".into())
             .spawn(move || {
-                let token = self.shutdown.register();
                 loop {
                     if self.shutdown.try_recv().expect("polled after signal") {
                         info!("shutdown signal received");
-                        drop(token);
                         return;
                     }
                     let now = Instant::now();

--- a/lading/src/generator/file_gen/logrotate.rs
+++ b/lading/src/generator/file_gen/logrotate.rs
@@ -57,9 +57,6 @@ pub enum Error {
     /// Failed to convert, value is 0
     #[error("Value provided must not be zero")]
     Zero,
-    /// Unable to register `Watcher`
-    #[error(transparent)]
-    Watcher(#[from] lading_signal::RegisterError),
 }
 
 #[derive(Debug, Deserialize, Serialize, PartialEq)]
@@ -173,7 +170,7 @@ impl Server {
                 maximum_bytes_per_file,
                 block_cache,
                 throttle,
-                shutdown.register()?,
+                shutdown.clone(),
             );
 
             handles.push(tokio::spawn(child.spin()));

--- a/lading/src/generator/file_gen/traditional.rs
+++ b/lading/src/generator/file_gen/traditional.rs
@@ -63,9 +63,6 @@ pub enum Error {
     /// Failed to convert, value is 0
     #[error("Value provided must not be zero")]
     Zero,
-    /// Unable to register `Watcher`
-    #[error(transparent)]
-    Watcher(#[from] lading_signal::RegisterError),
 }
 
 fn default_rotation() -> bool {
@@ -187,7 +184,7 @@ impl Server {
                 block_cache,
                 file_index: Arc::clone(&file_index),
                 rotate: config.rotate,
-                shutdown: shutdown.register()?,
+                shutdown: shutdown.clone(),
             };
 
             handles.push(tokio::spawn(child.spin()));

--- a/lading/src/generator/splunk_hec.rs
+++ b/lading/src/generator/splunk_hec.rs
@@ -120,9 +120,6 @@ pub enum Error {
     /// Wrapper around [`acknowledgements::Error`]
     #[error(transparent)]
     Acknowledge(#[from] acknowledgements::Error),
-    /// Unable to register `Watcher`
-    #[error(transparent)]
-    Watcher(#[from] lading_signal::RegisterError),
 }
 
 /// Defines a task that emits variant lines to a Splunk HEC server controlling
@@ -298,7 +295,7 @@ impl SplunkHec {
                     // the AckID, meaning we could just keep the channel logic
                     // in this main loop here and avoid the AckService entirely.
                     let permit = CONNECTION_SEMAPHORE.get().expect("Connecton Semaphore is empty or being initialized").acquire().await.expect("Semaphore has already been closed");
-                    tokio::spawn(send_hec_request(permit, block_length, labels, channel, client, request, self.shutdown.register()?));
+                    tokio::spawn(send_hec_request(permit, block_length, labels, channel, client, request, self.shutdown.clone()));
                 }
                 () = self.shutdown.recv() => {
                     info!("shutdown signal received");

--- a/lading/src/generator/unix_datagram.rs
+++ b/lading/src/generator/unix_datagram.rs
@@ -96,9 +96,6 @@ pub enum Error {
     /// Byte error
     #[error("Bytes must not be negative: {0}")]
     Byte(#[from] ByteError),
-    /// Unable to register `Watcher`
-    #[error(transparent)]
-    Watcher(#[from] lading_signal::RegisterError),
 }
 
 #[derive(Debug)]
@@ -163,7 +160,7 @@ impl UnixDatagram {
                 block_cache,
                 throttle: Throttle::new_with_config(config.throttle, bytes_per_second),
                 metric_labels: labels.clone(),
-                shutdown: shutdown.register()?,
+                shutdown: shutdown.clone(),
             };
 
             handles.push(tokio::spawn(child.spin(startup.subscribe())));

--- a/lading/src/target_metrics/prometheus.rs
+++ b/lading/src/target_metrics/prometheus.rs
@@ -17,9 +17,6 @@ pub enum Error {
     /// Prometheus scraper shut down unexpectedly
     #[error("Unexpected shutdown")]
     EarlyShutdown,
-    /// Unable to register `Watcher`
-    #[error(transparent)]
-    Watcher(#[from] lading_signal::RegisterError),
 }
 
 #[derive(Debug, Deserialize, PartialEq, Eq)]
@@ -106,7 +103,7 @@ impl Prometheus {
     #[allow(clippy::cast_possible_truncation)]
     #[allow(clippy::too_many_lines)]
     pub(crate) async fn run(mut self) -> Result<(), Error> {
-        let mut shutdown = self.shutdown.register()?;
+        let mut shutdown = self.shutdown.clone();
         let server = async {
             info!("Prometheus target metrics scraper running, but waiting for warmup to complete");
             self.experiment_started.recv().await; // block until experimental lading_signal::Watcher entered


### PR DESCRIPTION
### What does this PR do?

This commit adjusts lading so that only the CaptureManager has a registered Watcher. We wish to signal and exit the main loop before confirmed shutdown except in the case of the capture writer.

### Motivation

REF SMPTNG-455
