### PR TITLE
Allow blackhole to delay response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Linux observer is more resilient to scenarios where lading lacks ptrace permission.
 ### Removed
 - lading_capture no longer exports a protobuf version of the capture.
+### Added
+- HTTP blackhole now has a response_delay setting, allowing for simulation of latent network connections.
 
 ## [0.23.2]
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 - lading_capture no longer exports a protobuf version of the capture.
 ### Added
-- HTTP blackhole now has a response_delay setting, allowing for simulation of latent network connections.
+- HTTP blackhole now has a `response_delay_millis` setting, allowing for
+  simulation of latent network connections.
 
 ## [0.23.2]
 ### Changed

--- a/lading/src/blackhole/http.rs
+++ b/lading/src/blackhole/http.rs
@@ -62,8 +62,8 @@ fn default_body_variant() -> BodyVariant {
     BodyVariant::Nothing
 }
 
-fn default_response_delay() -> Duration {
-    Duration::from_millis(0)
+fn default_response_delay_millis() -> u64 {
+    0
 }
 
 fn default_status_code() -> u16 {
@@ -103,8 +103,8 @@ pub struct Config {
     #[serde(default)]
     pub raw_bytes: Vec<u8>,
     /// delay to add before making a response
-    #[serde(default = "default_response_delay")]
-    pub response_delay: Duration,
+    #[serde(default = "default_response_delay_millis")]
+    pub response_delay_millis: u64,
 }
 
 #[derive(Serialize)]
@@ -219,7 +219,7 @@ impl Http {
             status,
             shutdown,
             metric_labels,
-            response_delay: config.response_delay,
+            response_delay: Duration::from_millis(config.response_delay_millis),
         })
     }
 

--- a/lading/src/blackhole/http.rs
+++ b/lading/src/blackhole/http.rs
@@ -300,6 +300,7 @@ body_variant: "nothing"
             config,
             Config {
                 concurrent_requests_max: default_concurrent_requests_max(),
+                response_delay_millis: default_response_delay_millis(),
                 binding_addr: SocketAddr::from_str("127.0.0.1:1000")
                     .expect("Not possible to parse into SocketAddr"),
                 body_variant: BodyVariant::Nothing,
@@ -323,6 +324,7 @@ raw_bytes: [0x01, 0x02, 0x10]
             config,
             Config {
                 concurrent_requests_max: default_concurrent_requests_max(),
+                response_delay_millis: default_response_delay_millis(),
                 binding_addr: SocketAddr::from_str("127.0.0.1:1000")
                     .expect("Not possible to parse into SocketAddr"),
                 body_variant: BodyVariant::RawBytes,


### PR DESCRIPTION
### What does this PR do?

This commit allows lading HTTP blackhole to delay a response to
the sender, intention being to allow for the simulation of latent
network connections to a sink location.

