### PR TITLE
Use native ARM builders for container builds

### DIFF
--- a/.github/actionlint.yml
+++ b/.github/actionlint.yml
@@ -1,0 +1,3 @@
+self-hosted-runner:
+  labels:
+    - arm-4core-linux-ubuntu24.04

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -59,37 +59,45 @@ jobs:
           cache-from: type=registry,ref=ghcr.io/datadog/lading:cache
           cache-to: type=registry,ref=ghcr.io/datadog/lading:cache,mode=max
 
-  manifest:
-    name: Create Multi-Arch Manifest
-    needs: build
-    runs-on: ubuntu-20.04
-    permissions:
-      contents: read
-      packages: write
+manifest:
+  name: Create Multi-Arch Manifest
+  needs: build
+  runs-on: ubuntu-20.04
+  permissions:
+    contents: read
+    packages: write
 
-    steps:
-      - name: Log in to Container Registry
-        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3.3.0
-        with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+  steps:
+    - name: Log in to Container Registry
+      uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3.3.0
+      with:
+        registry: ${{ env.REGISTRY }}
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@c47758b77c9736f4b2ef4073d4d51994fabfe349 # v3.7.1
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@c47758b77c9736f4b2ef4073d4d51994fabfe349 # v3.7.1
 
-      - name: Extract Docker Metadata
-        uses: docker/metadata-action@8e5442c4ef9f78752691e2d8f8d19755c6f78e81 # v5.5.1
-        id: meta
-        with:
-          tags: |
-            type=sha,format=long
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+    - name: Extract Docker Metadata
+      uses: docker/metadata-action@8e5442c4ef9f78752691e2d8f8d19755c6f78e81 # v5.5.1
+      id: meta
+      with:
+        tags: |
+          type=sha,format=long
+        images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
 
-      - name: Create and Push Multi-Arch Manifest
-        run: |
-          docker manifest create ${{ steps.meta.outputs.tags }} \
-            ${{ steps.meta.outputs.tags }}-amd64 \
-            ${{ steps.meta.outputs.tags }}-arm64
+    - name: Confirm images exist
+      run: |
+        docker pull ${{ steps.meta.outputs.tags }}-amd64
+        docker pull ${{ steps.meta.outputs.tags }}-arm64
 
-          docker manifest push ${{ steps.meta.outputs.tags }}
+    - name: Create and Push Multiarch Manifest
+      run: |
+        docker manifest create ${{ steps.meta.outputs.tags }} \
+          ${{ steps.meta.outputs.tags }}-amd64 \
+          ${{ steps.meta.outputs.tags }}-arm64
+
+        docker manifest annotate ${{ steps.meta.outputs.tags }} ${{ steps.meta.outputs.tags }}-amd64 --os linux --arch amd64
+        docker manifest annotate ${{ steps.meta.outputs.tags }} ${{ steps.meta.outputs.tags }}-arm64 --os linux --arch arm64
+
+        docker manifest push ${{ steps.meta.outputs.tags }}

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -80,7 +80,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@vc47758b77c9736f4b2ef4073d4d51994fabfe349 # v3.7.1
+        uses: docker/setup-buildx-action@c47758b77c9736f4b2ef4073d4d51994fabfe349 # v3.7.1
 
       - name: Extract Docker Metadata
         uses: docker/metadata-action@8e5442c4ef9f78752691e2d8f8d19755c6f78e81 # v5.5.1

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -8,8 +8,15 @@ env:
   IMAGE_NAME: ${{ github.repository }}
 
 jobs:
-  container:
-    runs-on: ubuntu-20.04
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        include:
+          - arch: amd64
+            runner: ubuntu-20.04
+          - arch: arm64
+            runner: arm-4core-linux-ubuntu24.04
     permissions:
       contents: read
       packages: write
@@ -47,9 +54,50 @@ jobs:
         with:
           file: Dockerfile
           builder: ${{ steps.buildx.outputs.name }}
+          platforms: linux/${{ matrix.arch }}
+          tags: |
+            ${{ steps.meta.outputs.tags }}
+            ${{ steps.meta.outputs.tags }}-${{ matrix.arch }}
           push: true
