### PR TITLE
Pre-allocates the hash map for medium perf wins (5s vs 6.2s)

### DIFF
--- a/lading_payload/src/fluent.rs
+++ b/lading_payload/src/fluent.rs
@@ -128,7 +128,9 @@ where
                 .expect("failed to generate string"),
         ),
         1 => {
-            let mut obj = FxHashMap::default();
+            let s: std::hash::BuildHasherDefault<rustc_hash::FxHasher> =
+                std::hash::BuildHasherDefault::default();
+            let mut obj = FxHashMap::with_capacity_and_hasher(128, s);
             for _ in 0..rng.gen_range(0..128) {
                 let key = str_pool
                     .of_size_range(rng, 1_u8..16)


### PR DESCRIPTION
### What does this PR do?

Optimizes a hashmap during fluent log generation

### Motivation

Fluent payload is v slow.

### Related issues


### Additional Notes

