### PR TITLE
ci: add jobs to lint GitHub Actions and check all used actions are pinned to SHAs

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -19,6 +19,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
-      - uses: actions-rs/audit-check@24a24e9d5c8179709dd1ad4d7ba661572de756e6 # v1
+      - uses: actions-rust-lang/audit@531fba54daed81c23724925a1892a60c74969c38 # v1.2.1
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -18,7 +18,7 @@ jobs:
   security_audit:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4
+      - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
       - uses: actions-rs/audit-check@24a24e9d5c8179709dd1ad4d7ba661572de756e6 # v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/check-changelog.yml
+++ b/.github/workflows/check-changelog.yml
@@ -9,13 +9,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout code
-      uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4
+      uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
       with:
         fetch-depth: 2 # Only need preceeding commit
 
     - name: Check for no-changelog label
       id: label-check
-      uses: actions/github-script@5c56fde4671bc2d3592fb0f2c5b5bab9ddae03b1 # v7
+      uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
       with:
         script: |
           const payload = context.payload;
@@ -25,13 +25,13 @@ jobs:
     - name: Check if CHANGELOG.md was modified
       id: changelog-check
       if: steps.label-check.outputs.has_label == 'false'
-      uses: tj-actions/changed-files@c3a1bb2c992d77180ae65be6ae6c166cf40f857c # v45
+      uses: tj-actions/changed-files@c3a1bb2c992d77180ae65be6ae6c166cf40f857c # v45.0.3
       with:
         files: |
           CHANGELOG.md
 
     - name: Assert CHANGELOG.md is modified
-      uses: actions/github-script@5c56fde4671bc2d3592fb0f2c5b5bab9ddae03b1 # v7
+      uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
       if: steps.label-check.outputs.has_label == 'false' && steps.changelog-check.outputs.any_changed != 'true'
       with:
         script: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
             components: "clippy"
             command: cargo clippy --all-features
     steps:
-      - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4
+      - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
       - uses: actions-rust-lang/setup-rust-toolchain@11df97af8e8102fd60b60a77dfbf58d40cd843b8 # v1.10
         with:
           components: ${{matrix.components}}
@@ -41,14 +41,14 @@ jobs:
   cargo-deny: # only runs on Linux
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4
-      - uses: EmbarkStudios/cargo-deny-action@ef301417264190a1eb9f26fcf171642070085c5b # v1
+      - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
+      - uses: EmbarkStudios/cargo-deny-action@3f4a782664881cf5725d0ffd23969fcce89fd868 # v1.6.3
 
   test:
     name: Test Suite
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4
+      - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
       - uses: actions-rust-lang/setup-rust-toolchain@11df97af8e8102fd60b60a77dfbf58d40cd843b8 # v1.10
       - name: Install Protobuf
         uses: ./.github/actions/install-protobuf
@@ -60,7 +60,7 @@ jobs:
     name: Integration Tests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4
+      - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
       - uses: actions-rust-lang/setup-rust-toolchain@11df97af8e8102fd60b60a77dfbf58d40cd843b8 # v1.10
       - name: Install Protobuf
         uses: ./.github/actions/install-protobuf
@@ -75,7 +75,7 @@ jobs:
       matrix:
         crate: [lading_throttle, lading_payload]
     steps:
-      - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4
+      - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
       - uses: actions-rust-lang/setup-rust-toolchain@11df97af8e8102fd60b60a77dfbf58d40cd843b8 # v1.10
       - name: Install Protobuf
         uses: ./.github/actions/install-protobuf
@@ -92,7 +92,7 @@ jobs:
       matrix:
         crate: [lading_signal]
     steps:
-      - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4
+      - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
       - uses: actions-rust-lang/setup-rust-toolchain@11df97af8e8102fd60b60a77dfbf58d40cd843b8 # v1.10
       - name: Install Protobuf
         uses: ./.github/actions/install-protobuf
@@ -107,7 +107,7 @@ jobs:
     steps:
       # Check our protobufs for lint cleanliness and for lack of breaking
       # changes
-      - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4
+      - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
       - name: buf-setup
         uses: bufbuild/buf-setup-action@2211e06e8cf26d628cda2eea15c95f8c42b080b3 # v1.45.0
       - name: buf-lint

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,3 +116,36 @@ jobs:
         uses: bufbuild/buf-breaking-action@c57b3d842a5c3f3b454756ef65305a50a587c5ba # v1.1.4
         with:
           against: 'https://github.com/datadog/lading.git#branch=main'
+
+  actionlint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: set actionlint version & checksum
+        id: version
+        run: |
+          export ACTIONLINT="1.7.3"
+          export ACTIONLINT_CHECKSUM="37252b4d440b56374b0fc1726e05fd7452d30d6d774f6e9b52e65bb64475f9db"
+
+          echo "actionlint version: ${ACTIONLINT}"
+          echo "actionlint checksum: ${ACTIONLINT_CHECKSUM}"
+
+          echo "ACTIONLINT=${ACTIONLINT}" >> $GITHUB_OUTPUT
+          echo "ACTIONLINT_CHECKSUM=${ACTIONLINT_CHECKSUM}" >> $GITHUB_OUTPUT
+
+      - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
+      - name: Download actionlint
+        shell: bash
+        run: |
+          wget https://github.com/rhysd/actionlint/releases/download/v${{ steps.version.outputs.ACTIONLINT }}/actionlint_${{ steps.version.outputs.ACTIONLINT }}_linux_amd64.tar.gz
+
+          echo "${{ steps.version.outputs.ACTIONLINT_CHECKSUM }}  actionlint_${{ steps.version.outputs.ACTIONLINT }}_linux_amd64.tar.gz" >> CHECKSUMS
+          sha256sum -c CHECKSUMS
+
+          tar -xvf actionlint_${{ steps.version.outputs.ACTIONLINT }}_linux_amd64.tar.gz
+      - name: Check workflow files
+        shell: bash
+        run: |
+          ./actionlint -color \
+            -ignore 'Double quote to prevent globbing and word splitting' \
+            -ignore 'Consider using { cmd1; cmd2; } >> file instead of individual redirects' \
+            -ignore 'Declare and assign separately to avoid masking return values'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -149,3 +149,27 @@ jobs:
             -ignore 'Double quote to prevent globbing and word splitting' \
             -ignore 'Consider using { cmd1; cmd2; } >> file instead of individual redirects' \
             -ignore 'Declare and assign separately to avoid masking return values'
