### PR TITLE
github actions: pin to SHAs

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -18,7 +18,7 @@ jobs:
   security_audit:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions-rs/audit-check@v1
+      - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4
+      - uses: actions-rs/audit-check@24a24e9d5c8179709dd1ad4d7ba661572de756e6 # v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/check-changelog.yml
+++ b/.github/workflows/check-changelog.yml
@@ -9,13 +9,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4
       with:
         fetch-depth: 2 # Only need preceeding commit
 
     - name: Check for no-changelog label
       id: label-check
-      uses: actions/github-script@v7
+      uses: actions/github-script@5c56fde4671bc2d3592fb0f2c5b5bab9ddae03b1 # v7
       with:
         script: |
           const payload = context.payload;
@@ -25,13 +25,13 @@ jobs:
     - name: Check if CHANGELOG.md was modified
       id: changelog-check
       if: steps.label-check.outputs.has_label == 'false'
-      uses: tj-actions/changed-files@v45
+      uses: tj-actions/changed-files@c3a1bb2c992d77180ae65be6ae6c166cf40f857c # v45
       with:
         files: |
           CHANGELOG.md
 
     - name: Assert CHANGELOG.md is modified
-      uses: actions/github-script@v7
+      uses: actions/github-script@5c56fde4671bc2d3592fb0f2c5b5bab9ddae03b1 # v7
       if: steps.label-check.outputs.has_label == 'false' && steps.changelog-check.outputs.any_changed != 'true'
       with:
         script: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,8 +28,8 @@ jobs:
             components: "clippy"
             command: cargo clippy --all-features
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions-rust-lang/setup-rust-toolchain@v1.10
+      - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4
+      - uses: actions-rust-lang/setup-rust-toolchain@11df97af8e8102fd60b60a77dfbf58d40cd843b8 # v1.10
         with:
           components: ${{matrix.components}}
       - name: Install Protobuf
@@ -41,27 +41,27 @@ jobs:
   cargo-deny: # only runs on Linux
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: EmbarkStudios/cargo-deny-action@v1
+      - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4
+      - uses: EmbarkStudios/cargo-deny-action@ef301417264190a1eb9f26fcf171642070085c5b # v1
 
   test:
     name: Test Suite
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions-rust-lang/setup-rust-toolchain@v1.10
+      - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4
+      - uses: actions-rust-lang/setup-rust-toolchain@11df97af8e8102fd60b60a77dfbf58d40cd843b8 # v1.10
       - name: Install Protobuf
         uses: ./.github/actions/install-protobuf
       - name: Install nextest
-        uses: taiki-e/install-action@nextest
+        uses: taiki-e/install-action@49be99c627fae102cb8c86414e9605869641782a # nextest
       - run: cargo nextest run
 
   integration-test:
     name: Integration Tests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions-rust-lang/setup-rust-toolchain@v1.10
+      - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4
+      - uses: actions-rust-lang/setup-rust-toolchain@11df97af8e8102fd60b60a77dfbf58d40cd843b8 # v1.10
       - name: Install Protobuf
         uses: ./.github/actions/install-protobuf
       - run: cargo test -p sheepdog
@@ -75,8 +75,8 @@ jobs:
       matrix:
         crate: [lading_throttle, lading_payload]
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions-rust-lang/setup-rust-toolchain@v1.10
+      - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4
+      - uses: actions-rust-lang/setup-rust-toolchain@11df97af8e8102fd60b60a77dfbf58d40cd843b8 # v1.10
       - name: Install Protobuf
         uses: ./.github/actions/install-protobuf
       - name: Install kani
@@ -92,12 +92,12 @@ jobs:
       matrix:
         crate: [lading_signal]
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions-rust-lang/setup-rust-toolchain@v1.10
+      - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4
+      - uses: actions-rust-lang/setup-rust-toolchain@11df97af8e8102fd60b60a77dfbf58d40cd843b8 # v1.10
       - name: Install Protobuf
         uses: ./.github/actions/install-protobuf
       - name: Install nextest
-        uses: taiki-e/install-action@nextest
+        uses: taiki-e/install-action@49be99c627fae102cb8c86414e9605869641782a # nextest
       - run: RUSTFLAGS="--cfg loom" cargo nextest run --release
         working-directory: ${{ matrix.crate }}
         timeout-minutes: 30
