### PR TITLE
Send the HTTP Host header for the HTTP generator.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   them rather than incorrectly identifying the metric value.
 - Prometheus target metrics scraper will no longer panic if a metric has an
   invalid value (instead it will be logged)
-- HTTP traffic sent by the HTTP generator and Splunk generator now always include
+- HTTP traffic sent by the HTTP generator and Splunk generator now always includes
   a Host header to comply with HTTP 1.1 requirements
 
 ## [0.23.3]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   them rather than incorrectly identifying the metric value.
 - Prometheus target metrics scraper will no longer panic if a metric has an
   invalid value (instead it will be logged)
+- HTTP traffic sent by the HTTP generator and Splunk generator now always include
+  a Host header to comply with HTTP 1.1 requirements
 
 ## [0.23.3]
 ### Changed

--- a/lading/src/generator/http.rs
+++ b/lading/src/generator/http.rs
@@ -196,7 +196,6 @@ impl Http {
         let client: Client<HttpConnector, Body> = Client::builder()
             .pool_max_idle_per_host(self.parallel_connections as usize)
             .retry_canceled_requests(false)
-            .set_host(false)
             .build_http();
         let method = self.method;
         let uri = self.uri;

--- a/lading/src/generator/splunk_hec.rs
+++ b/lading/src/generator/splunk_hec.rs
@@ -248,7 +248,6 @@ impl SplunkHec {
         let client: Client<HttpConnector, Body> = Client::builder()
             .pool_max_idle_per_host(self.parallel_connections as usize)
             .retry_canceled_requests(false)
-            .set_host(false)
             .build_http();
 
         let uri = self.uri;

--- a/lading/src/generator/splunk_hec/acknowledgements.rs
+++ b/lading/src/generator/splunk_hec/acknowledgements.rs
@@ -89,7 +89,6 @@ impl Channels {
     ) {
         let client: Client<HttpConnector, Body> = Client::builder()
             .retry_canceled_requests(false)
-            .set_host(false)
             .build_http();
 
         let ack_service = AckService {


### PR DESCRIPTION
### What does this PR do?

Send the HTTP Host header for the HTTP generator and the Splunk generator.

### Motivation

The Host header is required for compliant HTTP traffic. Send it so that standard web servers will properly receive HTTP requests.

Note that there are two other places in the code that this `set_host(false)` method is used ([1](https://github.com/DataDog/lading/blob/4f7ec01c17fcf74abcf55cc9d9226a08c6155ff3/lading/src/generator/splunk_hec.rs#L251)) ([2](https://github.com/DataDog/lading/blob/4f7ec01c17fcf74abcf55cc9d9226a08c6155ff3/lading/src/generator/splunk_hec/acknowledgements.rs#L92)). I'm leaving them as is because I'm not familiar with Splunk and whether it needs this behavior.

UPDATE: Commit 9d3e627534d964 now removes the `set_host(false)` call from Splunk also, so Host headers are added by `hyper` everywhere.

### Related issues

### Additional Notes

