### PR TITLE
Adds ability for payload tool to emit the raw contents of blocks

### DIFF
--- a/lading/src/bin/payloadtool.rs
+++ b/lading/src/bin/payloadtool.rs
@@ -1,12 +1,14 @@
 use std::io::Read;
+use std::io::Write;
 use std::time::Instant;
 use std::{io, num::NonZeroU32};
 
 use clap::Parser;
 use lading::generator::http::Method;
-use lading_payload::block;
+use lading_payload::block::{self, Block};
 use rand::{SeedableRng, rngs::StdRng};
-use tracing::{debug, error, info, warn};
+use tracing::{error, info, warn};
+use tracing_subscriber::EnvFilter;
 use tracing_subscriber::{fmt::format::FmtSpan, util::SubscriberInitExt};
 
 const UDP_PACKET_LIMIT_BYTES: u32 = 65_507;
@@ -16,6 +18,10 @@ const UDP_PACKET_LIMIT_BYTES: u32 = 65_507;
 struct Args {
     /// Path to standard lading config file
     config_path: String,
+
+    /// Emit blocks line by line on stdout
+    #[clap(short, long)]
+    emit_to_stdout: bool,
 
     /// Optionally only run a single generator's payload
     #[clap(short, long)]
@@ -41,7 +47,7 @@ fn generate_and_check(
     seed: [u8; 32],
     total_bytes: NonZeroU32,
     max_block_size: byte_unit::Byte,
-) -> Result<(), Error> {
+) -> Result<Vec<Block>, Error> {
     let mut rng = StdRng::from_seed(seed);
     let start = Instant::now();
     let blocks =
@@ -49,13 +55,12 @@ fn generate_and_check(
             block::Cache::Fixed { blocks, .. } => blocks,
         };
     info!("Payload generation took {:?}", start.elapsed());
-    debug!("Payload: {:#?}", blocks);
 
     let mut total_generated_bytes: u32 = 0;
     for block in blocks.iter() {
         total_generated_bytes += block.total_bytes.get();
     }
-    if total_bytes.get() != total_generated_bytes {
+    if total_bytes.get() > total_generated_bytes {
         let total_requested_bytes = byte_unit::Byte::from_bytes(total_bytes.get().into());
         let total_requested_bytes_str = total_requested_bytes
             .get_appropriate_unit(false)
@@ -69,11 +74,11 @@ fn generate_and_check(
         )
     }
 
-    Ok(())
+    Ok(blocks)
 }
 
-fn check_generator(config: &lading::generator::Config) -> Result<(), Error> {
-    match &config.inner {
+fn check_generator(config: &lading::generator::Config, emit_to_stdout: bool) -> Result<(), Error> {
+    let blocks = match &config.inner {
         lading::generator::Inner::FileGen(_) => unimplemented!("FileGen not supported"),
         lading::generator::Inner::UnixDatagram(g) => {
             let max_block_size =
@@ -82,13 +87,13 @@ fn check_generator(config: &lading::generator::Config) -> Result<(), Error> {
             let total_bytes =
                 NonZeroU32::new(g.maximum_prebuild_cache_size_bytes.get_bytes() as u32)
                     .expect("Non-zero max prebuild cache size");
-            generate_and_check(&g.variant, g.seed, total_bytes, max_block_size)?;
+            generate_and_check(&g.variant, g.seed, total_bytes, max_block_size)?
         }
         lading::generator::Inner::Tcp(g) => {
             let total_bytes =
                 NonZeroU32::new(g.maximum_prebuild_cache_size_bytes.get_bytes() as u32)
                     .expect("Non-zero max prebuild cache size");
-            generate_and_check(&g.variant, g.seed, total_bytes, g.maximum_block_size)?;
+            generate_and_check(&g.variant, g.seed, total_bytes, g.maximum_block_size)?
         }
         lading::generator::Inner::Udp(g) => {
             let total_bytes =
@@ -97,7 +102,7 @@ fn check_generator(config: &lading::generator::Config) -> Result<(), Error> {
             let max_block_size =
                 byte_unit::Byte::from_unit(UDP_PACKET_LIMIT_BYTES.into(), byte_unit::ByteUnit::B)
                     .expect("valid bytes");
-            generate_and_check(&g.variant, g.seed, total_bytes, max_block_size)?;
+            generate_and_check(&g.variant, g.seed, total_bytes, max_block_size)?
         }
         lading::generator::Inner::Http(g) => {
             let (variant, max_prebuild_cache_size_bytes) = match &g.method {
@@ -109,7 +114,7 @@ fn check_generator(config: &lading::generator::Config) -> Result<(), Error> {
             };
             let total_bytes = NonZeroU32::new(max_prebuild_cache_size_bytes.get_bytes() as u32)
                 .expect("Non-zero max prebuild cache size");
-            generate_and_check(variant, g.seed, total_bytes, g.maximum_block_size)?;
+            generate_and_check(variant, g.seed, total_bytes, g.maximum_block_size)?
         }
         lading::generator::Inner::SplunkHec(_) => unimplemented!("SplunkHec not supported"),
         lading::generator::Inner::FileTree(_) => unimplemented!("FileTree not supported"),
@@ -117,23 +122,34 @@ fn check_generator(config: &lading::generator::Config) -> Result<(), Error> {
             let total_bytes =
                 NonZeroU32::new(g.maximum_prebuild_cache_size_bytes.get_bytes() as u32)
                     .expect("Non-zero max prebuild cache size");
-            generate_and_check(&g.variant, g.seed, total_bytes, g.maximum_block_size)?;
+            generate_and_check(&g.variant, g.seed, total_bytes, g.maximum_block_size)?
         }
         lading::generator::Inner::UnixStream(g) => {
             let total_bytes =
                 NonZeroU32::new(g.maximum_prebuild_cache_size_bytes.get_bytes() as u32)
                     .expect("Non-zero max prebuild cache size");
-            generate_and_check(&g.variant, g.seed, total_bytes, g.maximum_block_size)?;
+            generate_and_check(&g.variant, g.seed, total_bytes, g.maximum_block_size)?
         }
         lading::generator::Inner::PassthruFile(g) => {
             let total_bytes =
                 NonZeroU32::new(g.maximum_prebuild_cache_size_bytes.get_bytes() as u32)
                     .expect("Non-zero max prebuild cache size");
-            generate_and_check(&g.variant, g.seed, total_bytes, g.maximum_block_size)?;
+            generate_and_check(&g.variant, g.seed, total_bytes, g.maximum_block_size)?
         }
         lading::generator::Inner::ProcessTree(_) => unimplemented!("ProcessTree not supported"),
         lading::generator::Inner::ProcFs(_) => unimplemented!("ProcFs not supported"),
     };
+
+    if emit_to_stdout {
+        for block in blocks {
+            match std::io::stdout().write_all(&block.bytes) {
+                Ok(_) => {}
+                Err(e) => {
+                    error!("Failed to write block to stdout: {}", e);
+                }
+            }
+        }
+    }
 
     Ok(())
 }
@@ -144,6 +160,7 @@ async fn main() -> Result<(), Error> {
         .with_span_events(FmtSpan::CLOSE)
         .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
         .with_ansi(false)
+        .with_env_filter(EnvFilter::from_default_env())
         .finish()
         .init();
 
@@ -183,10 +200,10 @@ async fn main() -> Result<(), Error> {
                 error!("No generator found with id: {}", generator_id);
                 Error::InvalidArgs
             })?;
-        check_generator(generator)?;
+        check_generator(generator, args.emit_to_stdout)?;
     } else {
         for generator in config.generator {
-            check_generator(&generator)?;
+            check_generator(&generator, args.emit_to_stdout)?;
         }
     }
 


### PR DESCRIPTION

### What does this PR do?

Adds another option to payloadtool to debug block generation

### Motivation

Useful to see the actual output of some lading payloads, ie, dogstatsd.

### Related issues



### Additional Notes

