### PR TITLE
Release lading 0.23.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+## [0.23.4]
+### Added
+- Introduced logrotate_fs, a sub-generator of `file_gen` that exposes a FUSE
+  filesystem to mimic log rotation. Accurately records bytes lost by readers via
+  rotation.
 ### Fixed
 - The target metrics prometheus parser now handles labels that have spaces in
   them rather than incorrectly identifying the metric value.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1424,7 +1424,7 @@ dependencies = [
 
 [[package]]
 name = "lading"
-version = "0.23.3"
+version = "0.23.4"
 dependencies = [
  "async-compression",
  "async-pidfd",

--- a/lading/Cargo.toml
+++ b/lading/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lading"
-version = "0.23.3"
+version = "0.23.4"
 authors = [
   "Brian L. Troutwine <brian.troutwine@datadoghq.com>",
   "George Hahn <george.hahn@datadoghq.com>",


### PR DESCRIPTION
### What does this PR do?

This commit releases lading 0.23.4, incorporating fixes for our prometheus
metrics scraping, the way our HTTP client presents itself via the host header
and adds a log rotation filesystem.
