### PR TITLE
[target_metrics] Avoid panicking on an invalid counter or gauge value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
-
+### Fixed
+-  Prometheus target metrics scraper will no longer panic if a metric has an
+  invalid value (instead it will be logged)
 
 ## [0.23.3]
 ### Changed


### PR DESCRIPTION
### What does this PR do?

Simply discard invalid counter and gauge values instead of panicking.

### Motivation

Discovered when fixing #1039 

### Related issues

None

### Additional Notes

None