### PR TITLE
Ensure file size updates due to getattr

### DIFF
--- a/.github/actions/install-fuse/action.yml
+++ b/.github/actions/install-fuse/action.yml
@@ -5,7 +5,11 @@ runs:
   steps:
     - run: |
         if [ "${{ runner.os }}" == "Linux" ]; then
+<<<<<<< HEAD
           sudo apt-get update && sudo apt-get install -y fuse3 libfuse3-dev
+=======
+          sudo apt-get update && sudo apt-get install -y fuse
+>>>>>>> f07473c (install FUSE dependency)
         elif [ "${{ runner.os }}" == "macOS" ]; then
           brew install macfuse
         fi

--- a/.github/actions/install-fuse/action.yml
+++ b/.github/actions/install-fuse/action.yml
@@ -5,11 +5,7 @@ runs:
   steps:
     - run: |
         if [ "${{ runner.os }}" == "Linux" ]; then
-<<<<<<< HEAD
           sudo apt-get update && sudo apt-get install -y fuse3 libfuse3-dev
-=======
-          sudo apt-get update && sudo apt-get install -y fuse
->>>>>>> f07473c (install FUSE dependency)
         elif [ "${{ runner.os }}" == "macOS" ]; then
           brew install macfuse
         fi


### PR DESCRIPTION
### What does this PR do?

This commit ensures that a Node has advance_time called on it when
the filesystem calls getattr. If this is not done repeat calls to ls,
for instance, will show the file size not changing although a call to
read would.

