### PR TITLE
Drop file handle just to be extra certain

### DIFF
--- a/lading/src/generator/file_gen/logrotate.rs
+++ b/lading/src/generator/file_gen/logrotate.rs
@@ -307,6 +307,7 @@ impl Child {
 
                     if total_bytes_written > maximum_bytes_per_log {
                         fp.flush().await?;
+                        drop(fp);
 
                         // Delete the last name file, if it exists. Move all files to their next highest.
                         if fs::try_exists(&last_name).await? {
@@ -339,6 +340,8 @@ impl Child {
                 }
                 () = &mut shutdown_wait => {
                     fp.flush().await?;
+                    drop(fp);
+
                     info!("shutdown signal received");
                     return Ok(());
                 },


### PR DESCRIPTION
### What does this PR do?

This commit drops `fp` whenever we flush it and overwrite `fp`. This
 is implied by the overwrite, of course, but I found myself wondering
 about when exactly this operation took place, so now it's explicit.
