### PR TITLE
Make unmaintained crates a warning

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -23,7 +23,7 @@ allow-git = ["http://github.com/metrics-rs/metrics"]
 
 [advisories]
 vulnerability = "deny"
-unmaintained = "deny"
+unmaintained = "warn"
 notice = "deny"
 unsound = "deny"
 ignore = [


### PR DESCRIPTION
### What does this PR do?

This check is the most noisy hit we get from cargo-deny. Most often it's for a dependency of one of our dependencies, not something we can do anything about.