+
+  action-sha-pin-check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out branch
+        uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
+      - name: Check all GitHub Actions in ".github/workflows" are pinned to SHAs
+        uses: stacklok/frizbee-action@a0f3391cbe93a54e2a68cfaca2283f8cf3fd72ea # v0.0.2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          actions: ".github/workflows"
+          dockerfiles: ""
+          fail_on_unpinned: true
+          open_pr: false
+      - name: Check all GitHub Actions in ".github/actions" are pinned to SHAs
+        uses: stacklok/frizbee-action@a0f3391cbe93a54e2a68cfaca2283f8cf3fd72ea # v0.0.2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          actions: ".github/actions"
+          dockerfiles: ""
+          fail_on_unpinned: true
+          open_pr: false

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -15,23 +15,23 @@ jobs:
       packages: write
 
     steps:
-      - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4
+      - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
         with:
           sparse-checkout: .
 
       - name: Set up Docker Buildx
         id: buildx
-        uses: docker/setup-buildx-action@c47758b77c9736f4b2ef4073d4d51994fabfe349 # v3
+        uses: docker/setup-buildx-action@c47758b77c9736f4b2ef4073d4d51994fabfe349 # v3.7.1
 
       - name: Log in to the Container registry
-        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3
+        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3.3.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Extract metadata for Docker
-        uses: docker/metadata-action@8e5442c4ef9f78752691e2d8f8d19755c6f78e81 # v5
+        uses: docker/metadata-action@8e5442c4ef9f78752691e2d8f8d19755c6f78e81 # v5.5.1
         id: meta
         with:
           tags: |
@@ -42,8 +42,8 @@ jobs:
             type=semver,pattern={{major}},event=tag
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
 
-      - name: Build and push Docker image (${{ matrix.platform }})
-        uses: docker/build-push-action@4f58ea79222b3b9dc2c8bbdd6debcef730109a75 # v6
+      - name: Build and push Docker image
+        uses: docker/build-push-action@4f58ea79222b3b9dc2c8bbdd6debcef730109a75 # v6.9.0
         with:
           file: Dockerfile
           builder: ${{ steps.buildx.outputs.name }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,10 +12,10 @@ jobs:
   create-release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4
+      - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
 
       - name: Create GitHub release
-        uses: taiki-e/create-gh-release-action@72d65cee1f8033ef0c8b5d79eaf0c45c7c578ce3 # v1
+        uses: taiki-e/create-gh-release-action@72d65cee1f8033ef0c8b5d79eaf0c45c7c578ce3 # v1.8.2
         with:
           changelog: CHANGELOG.md
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -47,8 +47,8 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-      - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4
-      - uses: taiki-e/install-action@3e1dd227d968fb9fa43ff604bd9b0ccd1b714919 # v2
+      - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
+      - uses: taiki-e/install-action@3e1dd227d968fb9fa43ff604bd9b0ccd1b714919 # v2.44.40
         with:
           tool: cross
 
@@ -61,7 +61,7 @@ jobs:
 
       # Run the build & upload artifacts
       - name: Build and upload lading binaries
-        uses: taiki-e/upload-rust-binary-action@3bbb07bb7f438d0fdf6ce5118bdf9e6e21c0b2a5 # v1
+        uses: taiki-e/upload-rust-binary-action@3bbb07bb7f438d0fdf6ce5118bdf9e6e21c0b2a5 # v1.22.0
 
         with:
           bin: lading
@@ -72,7 +72,7 @@ jobs:
 
       # Auth for the S3 upload
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@5579c002bb4778aa43395ef1df492868a9a1c83f # v4.0.2
+        uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502 # v4.0.2
         with:
           aws-access-key-id: ${{ secrets.LADING_RELEASE_BOT_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.LADING_RELEASE_BOT_SECRET_ACCESS_KEY }}
@@ -86,7 +86,7 @@ jobs:
   crates-io-publish:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4
+      - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
 
       - name: Install protobuf
         run: sudo apt-get update && sudo apt-get install -y protobuf-compiler


### PR DESCRIPTION
### What does this PR do?

- Adds full version strings for any pinned GitHub Actions that had a `# v{major}` comment. Changing this comment to a `# v{major}.{minor}.{patch}` comment seems to make Dependabot update pull requests easier to read, and Dependabot is more likely to keep the comment in sync with the hash in the latter format.
- Adds an `actionlint` job, similar to that in the Single Machine Performance repo.
- Adds a job to check that all used Actions are pinned to SHAs.
- Replaces `actions-rs/audit-check` with `actions-rust-lang/audit` because the former has been archived and is read-only since 2023-10-13.

### Motivation

Avoid introducing any new uses of GitHub Actions that aren't pinned to SHAs, for security reasons.

### Related issues

SMPTNG-492.

### Additional Notes

This pull request uses a newer version of `actionlint` than Single Machine Performance.
