### PR TITLE
Add more information to lost_bytes telemetry

### DIFF
--- a/lading/src/generator/file_gen/logrotate_fs/model.rs
+++ b/lading/src/generator/file_gen/logrotate_fs/model.rs
@@ -662,7 +662,8 @@ impl State {
                 let (remove_current, next_peer) = match node {
                     Node::File { file } => {
                         file.incr_ordinal();
-                        counter!("log_file_rotated").increment(1);
+                        counter!("log_file_rotated", "group_id" => format!("{}", file.group_id))
+                            .increment(1);
 
                         let remove_current = file.ordinal() > self.max_rotations;
                         (remove_current, file.peer)


### PR DESCRIPTION
### What does this PR do?

This commit adds more information to the lost_bytes telemetry, intention
being to make it easier to debug under what conditions bytes are lost.

### Related issues

REF SMPTNG-517
