### PR TITLE
Start target metrics server on target startup

### DIFF
--- a/lading/src/bin/lading.rs
+++ b/lading/src/bin/lading.rs
@@ -465,7 +465,7 @@ async fn inner_main(
             let metrics_server = target_metrics::Server::new(
                 cfg,
                 shutdown_watcher.clone(),
-                experiment_started_watcher.clone(),
+                target_running_watcher.clone(),
             );
             tokio::spawn(async {
                 match metrics_server.run().await {

--- a/lading/src/target_metrics.rs
+++ b/lading/src/target_metrics.rs
@@ -48,17 +48,15 @@ impl Server {
     pub fn new(
         config: Config,
         shutdown: lading_signal::Watcher,
-        experiment_started: lading_signal::Watcher,
+        target_running: lading_signal::Watcher,
     ) -> Self {
         match config {
             Config::Expvar(conf) => {
-                Self::Expvar(expvar::Expvar::new(conf, shutdown, experiment_started))
+                Self::Expvar(expvar::Expvar::new(conf, shutdown, target_running))
             }
-            Config::Prometheus(conf) => Self::Prometheus(prometheus::Prometheus::new(
-                conf,
-                shutdown,
-                experiment_started,
-            )),
+            Config::Prometheus(conf) => {
+                Self::Prometheus(prometheus::Prometheus::new(conf, shutdown, target_running))
+            }
         }
     }
 

--- a/lading/src/target_metrics/expvar.rs
+++ b/lading/src/target_metrics/expvar.rs
@@ -37,7 +37,7 @@ pub struct Config {
 pub struct Expvar {
     config: Config,
     shutdown: lading_signal::Watcher,
-    experiment_started: lading_signal::Watcher,
+    target_running: lading_signal::Watcher,
 }
 
 impl Expvar {
@@ -49,12 +49,12 @@ impl Expvar {
     pub(crate) fn new(
         config: Config,
         shutdown: lading_signal::Watcher,
-        experiment_started: lading_signal::Watcher,
+        target_running: lading_signal::Watcher,
     ) -> Self {
         Self {
             config,
             shutdown,
-            experiment_started,
+            target_running,
         }
     }
 
@@ -70,8 +70,8 @@ impl Expvar {
     ///
     /// None are known.
     pub(crate) async fn run(self) -> Result<(), Error> {
-        info!("Expvar target metrics scraper running, but waiting for warmup to complete");
-        self.experiment_started.recv().await; // block until experimental lading_signal::Watcher entered
+        info!("Expvar target metrics scraper running, but waiting for target to run");
+        self.target_running.recv().await; // block until experimental lading_signal::Watcher entered
         info!("Expvar target metrics scraper starting collection");
 
         let client = reqwest::Client::new();

--- a/lading/src/target_metrics/prometheus.rs
+++ b/lading/src/target_metrics/prometheus.rs
@@ -65,7 +65,7 @@ pub struct Prometheus {
     config: Config,
     client: reqwest::Client,
     shutdown: lading_signal::Watcher,
-    experiment_started: lading_signal::Watcher,
+    target_running: lading_signal::Watcher,
 }
 
 impl Prometheus {
@@ -77,14 +77,14 @@ impl Prometheus {
     pub(crate) fn new(
         config: Config,
         shutdown: lading_signal::Watcher,
-        experiment_started: lading_signal::Watcher,
+        target_running: lading_signal::Watcher,
     ) -> Self {
         let client = reqwest::Client::new();
         Self {
             config,
             client,
             shutdown,
-            experiment_started,
+            target_running,
         }
     }
 
@@ -103,8 +103,8 @@ impl Prometheus {
     #[allow(clippy::cast_possible_truncation)]
     #[allow(clippy::too_many_lines)]
     pub(crate) async fn run(self) -> Result<(), Error> {
-        info!("Prometheus target metrics scraper running, but waiting for warmup to complete");
-        self.experiment_started.recv().await;
+        info!("Prometheus target metrics scraper running, but waiting for target to run");
+        self.target_running.recv().await;
         info!("Prometheus target metrics scraper starting collection");
 
         let client = self.client;
@@ -378,7 +378,7 @@ mod tests {
         let server_uri = format!("http://{addr}/metrics");
 
         let (shutdown_watcher, _) = lading_signal::signal();
-        let (experiment_started_watcher, experiment_started_broadcaster) = lading_signal::signal();
+        let (target_running_watcher, target_running_broadcast) = lading_signal::signal();
         let p = Prometheus::new(
             Config {
                 uri: server_uri,
@@ -386,14 +386,14 @@ mod tests {
                 tags,
             },
             shutdown_watcher,
-            experiment_started_watcher,
+            target_running_watcher,
         );
 
         let dr = metrics_util::debugging::DebuggingRecorder::new();
         let snapshotter = dr.snapshotter();
         dr.install().expect("failed to install recorder");
 
-        experiment_started_broadcaster.signal();
+        target_running_broadcast.signal();
 
         p.scrape_metrics().await;
 


### PR DESCRIPTION
### What does this PR do?

Changes the target metrics server to wait on target running signal rather than experiment started signal.

### Motivation

Currently we start the capture manager on target startup which means we are technically able to start both the observer and target metrics server on startup as well. We currently do this for the observer which gives us insight as to the targets startup behavior from the perspective of lading metrics. However it may be useful to also gain some insight as to the targets internal view of its behavior before we start the experiment (during warmup period).

### Related issues



### Additional Notes

I am not 100% confident we actually want this in main, open to peoples thoughts. 

For context I want this for investigating the agents startup behavior in dogstatsd experiments. Planning on cutting a rc from this branch so that I can use this version of lading in some test jobs. This pairs with my [pr](https://github.com/DataDog/single-machine-performance/pull/2233) in smp to reallow the exporting of warmup metrics.
