### PR TITLE
Avoid some allocations, hashes that aren't needed

### DIFF
--- a/examples/lading-logrotatefs.yaml
+++ b/examples/lading-logrotatefs.yaml
@@ -8,7 +8,7 @@ generator:
         total_rotations: 4
         max_depth: 0
         variant: "ascii"
-        bytes_per_second: 10MB
+        bytes_per_second: 1.3MB
         maximum_prebuild_cache_size_bytes: 1GB
         mount_point: /tmp/logrotate
 


### PR DESCRIPTION
### What does this PR do?

This commit removes allocations in the FUSE component that don't
need to exist and adjust the interior hashmap to use FxHashMap,
avoiding a secure hash in favor of a fast one. Also, directories
now keep their children in a BTreeSet so that readdir is always
in the same order when called.
