### PR TITLE
Make logrotate_fs a generator

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ COPY . /app
 RUN cargo build --release --locked --bin lading
 
 FROM docker.io/debian:bullseye-20240701-slim
-RUN apt-get update && apt-get install -y libfuse3-dev && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y libfuse3-dev=3.10.3-2 && rm -rf /var/lib/apt/lists/*
 COPY --from=builder /app/target/release/lading /usr/bin/lading
 
 # smoke test

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,7 @@ COPY . /app
 RUN cargo build --release --locked --bin lading
 
 FROM docker.io/debian:bullseye-20240701-slim
+RUN apt-get update && apt-get install -y libfuse3-dev && rm -rf /var/lib/apt/lists/*
 COPY --from=builder /app/target/release/lading /usr/bin/lading
 
 # smoke test

--- a/lading/src/generator/file_gen.rs
+++ b/lading/src/generator/file_gen.rs
@@ -13,7 +13,7 @@
 //!
 
 pub mod logrotate;
-pub mod model;
+pub mod logrotate_fs;
 pub mod traditional;
 
 use std::str;
@@ -31,6 +31,9 @@ pub enum Error {
     /// Wrapper around [`logrotate::Error`].
     #[error(transparent)]
     Logrotate(#[from] logrotate::Error),
+    /// Wrapper around [`logrotate_fs::Error`].
+    #[error(transparent)]
+    LogrotateFs(#[from] logrotate_fs::Error),
 }
 
 /// Configuration of [`FileGen`]
@@ -42,6 +45,8 @@ pub enum Config {
     Traditional(traditional::Config),
     /// See [`logrotate::Config`].
     Logrotate(logrotate::Config),
+    /// See [`logrotate_fs::Config`].
+    LogrotateFs(logrotate_fs::Config),
 }
 
 #[derive(Debug)]
@@ -54,6 +59,8 @@ pub enum FileGen {
     Traditional(traditional::Server),
     /// See [`logrotate::Server`] for details.
     Logrotate(logrotate::Server),
+    /// See [`logrotate_fs::Server`] for details.
+    LogrotateFs(logrotate_fs::Server),
 }
 
 impl FileGen {
@@ -78,6 +85,9 @@ impl FileGen {
                 Self::Traditional(traditional::Server::new(general, c, shutdown)?)
             }
             Config::Logrotate(c) => Self::Logrotate(logrotate::Server::new(general, c, shutdown)?),
+            Config::LogrotateFs(c) => {
+                Self::LogrotateFs(logrotate_fs::Server::new(general, c, shutdown)?)
+            }
         };
         Ok(srv)
     }
@@ -98,6 +108,7 @@ impl FileGen {
         match self {
             Self::Traditional(inner) => inner.spin().await?,
             Self::Logrotate(inner) => inner.spin().await?,
+            Self::LogrotateFs(inner) => inner.spin().await?,
         };
 
         Ok(())

--- a/lading/src/generator/file_gen/logrotate_fs.rs
+++ b/lading/src/generator/file_gen/logrotate_fs.rs
@@ -188,12 +188,13 @@ fn getattr_helper(
         let access_duration = Duration::from_secs(attr.access_tick);
         let modified_duration = Duration::from_secs(attr.modified_tick);
         let status_duration = Duration::from_secs(attr.status_tick);
+        let created_duration = Duration::from_secs(attr.created_tick);
 
         // Calculate SystemTime instances
         let atime = start_time_system + access_duration;
         let mtime = start_time_system + modified_duration;
         let ctime = start_time_system + status_duration;
-        let crtime = start_time_system; // Assume creation time is when the filesystem started
+        let crtime = start_time_system + created_duration;
 
         FileAttr {
             ino: attr.inode as u64,

--- a/lading/src/generator/file_gen/logrotate_fs/model.rs
+++ b/lading/src/generator/file_gen/logrotate_fs/model.rs
@@ -544,13 +544,13 @@ impl State {
                 // become the 0th ordinal in the `group_id` and may -- although
                 // we don't know yet -- cause `rotated_inode` to be deleted.
                 let new_file_inode = self.next_inode;
-                let new_file = File {
+                let mut new_file = File {
                     parent: parent_inode,
                     bytes_written: 0,
                     bytes_read: 0,
-                    access_tick: now,
-                    modified_tick: now,
-                    status_tick: now,
+                    access_tick: self.now,
+                    modified_tick: self.now,
+                    status_tick: self.now,
                     bytes_per_tick,
                     read_only: false,
                     ordinal: 0,
@@ -559,6 +559,7 @@ impl State {
                     open_handles: 0,
                     unlinked: false,
                 };
+                new_file.advance_time(now);
 
                 // Insert `new_file` into the node list and make it a member of
                 // its directory's children.
@@ -757,6 +758,7 @@ impl State {
 
                 // Get data from block_cache without worrying about blocks
                 let data = self.block_cache.read_at(offset as u64, to_read);
+                assert!(data.len() == to_read, "Data returned from block_cache is distinct from the read size: {l} != {to_read}", l = data.len());
 
                 file.read(to_read as u64, now);
 

--- a/lading/src/generator/file_gen/logrotate_fs/model.rs
+++ b/lading/src/generator/file_gen/logrotate_fs/model.rs
@@ -144,6 +144,7 @@ impl File {
             self.status_tick = now;
         }
 
+        counter!("bytes_read").increment(request);
         self.bytes_read = self.bytes_read.saturating_add(request);
     }
 
@@ -162,6 +163,7 @@ impl File {
         let diff = now.saturating_sub(self.modified_tick);
         let bytes_accum = diff.saturating_mul(self.bytes_per_tick);
 
+        counter!("bytes_written").increment(bytes_accum);
         self.bytes_written = self.bytes_written.saturating_add(bytes_accum);
         self.modified_tick = now;
         self.status_tick = now;

--- a/lading/src/generator/file_gen/logrotate_fs/model.rs
+++ b/lading/src/generator/file_gen/logrotate_fs/model.rs
@@ -847,9 +847,7 @@ mod test {
         num::NonZeroU32,
     };
 
-    use crate::generator::file_gen::model::FileHandle;
-
-    use super::{Inode, Node, State};
+    use super::{FileHandle, Inode, Node, State};
     use lading_payload::block;
     use proptest::collection::vec;
     use proptest::prelude::*;
@@ -1015,10 +1013,7 @@ mod test {
                         }
 
                         if let Some(Node::File { file: peer_file }) = state.nodes.get(&peer_inode) {
-                            assert!(
-                                !peer_file.unlinked(),
-                                "File was found in peer chain unlinked"
-                            );
+                            assert!(!peer_file.unlinked, "File was found in peer chain unlinked");
                             expected_ordinal += 1;
                             assert_eq!(
                                 peer_file.ordinal,
@@ -1040,7 +1035,7 @@ mod test {
         // No ordinal should exeed max_rotations, so long as the file is linked.
         for node in state.nodes.values() {
             if let Node::File { file } = node {
-                if file.unlinked() {
+                if file.unlinked {
                     continue;
                 }
                 assert!(
@@ -1062,7 +1057,7 @@ mod test {
         // holds linked and unlinked files.
         for (&inode, node) in &state.nodes {
             if let Node::File { file } = node {
-                if file.unlinked() && file.open_handles() == 0 {
+                if file.unlinked && file.open_handles == 0 {
                     panic!(
                         "Found orphaned file inode {} (unlinked with zero open handles)",
                         inode
@@ -1077,7 +1072,7 @@ mod test {
         // the correct name.
         for (&inode, node) in &state.nodes {
             if let Node::File { file } = node {
-                if file.unlinked() {
+                if file.unlinked {
                     continue;
                 }
                 if let Some(names) = state.group_names.get(file.group_id as usize) {

--- a/lading/src/generator/file_gen/logrotate_fs/model.rs
+++ b/lading/src/generator/file_gen/logrotate_fs/model.rs
@@ -51,7 +51,7 @@ pub(crate) struct File {
     /// happen -- or not.
     read_only: bool,
 
-    /// When the file became read-only. Will only be Some if read_only is false.
+    /// When the file became read-only. Will only be Some if `read_only` is false.
     read_only_since: Option<Tick>,
 
     /// The peer of this file, the next in line in rotation. So, if this file is
@@ -508,6 +508,7 @@ impl State {
     ///
     /// Will panic if passed `now` is less than recorded `now`. Time can only
     /// advance.
+    #[allow(clippy::too_many_lines)]
     pub(crate) fn advance_time(&mut self, now: Tick) {
         assert!(now >= self.now);
         let mut inodes: Vec<Inode> = self.nodes.keys().copied().collect();


### PR DESCRIPTION
### What does this PR do?

This commit migrates logrotate_fs to be a generator and not a stand-alone binary. While I think it is interesting to consider logrotate_fs as a user defined generator that's more of a rig that needs to be developed than I would like to for this project.
