### PR TITLE
Do not transmit pid 0 as the target pid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+### Fixed
+- Target pid watcher will not report 0 for containers.
+
 ## [0.23.4]
 ### Added
 - Introduced logrotate_fs, a sub-generator of `file_gen` that exposes a FUSE


### PR DESCRIPTION
### What does this PR do?

In some cases docker will report that the pid of a new container is 0.
This is not a usable pid and we believe it is a race condition. Loop
around again in this even, logging.