-          platforms: linux/amd64, linux/arm64
-          tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha, scope=${{ github.workflow }}
-          cache-to: type=gha, scope=${{ github.workflow }}
+          cache-from: type=registry,ref=ghcr.io/datadog/lading:latest
+          cache-to: type=registry,ref=ghcr.io/datadog/lading:latest,mode=max
+
+  manifest:
+    name: Create Multi-Arch Manifest
+    needs: build
+    runs-on: ubuntu-20.04
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Log in to Container Registry
+        uses: docker/login-action@v3.3.0
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3.7.1
+
+      - name: Extract Docker Metadata
+        uses: docker/metadata-action@v5.5.1
+        id: meta
+        with:
+          tags: |
+            type=sha,format=long
+            type=ref,prefix=pr-,event=pr
+            type=semver,pattern={{version}},event=tag
+            type=semver,pattern={{major}}.{{minor}},event=tag
+            type=semver,pattern={{major}},event=tag
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
+      - name: Create and Push Multi-Arch Manifest
+        run: |
+          docker manifest create ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.meta.outputs.tags }} \
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.meta.outputs.tags }}-amd64 \
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.meta.outputs.tags }}-arm64
+
+          docker manifest push ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.meta.outputs.tags }}

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -60,8 +60,8 @@ jobs:
             ${{ steps.meta.outputs.tags }}-${{ matrix.arch }}
           push: true
           labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=registry,ref=ghcr.io/datadog/lading:latest
-          cache-to: type=registry,ref=ghcr.io/datadog/lading:latest,mode=max
+          cache-from: type=registry,ref=ghcr.io/datadog/lading:cache
+          cache-to: type=registry,ref=ghcr.io/datadog/lading:cache,mode=max
 
   manifest:
     name: Create Multi-Arch Manifest
@@ -96,8 +96,8 @@ jobs:
 
       - name: Create and Push Multi-Arch Manifest
         run: |
-          docker manifest create ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.meta.outputs.tags }} \
-            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.meta.outputs.tags }}-amd64 \
-            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.meta.outputs.tags }}-arm64
+          docker manifest create ${{ steps.meta.outputs.tags }} \
+            ${{ steps.meta.outputs.tags }}-amd64 \
+            ${{ steps.meta.outputs.tags }}-arm64
 
-          docker manifest push ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.meta.outputs.tags }}
+          docker manifest push ${{ steps.meta.outputs.tags }}

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -88,10 +88,6 @@ jobs:
         with:
           tags: |
             type=sha,format=long
-            type=ref,prefix=pr-,event=pr
-            type=semver,pattern={{version}},event=tag
-            type=semver,pattern={{major}}.{{minor}},event=tag
-            type=semver,pattern={{major}},event=tag
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
 
       - name: Create and Push Multi-Arch Manifest

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -53,11 +53,7 @@ jobs:
         uses: docker/build-push-action@4f58ea79222b3b9dc2c8bbdd6debcef730109a75 # v6.9.0
         with:
           file: Dockerfile
-          builder: ${{ steps.buildx.outputs.name }}
-          platforms: linux/${{ matrix.arch }}
-          tags: |
-            ${{ steps.meta.outputs.tags }}
-            ${{ steps.meta.outputs.tags }}-${{ matrix.arch }}
+          tags: ${{ steps.meta.outputs.tags }}-${{ matrix.arch }}
           push: true
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=registry,ref=ghcr.io/datadog/lading:cache

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -59,45 +59,45 @@ jobs:
           cache-from: type=registry,ref=ghcr.io/datadog/lading:cache
           cache-to: type=registry,ref=ghcr.io/datadog/lading:cache,mode=max
 
-manifest:
-  name: Create Multi-Arch Manifest
-  needs: build
-  runs-on: ubuntu-20.04
-  permissions:
-    contents: read
-    packages: write
+  manifest:
+    name: Create Multi-Arch Manifest
+    needs: build
+    runs-on: ubuntu-20.04
+    permissions:
+      contents: read
+      packages: write
 
-  steps:
-    - name: Log in to Container Registry
-      uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3.3.0
-      with:
-        registry: ${{ env.REGISTRY }}
-        username: ${{ github.actor }}
-        password: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - name: Log in to Container Registry
+        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3.3.0
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
-    - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@c47758b77c9736f4b2ef4073d4d51994fabfe349 # v3.7.1
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@c47758b77c9736f4b2ef4073d4d51994fabfe349 # v3.7.1
 
-    - name: Extract Docker Metadata
-      uses: docker/metadata-action@8e5442c4ef9f78752691e2d8f8d19755c6f78e81 # v5.5.1
-      id: meta
-      with:
-        tags: |
-          type=sha,format=long
-        images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+      - name: Extract Docker Metadata
+        uses: docker/metadata-action@8e5442c4ef9f78752691e2d8f8d19755c6f78e81 # v5.5.1
+        id: meta
+        with:
+          tags: |
+            type=sha,format=long
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
 
-    - name: Confirm images exist
-      run: |
-        docker pull ${{ steps.meta.outputs.tags }}-amd64
-        docker pull ${{ steps.meta.outputs.tags }}-arm64
+      - name: Confirm images exist
+        run: |
+          docker pull ${{ steps.meta.outputs.tags }}-amd64
+          docker pull ${{ steps.meta.outputs.tags }}-arm64
 
