### PR TITLE
Attempt to speed up container builds

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -51,5 +51,5 @@ jobs:
           platforms: linux/amd64, linux/arm64
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha, scope=${{ github.workflow }}
-          cache-to: type=gha, scope=${{ github.workflow }}
+          cache-from: type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest
+          cache-to: type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest,mode=max

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -5,7 +5,7 @@ on:
 
 env:
   REGISTRY: ghcr.io
-  IMAGE_NAME: ${{ github.repository }}
+  IMAGE_NAME: ${{ github.repository | toLower }}
 
 jobs:
   container:

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -5,7 +5,7 @@ on:
 
 env:
   REGISTRY: ghcr.io
-  IMAGE_NAME: ${{ github.repository | toLower }}
+  IMAGE_NAME: ${{ toLower(github.repository) }}
 
 jobs:
   container:

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -5,7 +5,7 @@ on:
 
 env:
   REGISTRY: ghcr.io
-  IMAGE_NAME: ${{ toLower(github.repository) }}
+  IMAGE_NAME: ${{ github.repository }}
 
 jobs:
   container:
@@ -51,5 +51,5 @@ jobs:
           platforms: linux/amd64, linux/arm64
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest
-          cache-to: type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest,mode=max
+          cache-from: type=registry,ref=ghcr.io/datadog/lading:latest
+          cache-to: type=registry,ref=ghcr.io/datadog/lading:latest,mode=max

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ uuid = { version = "1.11", default-features = false, features = ["v4", "serde"] 
 once_cell = { version = "1.20" }
 
 [profile.release]
+strip = true      # Strip debug symbols from the binary.
 lto = true        # Optimize our binary at link stage.
 codegen-units = 1 # Increases compile time but improves optmization alternatives.
 opt-level = 3     # Optimize with 'all' optimization flipped on. May produce larger binaries than 's' or 'z'.

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ WORKDIR /app
 RUN apt-get update && apt-get install -y \
     protobuf-compiler fuse3 libfuse3-dev \
     && rm -rf /var/lib/apt/lists/*
-RUN cargo install cargo-chef
+RUN cargo install cargo-chef --locked
 
 # Planning stage, artifact is 'recipe.json'
 FROM chef AS planner

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,18 +1,36 @@
-# Update the rust version in-sync with the version in rust-toolchain.toml
-FROM docker.io/rust:1.81.0-bullseye AS builder
+# Lading arm64 builds are very slow. We use cargo-chef and aggressive layer
+# caching to avoid some of the build delay.
 
+# Builder image, cargo-chef installed
+FROM docker.io/rust:1.81.0-bullseye AS chef
+WORKDIR /app
 RUN apt-get update && apt-get install -y \
     protobuf-compiler fuse3 libfuse3-dev \
     && rm -rf /var/lib/apt/lists/*
+RUN cargo install cargo-chef
 
-WORKDIR /app
-COPY . /app
+# Planning stage, artifact is 'recipe.json'
+FROM chef AS planner
+COPY . .
+RUN cargo chef prepare --recipe-path recipe.json
+
+# Cache dependencies per the recipe artifact.
+FROM chef AS cacher
+COPY --from=planner /app/recipe.json recipe.json
+RUN cargo chef cook --release --recipe-path recipe.json
+
+# Actually build lading.
+FROM chef AS builder
+COPY . .
 RUN cargo build --release --locked --bin lading
 
-FROM docker.io/debian:bullseye-20240701-slim
-RUN apt-get update && apt-get install -y libfuse3-dev=3.10.3-2 fuse3=3.10.3-2 && rm -rf /var/lib/apt/lists/*
+# Install lading. This is the image that users will run.
+FROM docker.io/debian:bullseye-20241016-slim AS target
+RUN apt-get update && apt-get install -y \
+    libfuse3-dev=3.10.3-2 fuse3=3.10.3-2 \
+    && rm -rf /var/lib/apt/lists/*
 COPY --from=builder /app/target/release/lading /usr/bin/lading
 
-# smoke test
+# Smoke test
 RUN ["/usr/bin/lading", "--help"]
 ENTRYPOINT ["/usr/bin/lading"]


### PR DESCRIPTION
### What does this PR do?

The lading container build right now is roughly 1 hour. This is a very long loop to wait on. Introduce cargo-chef and more aggressive caching to hopefully cut this time.