@@ -107,12 +107,12 @@ jobs:
     steps:
       # Check our protobufs for lint cleanliness and for lack of breaking
       # changes
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4
       - name: buf-setup
-        uses: bufbuild/buf-setup-action@v1.45.0
+        uses: bufbuild/buf-setup-action@2211e06e8cf26d628cda2eea15c95f8c42b080b3 # v1.45.0
       - name: buf-lint
-        uses: bufbuild/buf-lint-action@v1.1.1
+        uses: bufbuild/buf-lint-action@06f9dd823d873146471cfaaf108a993fe00e5325 # v1.1.1
       - name: buf-breaking
-        uses: bufbuild/buf-breaking-action@v1.1.4
+        uses: bufbuild/buf-breaking-action@c57b3d842a5c3f3b454756ef65305a50a587c5ba # v1.1.4
         with:
           against: 'https://github.com/datadog/lading.git#branch=main'

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -15,23 +15,23 @@ jobs:
       packages: write
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4
         with:
           sparse-checkout: .
 
       - name: Set up Docker Buildx
         id: buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@c47758b77c9736f4b2ef4073d4d51994fabfe349 # v3
 
       - name: Log in to the Container registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Extract metadata for Docker
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@8e5442c4ef9f78752691e2d8f8d19755c6f78e81 # v5
         id: meta
         with:
           tags: |
@@ -43,7 +43,7 @@ jobs:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
 
       - name: Build and push Docker image (${{ matrix.platform }})
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@4f58ea79222b3b9dc2c8bbdd6debcef730109a75 # v6
         with:
           file: Dockerfile
           builder: ${{ steps.buildx.outputs.name }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,10 +12,10 @@ jobs:
   create-release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4
 
       - name: Create GitHub release
-        uses: taiki-e/create-gh-release-action@v1
+        uses: taiki-e/create-gh-release-action@72d65cee1f8033ef0c8b5d79eaf0c45c7c578ce3 # v1
         with:
           changelog: CHANGELOG.md
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -47,8 +47,8 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-      - uses: actions/checkout@v4
-      - uses: taiki-e/install-action@v2
+      - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4
+      - uses: taiki-e/install-action@3e1dd227d968fb9fa43ff604bd9b0ccd1b714919 # v2
         with:
           tool: cross
 
@@ -61,7 +61,7 @@ jobs:
 
       # Run the build & upload artifacts
       - name: Build and upload lading binaries
-        uses: taiki-e/upload-rust-binary-action@v1
+        uses: taiki-e/upload-rust-binary-action@3bbb07bb7f438d0fdf6ce5118bdf9e6e21c0b2a5 # v1
 
         with:
           bin: lading
@@ -72,7 +72,7 @@ jobs:
 
       # Auth for the S3 upload
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v4.0.2
+        uses: aws-actions/configure-aws-credentials@5579c002bb4778aa43395ef1df492868a9a1c83f # v4.0.2
         with:
           aws-access-key-id: ${{ secrets.LADING_RELEASE_BOT_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.LADING_RELEASE_BOT_SECRET_ACCESS_KEY }}
@@ -86,7 +86,7 @@ jobs:
   crates-io-publish:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4
 
       - name: Install protobuf
         run: sudo apt-get update && sudo apt-get install -y protobuf-compiler


### PR DESCRIPTION
### What does this PR do?

To silence some Datadog security warnings, this commit pins all of the GitHub Actions we use to SHAs, via
[`frizbee`](https://github.com/stacklok/frizbee)

```shell
GITHUB_TOKEN="$(gh auth token)" frizbee actions \
    "$(git rev-parse --show-toplevel)/.github/workflows"
GITHUB_TOKEN="$(gh auth token)" frizbee actions \
    "$(git rev-parse --show-toplevel)/.github/actions"
```

Without authentication, `frizbee`'s GitHub API requests may be rate-limited, which causes silent failures, and `frizbee` may fail to replace some version tags with SHAs.

### Motivation

This Datadog security [notification](https://github.com/DataDog/lading/pull/1036#discussion_r1799023703).

### Related issues

SMPTNG-492.

### Additional Notes

Frizbee is installable via

```shell
brew install frizbee
```