-    - name: Create and Push Multiarch Manifest
-      run: |
-        docker manifest create ${{ steps.meta.outputs.tags }} \
-          ${{ steps.meta.outputs.tags }}-amd64 \
-          ${{ steps.meta.outputs.tags }}-arm64
+      - name: Create and Push Multiarch Manifest
+        run: |
+          docker manifest create ${{ steps.meta.outputs.tags }} \
+            ${{ steps.meta.outputs.tags }}-amd64 \
+            ${{ steps.meta.outputs.tags }}-arm64
 
-        docker manifest annotate ${{ steps.meta.outputs.tags }} ${{ steps.meta.outputs.tags }}-amd64 --os linux --arch amd64
-        docker manifest annotate ${{ steps.meta.outputs.tags }} ${{ steps.meta.outputs.tags }}-arm64 --os linux --arch arm64
+          docker manifest annotate ${{ steps.meta.outputs.tags }} ${{ steps.meta.outputs.tags }}-amd64 --os linux --arch amd64
+          docker manifest annotate ${{ steps.meta.outputs.tags }} ${{ steps.meta.outputs.tags }}-arm64 --os linux --arch arm64
 
-        docker manifest push ${{ steps.meta.outputs.tags }}
+          docker manifest push ${{ steps.meta.outputs.tags }}

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -9,7 +9,7 @@ env:
 
 jobs:
   build:
-    runs-on: ${{ matrix.os }}
+    runs-on: ${{ matrix.runner }}
     strategy:
       matrix:
         include:

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -73,17 +73,17 @@ jobs:
 
     steps:
       - name: Log in to Container Registry
-        uses: docker/login-action@v3.3.0
+        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3.3.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3.7.1
+        uses: docker/setup-buildx-action@vc47758b77c9736f4b2ef4073d4d51994fabfe349 # v3.7.1
 
       - name: Extract Docker Metadata
-        uses: docker/metadata-action@v5.5.1
+        uses: docker/metadata-action@8e5442c4ef9f78752691e2d8f8d19755c6f78e81 # v5.5.1
         id: meta
         with:
           tags: |

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -86,18 +86,9 @@ jobs:
             type=sha,format=long
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
 
-      - name: Confirm images exist
-        run: |
-          docker pull ${{ steps.meta.outputs.tags }}-amd64
-          docker pull ${{ steps.meta.outputs.tags }}-arm64
-
       - name: Create and Push Multiarch Manifest
         run: |
-          docker manifest create ${{ steps.meta.outputs.tags }} \
+          docker buildx imagetools create \
+            --tag ${{ steps.meta.outputs.tags }} \
             ${{ steps.meta.outputs.tags }}-amd64 \
             ${{ steps.meta.outputs.tags }}-arm64
-
-          docker manifest annotate ${{ steps.meta.outputs.tags }} ${{ steps.meta.outputs.tags }}-amd64 --os linux --arch amd64
-          docker manifest annotate ${{ steps.meta.outputs.tags }} ${{ steps.meta.outputs.tags }}-arm64 --os linux --arch arm64
-
-          docker manifest push ${{ steps.meta.outputs.tags }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Update the rust version in-sync with the version in rust-toolchain.toml
-FROM --platform=$BUILDPLATFORM docker.io/rust:1.81.0-bullseye AS builder
+FROM docker.io/rust:1.81.0-bullseye AS builder
 
 RUN apt-get update && apt-get install -y \
     protobuf-compiler fuse3 libfuse3-dev \
@@ -9,7 +9,7 @@ WORKDIR /app
 COPY . /app
 RUN cargo build --release --locked --bin lading
 
-FROM --platform=$BUILDPLATFORM  docker.io/debian:bullseye-20240701-slim
+FROM docker.io/debian:bullseye-20240701-slim
 RUN apt-get update && apt-get install -y libfuse3-dev=3.10.3-2 fuse3=3.10.3-2 && rm -rf /var/lib/apt/lists/*
 COPY --from=builder /app/target/release/lading /usr/bin/lading
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Update the rust version in-sync with the version in rust-toolchain.toml
-FROM docker.io/rust:1.81.0-bullseye AS builder
+FROM --platform=$BUILDPLATFORM docker.io/rust:1.81.0-bullseye AS builder
 
 RUN apt-get update && apt-get install -y \
     protobuf-compiler fuse3 libfuse3-dev \
@@ -9,7 +9,7 @@ WORKDIR /app
 COPY . /app
 RUN cargo build --release --locked --bin lading
 
-FROM docker.io/debian:bullseye-20240701-slim
+FROM --platform=$BUILDPLATFORM  docker.io/debian:bullseye-20240701-slim
 RUN apt-get update && apt-get install -y libfuse3-dev=3.10.3-2 fuse3=3.10.3-2 && rm -rf /var/lib/apt/lists/*
 COPY --from=builder /app/target/release/lading /usr/bin/lading
 


### PR DESCRIPTION
### What does this PR do?

This commit replaces #1088 and attempts to build a lading multi-platform image by use of organization provided ARM native builders. Unsure if this'll work but I figure it's worth a shot.


