### PR TITLE
adds check write perm to audit action

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -1,5 +1,10 @@
 name: Security Audit
 
+
+# The clippy-check job requires this permission to properly surface failures
+permissions:
+  checks: write
+
 on:
   pull_request:
   push:


### PR DESCRIPTION
### What does this PR do?

cargo audit runs are currently only visible within the execution logs due to the lack of this permission.

eg, from
https://github.com/DataDog/lading/actions/runs/10726172279/job/29745638706#step:3:128

```
Warning: 1 warnings found!
Found 1 unmaintained
Error: Unable to publish audit check! Reason: HttpError: Resource not accessible by integration
Warning: It seems that this Action is executed from the forked repository.
Warning: GitHub Actions are not allowed to use Check API, when executed for a forked repos. See https://github.com/actions-rs/clippy-check/issues/2 for details.
```

### Motivation

surface cargo-audit failures in a more noticeable way

### Related issues



### Additional Notes

