### PR TITLE
Capture files will now exclude metrics that have not been emitted recently

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1434,6 +1434,7 @@ dependencies = [
  "procfs",
  "proptest",
  "proptest-derive",
+ "quanta",
  "rand",
  "regex",
  "reqwest",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -704,7 +704,7 @@ dependencies = [
  "once_cell",
  "serde_json",
  "shared",
- "sketches-ddsketch 0.3.0",
+ "sketches-ddsketch",
  "tokio",
  "tokio-stream",
  "tonic 0.9.2",
@@ -1607,8 +1607,7 @@ checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 [[package]]
 name = "metrics"
 version = "0.23.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "884adb57038347dfbaf2d5065887b6cf4312330dc8e94bc30a1a839bd79d3261"
+source = "git+https://github.com/scottopell/metrics.git?rev=6e40d6c08f4d3a2059a0a7577a6e11930acb52ee#6e40d6c08f4d3a2059a0a7577a6e11930acb52ee"
 dependencies = [
  "ahash",
  "portable-atomic",
@@ -1617,8 +1616,7 @@ dependencies = [
 [[package]]
 name = "metrics-exporter-prometheus"
 version = "0.15.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4f0c8427b39666bf970460908b213ec09b3b350f20c0c2eabcbba51704a08e6"
+source = "git+https://github.com/scottopell/metrics.git?rev=6e40d6c08f4d3a2059a0a7577a6e11930acb52ee#6e40d6c08f4d3a2059a0a7577a6e11930acb52ee"
 dependencies = [
  "base64 0.22.1",
  "http-body-util",
@@ -1637,8 +1635,7 @@ dependencies = [
 [[package]]
 name = "metrics-util"
 version = "0.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4259040465c955f9f2f1a4a8a16dc46726169bca0f88e8fb2dbeced487c3e828"
+source = "git+https://github.com/scottopell/metrics.git?rev=6e40d6c08f4d3a2059a0a7577a6e11930acb52ee#6e40d6c08f4d3a2059a0a7577a6e11930acb52ee"
 dependencies = [
  "aho-corasick",
  "crossbeam-epoch",
@@ -1646,11 +1643,10 @@ dependencies = [
  "hashbrown 0.14.5",
  "indexmap 2.2.6",
  "metrics",
- "num_cpus",
  "ordered-float",
  "quanta",
  "radix_trie",
- "sketches-ddsketch 0.2.2",
+ "sketches-ddsketch",
 ]
 
 [[package]]
@@ -2664,12 +2660,6 @@ checksum = "a9e9e0b4211b72e7b8b6e85c807d36c212bdb33ea8587f7569562a84df5465b1"
 dependencies = [
  "libc",
 ]
-
-[[package]]
-name = "sketches-ddsketch"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85636c14b73d81f541e525f585c0a2109e6744e1565b5c1668e31c70c10ed65c"
 
 [[package]]
 name = "sketches-ddsketch"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,12 +12,13 @@ members = [
 [workspace.dependencies]
 bytes = { version = "1.7", default-features = false, features = ["std"] }
 byte-unit = { version = "4.0", features = ["serde"] }
-metrics = { version = "0.23.0" }
-metrics-util = { version = "0.17.0" }
-metrics-exporter-prometheus = { version = "0.15.3", default-features = false, features = [
-  "http-listener",
-  "uds-listener",
-] }
+
+# Metrics-rs crates are pinned to 6e40d6c08f4d3a2059a0a7577a6e11930acb52ee until
+# a release is cut that contains https://github.com/metrics-rs/metrics/pull/522
+metrics = { git = "https://github.com/scottopell/metrics.git", rev = "6e40d6c08f4d3a2059a0a7577a6e11930acb52ee" }
+metrics-util = { git = "https://github.com/scottopell/metrics.git", rev = "6e40d6c08f4d3a2059a0a7577a6e11930acb52ee" }
+metrics-exporter-prometheus = { git = "https://github.com/scottopell/metrics.git", rev = "6e40d6c08f4d3a2059a0a7577a6e11930acb52ee", default-features = false, features = ["http-listener", "uds-listener"]}
+
 prost = "0.11"
 rand = { version = "0.8", default-features = false }
 rustc-hash = { version = "1.1" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ tokio = { version = "1.40" }
 tracing = { version = "0.1" }
 uuid = { version = "1.6", default-features = false, features = ["v4", "serde"] }
 once_cell = { version = "1.19" }
+quanta = { version = "0.12", default-features = false, features = [] }
 
 [profile.release]
 lto = true        # Optimize our binary at link stage.

--- a/lading/Cargo.toml
+++ b/lading/Cargo.toml
@@ -83,6 +83,7 @@ tracing = { workspace = true }
 tracing-subscriber = { version = "0.3", features = ["std", "env-filter"] }
 uuid = { workspace = true }
 zstd = "0.13.1"
+quanta = { workspace = true }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 cgroups-rs = { version = "0.3", default-features = false, features = [] }

--- a/lading/src/blackhole/http.rs
+++ b/lading/src/blackhole/http.rs
@@ -15,7 +15,7 @@ use hyper::{
     service::{make_service_fn, service_fn},
     Body, Request, Response, Server, StatusCode,
 };
-use metrics::{counter, Counter};
+use metrics::counter;
 use serde::{Deserialize, Serialize};
 use tower::ServiceBuilder;
 use tracing::{debug, error, info};
@@ -119,13 +119,12 @@ struct KinesisPutRecordBatchResponse {
 #[allow(clippy::borrow_interior_mutable_const)]
 async fn srv(
     status: StatusCode,
-    bytes_received: Counter,
-    requests_received: Counter,
+    metric_labels: Vec<(String, String)>,
     body_bytes: Vec<u8>,
     req: Request<Body>,
     headers: HeaderMap,
 ) -> Result<Response<Body>, hyper::Error> {
-    requests_received.increment(1);
+    counter!("requests_received", &metric_labels).increment(1);
 
     let (parts, body) = req.into_parts();
 
@@ -134,7 +133,7 @@ async fn srv(
     match crate::codec::decode(parts.headers.get(hyper::header::CONTENT_ENCODING), bytes) {
         Err(response) => Ok(response),
         Ok(body) => {
-            bytes_received.increment(body.len() as u64);
+            counter!("bytes_received", &metric_labels).increment(body.len() as u64);
 
             let mut okay = Response::default();
             *okay.status_mut() = status;
@@ -221,20 +220,16 @@ impl Http {
     /// Function will return an error if the configuration is invalid or if
     /// receiving a packet fails.
     pub async fn run(self) -> Result<(), Error> {
-        let bytes_received = counter!("bytes_received", &self.metric_labels);
-        let requests_received = counter!("requests_received", &self.metric_labels);
         let service = make_service_fn(|_: &AddrStream| {
-            let bytes_received = bytes_received.clone();
-            let requests_received = requests_received.clone();
             let body_bytes = self.body_bytes.clone();
             let headers = self.headers.clone();
+            let metric_labels = self.metric_labels.clone();
             async move {
                 Ok::<_, hyper::Error>(service_fn(move |request| {
                     debug!("REQUEST: {:?}", request);
                     srv(
                         self.status,
-                        bytes_received.clone(),
-                        requests_received.clone(),
+                        metric_labels.clone(),
                         body_bytes.clone(),
                         request,
                         headers.clone(),

--- a/lading/src/blackhole/sqs.rs
+++ b/lading/src/blackhole/sqs.rs
@@ -14,7 +14,7 @@ use hyper::{
     service::{make_service_fn, service_fn},
     Body, Request, Response, Server, StatusCode,
 };
-use metrics::{counter, Counter};
+use metrics::counter;
 use rand::{distributions::Alphanumeric, thread_rng, Rng};
 use serde::{Deserialize, Serialize};
 use tokio::time::Duration;
@@ -97,16 +97,11 @@ impl Sqs {
     ///
     /// None known.
     pub async fn run(self) -> Result<(), Error> {
-        let bytes_received = counter!("bytes_received", &self.metric_labels);
-        let requests_received = counter!("requests_received", &self.metric_labels);
         let service = make_service_fn(|_: &AddrStream| {
-            let bytes_received = bytes_received.clone();
-            let requests_received = requests_received.clone();
+            let metric_labels = self.metric_labels.clone();
             async move {
                 Ok::<_, hyper::Error>(service_fn(move |req| {
-                    let bytes_received = bytes_received.clone();
-                    let requests_received = requests_received.clone();
-                    srv(req, requests_received, bytes_received)
+                    srv(req, metric_labels.clone())
                 }))
             }
         });
@@ -238,13 +233,12 @@ impl DeleteMessageBatch {
 
 async fn srv(
     req: Request<Body>,
-    requests_received: Counter,
-    bytes_received: Counter,
+    metric_labels: Vec<(String, String)>,
 ) -> Result<Response<Body>, Error> {
-    requests_received.increment(1);
+    counter!("requests_received", &metric_labels).increment(1);
 
     let bytes = body::to_bytes(req).await?;
-    bytes_received.increment(bytes.len() as u64);
+    counter!("bytes_received", &metric_labels).increment(bytes.len() as u64);
 
     let action: Action = serde_qs::from_bytes(&bytes)?;
 

--- a/lading/src/blackhole/tcp.rs
+++ b/lading/src/blackhole/tcp.rs
@@ -63,13 +63,11 @@ impl Tcp {
 
     async fn handle_connection(socket: TcpStream, labels: &'static [(String, String)]) {
         let mut stream = ReaderStream::new(socket);
-        let bytes_received = counter!("bytes_received", labels);
-        let message_received = counter!("message_received", labels);
 
         while let Some(msg) = stream.next().await {
-            message_received.increment(1);
+            counter!("message_received", labels).increment(1);
             if let Ok(msg) = msg {
-                bytes_received.increment(msg.len() as u64);
+                counter!("bytes_received", labels).increment(msg.len() as u64);
             }
         }
     }
@@ -91,7 +89,6 @@ impl Tcp {
             .await
             .map_err(Error::Io)?;
 
-        let connection_accepted = counter!("connection_accepted", &self.metric_labels);
         let labels: &'static _ = Box::new(self.metric_labels.clone()).leak();
 
         let shutdown_wait = self.shutdown.recv();
@@ -100,7 +97,7 @@ impl Tcp {
             tokio::select! {
                 conn = listener.accept() => {
                     let (socket, _) = conn.map_err(Error::Io)?;
-                    connection_accepted.increment(1);
+                    counter!("connection_accepted", &self.metric_labels).increment(1);
                     tokio::spawn(
                         Self::handle_connection(socket, labels)
                     );

--- a/lading/src/blackhole/unix_datagram.rs
+++ b/lading/src/blackhole/unix_datagram.rs
@@ -77,15 +77,13 @@ impl UnixDatagram {
         let socket = net::UnixDatagram::bind(&self.path).map_err(Error::Io)?;
         let mut buf = [0; 65536];
 
-        let bytes_received = counter!("bytes_received", &self.metric_labels);
-
         let shutdown_wait = self.shutdown.recv();
         tokio::pin!(shutdown_wait);
         loop {
             tokio::select! {
                 res = socket.recv(&mut buf) => {
                     let n: usize = res.map_err(Error::Io)?;
-                    bytes_received.increment(n as u64);
+                    counter!("bytes_received", &self.metric_labels).increment(n as u64);
                 }
                 () = &mut shutdown_wait => {
                     info!("shutdown signal received");

--- a/lading/src/captures.rs
+++ b/lading/src/captures.rs
@@ -131,11 +131,12 @@ impl CaptureManager {
             .registry
             .visit_counters(|key: &metrics::Key, counter| {
                 let gen = counter.get_generation();
-
-                if !self
+                let should_store = self
                     .inner
                     .recency
-                    .should_store_counter(key, gen, &self.inner.registry)
+                    .has_counter_expired(key, gen, &self.inner.registry);
+
+                if !should_store
                 {
                     // Skip this metric, its too old
                     return;
@@ -161,11 +162,12 @@ impl CaptureManager {
             .registry
             .visit_gauges(|key: &metrics::Key, gauge| {
                 let gen = gauge.get_generation();
-
-                if !self
+                let should_store = self
                     .inner
                     .recency
-                    .should_store_gauge(key, gen, &self.inner.registry)
+                    .has_gauge_expired(key, gen, &self.inner.registry);
+
+                if !should_store
                 {
                     // Skip this metric, its too old
                     return;

--- a/lading/src/captures.rs
+++ b/lading/src/captures.rs
@@ -75,6 +75,7 @@ impl CaptureManager {
     /// Function will error if the underlying capture file cannot be opened.
     pub async fn new(
         capture_path: PathBuf,
+        metric_expiration_duration: Option<Duration>,
         shutdown: lading_signal::Watcher,
         experiment_started: lading_signal::Watcher,
         target_running: lading_signal::Watcher,
@@ -94,7 +95,7 @@ impl CaptureManager {
                 recency: Recency::new(
                     quanta::Clock::new(),
                     MetricKindMask::COUNTER | MetricKindMask::GAUGE,
-                    Some(Duration::from_secs(2)),
+                    metric_expiration_duration,
                 ),
             }),
             global_labels: FxHashMap::default(),

--- a/lading/src/config.rs
+++ b/lading/src/config.rs
@@ -80,6 +80,8 @@ pub enum Telemetry {
         path: PathBuf,
         /// Additional labels to include in every metric
         global_labels: FxHashMap<String, String>,
+        /// Time to consider metrics 'expired' and not to be included in the log
+        metric_expiration_duration: Option<std::time::Duration>,
     },
 }
 

--- a/lading/src/generator/file_gen/logrotate.rs
+++ b/lading/src/generator/file_gen/logrotate.rs
@@ -279,7 +279,6 @@ impl Child {
         let (snd, rcv) = mpsc::channel(1024);
         let mut rcv: PeekableReceiver<Block> = PeekableReceiver::new(rcv);
         thread::Builder::new().spawn(|| block_cache.spin(snd))?;
-        let bytes_written = counter!("bytes_written");
 
         let shutdown_wait = self.shutdown.recv();
         tokio::pin!(shutdown_wait);
@@ -296,7 +295,7 @@ impl Child {
 
                     {
                         fp.write_all(&blk.bytes).await?;
-                        bytes_written.increment(total_bytes);
+                        counter!("bytes_written").increment(total_bytes);
                         total_bytes_written += total_bytes;
                     }
 

--- a/lading/src/generator/file_gen/traditional.rs
+++ b/lading/src/generator/file_gen/traditional.rs
@@ -255,7 +255,6 @@ impl Child {
         let (snd, rcv) = mpsc::channel(1024);
         let mut rcv: PeekableReceiver<Block> = PeekableReceiver::new(rcv);
         thread::Builder::new().spawn(|| block_cache.spin(snd))?;
-        let bytes_written = counter!("bytes_written");
 
         let shutdown_wait = self.shutdown.recv();
         tokio::pin!(shutdown_wait);
@@ -270,7 +269,7 @@ impl Child {
 
                     {
                         fp.write_all(&blk.bytes).await?;
-                        bytes_written.increment(total_bytes);
+                        counter!("bytes_written").increment(total_bytes);
                         total_bytes_written += total_bytes;
                     }
 

--- a/lading/src/target_metrics/expvar.rs
+++ b/lading/src/target_metrics/expvar.rs
@@ -107,11 +107,10 @@ impl Expvar {
                     let val = json.pointer(var_name).and_then(serde_json::Value::as_f64);
                     if let Some(val) = val {
                         trace!("expvar: {} = {}", var_name, val);
-                        let handle = gauge!(
+                        gauge!(
                             format!("target/{name}", name = var_name.trim_start_matches('/'),),
                             &all_labels
-                        );
-                        handle.set(val);
+                        ).set(val);
                     }
                 }
             }

--- a/lading/src/target_metrics/prometheus.rs
+++ b/lading/src/target_metrics/prometheus.rs
@@ -279,8 +279,7 @@ pub(crate) async fn scrape_metrics(
                 };
 
                 trace!("counter: {name} = {value}");
-                let handle = counter!(format!("target/{name}"), &all_labels.unwrap_or_default());
-                handle.absolute(value);
+                counter!(format!("target/{name}"), &all_labels.unwrap_or_default()).absolute(value);
             }
             Some(_) => {
                 trace!("unsupported metric type: {name} = {value}");

--- a/lading/src/target_metrics/prometheus.rs
+++ b/lading/src/target_metrics/prometheus.rs
@@ -256,8 +256,7 @@ pub(crate) async fn scrape_metrics(
                     continue;
                 };
 
-                let handle = gauge!(format!("target/{name}"), &all_labels.unwrap_or_default());
-                handle.set(value);
+                gauge!(format!("target/{name}"), &all_labels.unwrap_or_default()).set(value);
             }
             Some(MetricType::Counter) => {
                 let Ok(value): Result<f64, _> = value.parse() else {


### PR DESCRIPTION
### What does this PR do?

Only consider metrics emitted within the last 2 seconds when emitting to the capture file

### Motivation

Stale counters are a particularly large problem when considering short-lived processes and the observer metrics.

### Related issues

This is basically the exact same code from #748 , which was later reverted in #762. At the time, a deadlock was occurring which prevented forward progress.

That is the main risk I'll be evaluating while trying to land this change.

### Additional Notes

Currently this relies on a custom branch of `metrics-rs` https://github.com/metrics-rs/metrics/pull/522

This is needed due to the `RWMutex` interactions with `Recency`, so another option for this is to rewrite the capture exporter entirely to avoid needing `Recency` at all.

```
George Hahn
  Yesterday at 1:21 PM
Could we get onto a better path if we moved away from the prometheus exporter? We copied and customized it to write a file, and we should have flexibility with how that's wired up.
tobz
100%, yes
tobz
my understanding of your metrics load is that it's not very high -- like 100s to 1000s of emissions per second? -- which would be more than fast enough even if you just did a simple Mutex<HashMap<...>> or whatever
:nod2:

tobz
  and then every reporting period consumes that map, and voila, now you're "expiring" old metrics
George Hahn
  Yep, that's right in line with our typical load. We handle writing on a separate thread too, bet we could swap maps and block for almost no time.
tobz
  yeah, swap maps, whatever
Scott Opell
  I don’t follow the idea here, are we talking about a custom Registry? Or just calling retain_* to delete all metrics after a given reporting peried?
George Hahn
  I should note I'm not up to speed on metrics internals. My thought is that we could fully break from the patterns used in the capture manager today and build a recorder from the ground up. Looking at something like the [tcp exporter](https://github.com/metrics-rs/metrics/blob/main/metrics-exporter-tcp/src/lib.rs), I think that could mean running without a registry at all.
tobz
  yeah, exactly
tobz
  it could be anything from:
every every handle just wraps an Arc<Mutex<HashMap<...>>> and does a get/insert to emit a metric
every handle wraps a Arc<SomeMpscChannel<...>> and sends a message to emit a metric
tobz
  or something else!
```


REF [SMPTNG-85](https://datadoghq.atlassian.net/browse/SMPTNG-85)


[SMPTNG-85]: https://datadoghq.atlassian.net/browse/SMPTNG-85?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