### PR TITLE
Update file timestamps to reflect real systemtime

### DIFF
--- a/.github/actions/install-fuse/action.yml
+++ b/.github/actions/install-fuse/action.yml
@@ -5,7 +5,11 @@ runs:
   steps:
     - run: |
         if [ "${{ runner.os }}" == "Linux" ]; then
+<<<<<<< HEAD
           sudo apt-get update && sudo apt-get install -y fuse3 libfuse3-dev
+=======
+          sudo apt-get update && sudo apt-get install -y fuse
+>>>>>>> f07473c (install FUSE dependency)
         elif [ "${{ runner.os }}" == "macOS" ]; then
           brew install macfuse
         fi

--- a/.github/actions/install-fuse/action.yml
+++ b/.github/actions/install-fuse/action.yml
@@ -5,11 +5,7 @@ runs:
   steps:
     - run: |
         if [ "${{ runner.os }}" == "Linux" ]; then
-<<<<<<< HEAD
           sudo apt-get update && sudo apt-get install -y fuse3 libfuse3-dev
-=======
-          sudo apt-get update && sudo apt-get install -y fuse
->>>>>>> f07473c (install FUSE dependency)
         elif [ "${{ runner.os }}" == "macOS" ]; then
           brew install macfuse
         fi

--- a/lading/src/generator/file_gen/model.rs
+++ b/lading/src/generator/file_gen/model.rs
@@ -168,6 +168,12 @@ pub struct NodeAttributes {
     pub kind: NodeType,
     /// The size in bytes.
     pub size: u64,
+    /// The last access time in ticks.
+    pub access_tick: Tick,
+    /// The last modified time in ticks.
+    pub modified_tick: Tick,
+    /// The last status change time in ticks.
+    pub status_tick: Tick,
 }
 
 /// Describe whether the Node is a File or Directory.
@@ -298,11 +304,17 @@ impl State {
                 inode,
                 kind: NodeType::File,
                 size: file.bytes_written,
+                access_tick: file.access_tick,
+                modified_tick: file.modified_tick,
+                status_tick: file.status_tick,
             },
             Node::Directory { .. } => NodeAttributes {
                 inode,
                 kind: NodeType::Directory,
                 size: 0,
+                access_tick: self.now,
+                modified_tick: self.now,
+                status_tick: self.now,
             },
         })
     }


### PR DESCRIPTION
### What does this PR do?

This commit retains the use of a stateless tick in the model but
allows for the filesystem to report times in systemtime. This
resolves a problem where all times were previously reported by the
filesystem as being UNIX_EPOCH even though the model kept track of
time.

