### PR TITLE
captool: use streaming readers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -87,6 +87,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-compression"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fec134f64e2bc57411226dfc4e52dec859ddfc7e711fc5e07b612584f000e4aa"
+dependencies = [
+ "futures-core",
+ "memchr",
+ "pin-project-lite",
+ "tokio",
+ "zstd",
+ "zstd-safe",
+]
+
+[[package]]
 name = "async-io"
 version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1408,6 +1422,7 @@ dependencies = [
 name = "lading"
 version = "0.23.2"
 dependencies = [
+ "async-compression",
  "async-pidfd",
  "average",
  "bollard",
@@ -1445,6 +1460,7 @@ dependencies = [
  "tempfile",
  "thiserror",
  "tokio",
+ "tokio-stream",
  "tokio-util",
  "tonic 0.9.2",
  "tower",

--- a/lading/Cargo.toml
+++ b/lading/Cargo.toml
@@ -20,6 +20,7 @@ lading-payload = { version = "0.1", path = "../lading_payload" }
 lading-throttle = { version = "0.1", path = "../lading_throttle" }
 lading-signal = { version = "0.1", path = "../lading_signal" }
 
+async-compression = { version = "0.4.6", features = ["tokio", "zstd"] }
 average = { version = "0.15", default-features = false, features = [] }
 bollard = { version = "0.17", default-features = false, features = [] }
 byte-unit = { workspace = true }
@@ -70,6 +71,7 @@ tokio = { workspace = true, features = [
   "time",
   "net",
 ] }
+tokio-stream = { version = "0.1", features = ["io-util"] }
 tokio-util = { version = "0.7", features = ["io"] }
 tonic = { version = "0.9" }
 tower = { version = "0.4", default-features = false, features = [

--- a/lading/src/captures.rs
+++ b/lading/src/captures.rs
@@ -8,7 +8,6 @@
 //! that same crate.
 
 use std::{
-    borrow::Cow,
     ffi::OsStr,
     io::{self, BufWriter, Write},
     path::PathBuf,
@@ -127,7 +126,7 @@ impl CaptureManager {
                     labels.insert(lbl.key().into(), lbl.value().into());
                 }
                 let line = json::Line {
-                    run_id: Cow::Borrowed(&self.run_id),
+                    run_id: self.run_id,
                     time: now_ms,
                     fetch_index: self.fetch_index,
                     metric_name: key.name().into(),
@@ -147,7 +146,7 @@ impl CaptureManager {
                 }
                 let value: f64 = f64::from_bits(gauge.load(Ordering::Relaxed));
                 let line = json::Line {
-                    run_id: Cow::Borrowed(&self.run_id),
+                    run_id: self.run_id,
                     time: now_ms,
                     fetch_index: self.fetch_index,
                     metric_name: key.name().into(),

--- a/lading_capture/src/json.rs
+++ b/lading_capture/src/json.rs
@@ -3,7 +3,6 @@
 
 use rustc_hash::FxHashMap;
 use serde::{Deserialize, Serialize};
-use std::borrow::Cow;
 use uuid::Uuid;
 
 #[derive(Debug, Serialize, Deserialize, Clone, Copy)]
@@ -49,11 +48,10 @@ impl std::fmt::Display for LineValue {
 
 #[derive(Debug, Serialize, Deserialize)]
 /// The structure of a capture file line.
-pub struct Line<'a> {
-    #[serde(borrow)]
+pub struct Line {
     /// An id that is mostly unique to this run, allowing us to distinguish
     /// duplications of the same observational setup.
-    pub run_id: Cow<'a, Uuid>,
+    pub run_id: Uuid,
     /// The time in milliseconds that this line was written.
     pub time: u128,
     /// The "fetch index". Previous versions of lading scraped prometheus
@@ -72,7 +70,7 @@ pub struct Line<'a> {
     pub labels: FxHashMap<String, String>,
 }
 
-impl<'a> Line<'a> {
+impl Line {
     #[must_use]
     #[allow(clippy::cast_possible_truncation)]
     /// Returns the number of seconds since unix epoch


### PR DESCRIPTION
### What does this PR do?

Convert captool to stream input files rather than reading them in entirety.

### Motivation

This is not much faster, but ought to have much lower peak memory usage.
