### PR TITLE
captool: fix zstd detection

### DIFF
--- a/lading/src/bin/captool.rs
+++ b/lading/src/bin/captool.rs
@@ -55,7 +55,7 @@ async fn main() -> Result<(), Error> {
 
     let is_zstd = capture_path
         .extension()
-        .is_some_and(|ext| ext == OsStr::new(".zstd"));
+        .is_some_and(|ext| ext == OsStr::new("zstd"));
 
     let mut file = tokio::fs::File::open(capture_path).await?;
 


### PR DESCRIPTION
### What does this PR do?

Fix zstd-by-extension detection in captool.

### Motivation

Make captool correctly detect capture format by extension name.