### PR TITLE
Don't start warmup period until target is running

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
-
-###
+### Changed
 - Now built using rust 1.81.0.
+
+### Fixed
+- Warmup period is now respected when container targeting is in use.
 
 ## [0.23.1]
 ### Fixed


### PR DESCRIPTION
### What does this PR do?

Wait for the target PID broadcast before starting the warmup timer. This indicates that the target is running. I decided not to use a standard lading signal because the PID broadcast is already setup and serving the same purpose.

### Motivation

This fixes an issue where the warmup period is finishing before the target is fully started when container targeting is used.
