### PR TITLE
Remove debugging `names` info! call

### DIFF
--- a/lading/src/generator/file_gen/logrotate.rs
+++ b/lading/src/generator/file_gen/logrotate.rs
@@ -241,8 +241,6 @@ impl Child {
             names.push(pth);
         }
 
-        info!("names: {names:?}");
-
         Self {
             names,
             bytes_per_second,


### PR DESCRIPTION
### What does this PR do?

As it says on the tin, I no longer need this info! call and it just
pollutes the logs without need at this point.

