### PR TITLE
Make `Watcher::recv` take ownership

### DIFF
--- a/lading/src/blackhole/http.rs
+++ b/lading/src/blackhole/http.rs
@@ -220,7 +220,7 @@ impl Http {
     ///
     /// Function will return an error if the configuration is invalid or if
     /// receiving a packet fails.
-    pub async fn run(mut self) -> Result<(), Error> {
+    pub async fn run(self) -> Result<(), Error> {
         let bytes_received = counter!("bytes_received", &self.metric_labels);
         let requests_received = counter!("requests_received", &self.metric_labels);
         let service = make_service_fn(|_: &AddrStream| {

--- a/lading/src/blackhole/splunk_hec.rs
+++ b/lading/src/blackhole/splunk_hec.rs
@@ -186,7 +186,7 @@ impl SplunkHec {
     /// # Panics
     ///
     /// None known.
-    pub async fn run(mut self) -> Result<(), Error> {
+    pub async fn run(self) -> Result<(), Error> {
         let labels = Arc::new(self.metric_labels.clone());
         let service = make_service_fn(|_: &AddrStream| {
             let labels = labels.clone();

--- a/lading/src/blackhole/sqs.rs
+++ b/lading/src/blackhole/sqs.rs
@@ -96,7 +96,7 @@ impl Sqs {
     /// # Panics
     ///
     /// None known.
-    pub async fn run(mut self) -> Result<(), Error> {
+    pub async fn run(self) -> Result<(), Error> {
         let bytes_received = counter!("bytes_received", &self.metric_labels);
         let requests_received = counter!("requests_received", &self.metric_labels);
         let service = make_service_fn(|_: &AddrStream| {

--- a/lading/src/blackhole/tcp.rs
+++ b/lading/src/blackhole/tcp.rs
@@ -86,7 +86,7 @@ impl Tcp {
     /// # Panics
     ///
     /// None known.
-    pub async fn run(mut self) -> Result<(), Error> {
+    pub async fn run(self) -> Result<(), Error> {
         let listener = TcpListener::bind(self.binding_addr)
             .await
             .map_err(Error::Io)?;
@@ -94,6 +94,8 @@ impl Tcp {
         let connection_accepted = counter!("connection_accepted", &self.metric_labels);
         let labels: &'static _ = Box::new(self.metric_labels.clone()).leak();
 
+        let shutdown_wait = self.shutdown.recv();
+        tokio::pin!(shutdown_wait);
         loop {
             tokio::select! {
                 conn = listener.accept() => {
@@ -103,7 +105,7 @@ impl Tcp {
                         Self::handle_connection(socket, labels)
                     );
                 }
-                () = self.shutdown.recv() => {
+                () = &mut shutdown_wait => {
                     info!("shutdown signal received");
                     return Ok(())
                 }

--- a/lading/src/generator/file_tree.rs
+++ b/lading/src/generator/file_tree.rs
@@ -174,6 +174,8 @@ impl FileTree {
         let mut iter = self.nodes.iter().cycle();
         let mut folders = Vec::with_capacity(self.total_folder);
 
+        let shutdown_wait = self.shutdown.recv();
+        tokio::pin!(shutdown_wait);
         loop {
             tokio::select! {
                 _ = self.open_throttle.wait() => {
@@ -193,7 +195,7 @@ impl FileTree {
                         rename_folder(&mut self.rng, folder, self.name_len.get()).await?;
                     }
                 }
-                () = self.shutdown.recv() => {
+                () = &mut shutdown_wait => {
                     info!("shutdown signal received");
                     break;
                 },

--- a/lading/src/generator/passthru_file.rs
+++ b/lading/src/generator/passthru_file.rs
@@ -145,6 +145,8 @@ impl PassthruFile {
 
         let bytes_written = counter!("bytes_written", &self.metric_labels);
 
+        let shutdown_wait = self.shutdown.recv();
+        tokio::pin!(shutdown_wait);
         let mut current_file = None;
         loop {
             let Some(ref mut current_file) = current_file else {
@@ -189,7 +191,7 @@ impl PassthruFile {
                         }
                     }
                 }
-                () = self.shutdown.recv() => {
+                () = &mut shutdown_wait => {
                     info!("shutdown signal received");
                     return Ok(());
                 },

--- a/lading/src/generator/process_tree.rs
+++ b/lading/src/generator/process_tree.rs
@@ -315,6 +315,8 @@ impl ProcessTree {
     pub async fn spin(mut self) -> Result<(), Error> {
         let lading_path = self.lading_path.to_str().ok_or(Error::ToStr)?;
 
+        let shutdown_wait = self.shutdown.recv();
+        tokio::pin!(shutdown_wait);
         loop {
             tokio::select! {
                 _ = self.throttle.wait() => {
@@ -335,7 +337,7 @@ impl ProcessTree {
                     }
                 },
 
-                () = self.shutdown.recv() => {
+                () = &mut shutdown_wait => {
                     info!("shutdown signal received");
                     break;
                 },

--- a/lading/src/generator/procfs.rs
+++ b/lading/src/generator/procfs.rs
@@ -165,7 +165,7 @@ impl ProcFs {
     /// This function will terminate with an error if files cannot be written to
     /// the directory tree rooted at `self.root`. Any error from
     /// `std::io::Error` is possible.
-    pub async fn spin(mut self) -> Result<(), Error> {
+    pub async fn spin(self) -> Result<(), Error> {
         self.shutdown.recv().await;
         tracing::info!("shutdown signal received");
         Ok(())

--- a/lading/src/generator/udp.rs
+++ b/lading/src/generator/udp.rs
@@ -164,6 +164,8 @@ impl Udp {
         let bytes_written = counter!("bytes_written", &self.metric_labels);
         let packets_sent = counter!("packets_sent", &self.metric_labels);
 
+        let shutdown_wait = self.shutdown.recv();
+        tokio::pin!(shutdown_wait);
         loop {
             let blk = rcv.peek().await.expect("block cache should never be empty");
             let total_bytes = blk.total_bytes;
@@ -204,7 +206,7 @@ impl Udp {
                         }
                     }
                 }
-                () = self.shutdown.recv() => {
+                () = &mut shutdown_wait => {
                     info!("shutdown signal received");
                     return Ok(());
                 },

--- a/lading/src/generator/unix_stream.rs
+++ b/lading/src/generator/unix_stream.rs
@@ -157,6 +157,8 @@ impl UnixStream {
 
         let mut current_connection = None;
 
+        let shutdown_wait = self.shutdown.recv();
+        tokio::pin!(shutdown_wait);
         loop {
             let Some(ref socket) = current_connection else {
                 match net::UnixStream::connect(&self.path).await {
@@ -231,7 +233,7 @@ impl UnixStream {
                         }
                     }
                 }
-                () = self.shutdown.recv() => {
+                () = &mut shutdown_wait => {
                     info!("shutdown signal received");
                     return Ok(());
                 },

--- a/lading/src/inspector.rs
+++ b/lading/src/inspector.rs
@@ -107,7 +107,7 @@ impl Server {
     /// # Panics
     ///
     /// None are known.
-    pub async fn run(mut self, mut pid_snd: TargetPidReceiver) -> Result<ExitStatus, Error> {
+    pub async fn run(self, mut pid_snd: TargetPidReceiver) -> Result<ExitStatus, Error> {
         let target_pid = pid_snd.recv().await?;
         drop(pid_snd);
 

--- a/lading/src/target_metrics/expvar.rs
+++ b/lading/src/target_metrics/expvar.rs
@@ -69,7 +69,7 @@ impl Expvar {
     /// # Panics
     ///
     /// None are known.
-    pub(crate) async fn run(mut self) -> Result<(), Error> {
+    pub(crate) async fn run(self) -> Result<(), Error> {
         info!("Expvar target metrics scraper running, but waiting for warmup to complete");
         self.experiment_started.recv().await; // block until experimental lading_signal::Watcher entered
         info!("Expvar target metrics scraper starting collection");

--- a/lading_signal/src/lib.rs
+++ b/lading_signal/src/lib.rs
@@ -183,7 +183,7 @@ impl Watcher {
     ///
     /// If `recv` is called multiple times after the signal has been received
     /// this function will return immediately.
-    pub async fn recv(&mut self) {
+    pub async fn recv(mut self) {
         if self.signal_received {
             // Once the signal is received if this function were called in a
             // `select!` it might drown out every other arm. May indicate the
@@ -210,7 +210,6 @@ impl Watcher {
     ///
     /// If the signal has not been received returns Ok(false). If it has been
     /// received Ok(true). All calls after will return `TryRecvError::SignalReceived`.
-    #[tracing::instrument(skip(self))]
     pub fn try_recv(&mut self) -> Result<bool, TryRecvError> {
         // If the shutdown signal has already been received, return with error.
         if self.signal_received {
@@ -285,7 +284,7 @@ mod tests {
         use crate::signal;
 
         loom::model(|| {
-            let (mut watcher, broadcaster) = signal();
+            let (watcher, broadcaster) = signal();
 
             // In a thread we have a singular watcher that blocks on recv.
             let watcher_handle = thread::spawn(move || {
@@ -309,7 +308,7 @@ mod tests {
         use crate::signal;
 
         loom::model(|| {
-            let (mut watcher, broadcaster) = signal();
+            let (watcher, broadcaster) = signal();
             let _unregistered_watcher = watcher.clone();
 
             // In a thread we have a singular watcher that blocks on recv.
@@ -359,8 +358,8 @@ mod tests {
         use crate::signal;
 
         loom::model(|| {
-            let (mut watcher1, broadcaster) = signal();
-            let mut watcher2 = watcher1.register().unwrap();
+            let (watcher1, broadcaster) = signal();
+            let watcher2 = watcher1.register().unwrap();
 
             // Create two watchers in two threads, blocking on recv.
             let watcher_handle1 = thread::spawn(move || {
@@ -388,8 +387,8 @@ mod tests {
         use crate::signal;
 
         loom::model(|| {
-            let (mut watcher1, broadcaster) = signal();
-            let mut watcher2 = watcher1.register().unwrap();
+            let (watcher1, broadcaster) = signal();
+            let watcher2 = watcher1.register().unwrap();
             let _unregistered_watcher = watcher2.clone();
 
             // Create two watchers in two threads, blocking on recv.


### PR DESCRIPTION
### What does this PR do?

This commit resolves a long-standing confusion as to whether recv
should be called multiple times and to what will happen if it is.
We resolve now to only allow it to be called once, requiring a future
from recv to be pinned on the stack.

### Motivation

SMPTNG-455

