### PR TITLE
Remove span event log churn

### DIFF
--- a/lading/src/bin/lading.rs
+++ b/lading/src/bin/lading.rs
@@ -30,7 +30,7 @@ use tokio::{
     time::{self, sleep, Duration},
 };
 use tracing::{debug, error, info, info_span, warn, Instrument};
-use tracing_subscriber::{fmt::format::FmtSpan, util::SubscriberInitExt, EnvFilter};
+use tracing_subscriber::{util::SubscriberInitExt, EnvFilter};
 
 #[derive(thiserror::Error, Debug)]
 enum Error {
@@ -628,7 +628,6 @@ fn run_extra_cmds(cmds: ExtraCommands) -> Result<(), Error> {
 
 fn main() -> Result<(), Error> {
     tracing_subscriber::fmt()
-        .with_span_events(FmtSpan::FULL)
         .with_env_filter(EnvFilter::from_default_env())
         .with_ansi(false)
         .finish()

--- a/lading/src/generator/file_gen/logrotate.rs
+++ b/lading/src/generator/file_gen/logrotate.rs
@@ -239,6 +239,8 @@ impl Child {
             names.push(pth);
         }
 
+        info!("names: {names:?}");
+
         Self {
             names,
             bytes_per_second,


### PR DESCRIPTION
### What does this PR do?

This commit removes every span event by configuration. It's not useful information
in logs per se and really does muddy up any analysis of the logs by a human.

