### PR TITLE
Set logrotate_fs behind a feature flag

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,12 +19,12 @@ jobs:
             protobuf: true
             fuse: true
             components: ""
-            command: cargo check
+            command: cargo check --all-features
           - tool: fmt
             protobuf: true
             fuse: true
             components: "rustfmt"
-            command: cargo fmt --all -- --check
+            command: cargo fmt --all -- --check --all-features
           - tool: clippy
             protobuf: true
             fuse: true
@@ -62,7 +62,7 @@ jobs:
         uses: ./.github/actions/install-fuse
       - name: Install nextest
         uses: taiki-e/install-action@49be99c627fae102cb8c86414e9605869641782a # nextest
-      - run: cargo nextest run
+      - run: cargo nextest run --all-features
 
   integration-test:
     name: Integration Tests

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+## Changed
+- logrotate_fs is now behind a feature flag and not enabled in the default
+  build. It remains enabled in the release artifact.
+
 ## [0.24.0]
 ## Added
 - Introduced load profile configuration for logrotate FS. This is a breaking

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ RUN apt-get update && apt-get install -y \
 
 WORKDIR /app
 COPY . /app
-RUN cargo build --release --locked --bin lading
+RUN cargo build --release --locked --bin lading --features logrotate_fs
 
 FROM docker.io/debian:bullseye-20240701-slim
 RUN apt-get update && apt-get install -y libfuse3-dev=3.10.3-2 fuse3=3.10.3-2 && rm -rf /var/lib/apt/lists/*

--- a/lading/Cargo.toml
+++ b/lading/Cargo.toml
@@ -34,7 +34,7 @@ flate2 = { version = "1.0.34", default-features = false, features = [
   "rust_backend",
 ] }
 futures = "0.3.31"
-fuser = "0.15"
+fuser = { version = "0.15", optional = true }
 http = "0.2"
 http-serde = "1.1"
 hyper = { version = "0.14", features = ["client"] }
@@ -97,6 +97,7 @@ proptest = "1.5"
 
 [features]
 default = []
+logrotate_fs = ["fuser"]
 
 [lib]
 doctest = false

--- a/lading/src/generator/file_gen.rs
+++ b/lading/src/generator/file_gen.rs
@@ -13,6 +13,7 @@
 //!
 
 pub mod logrotate;
+#[cfg(feature = "logrotate_fs")]
 pub mod logrotate_fs;
 pub mod traditional;
 
@@ -31,6 +32,7 @@ pub enum Error {
     /// Wrapper around [`logrotate::Error`].
     #[error(transparent)]
     Logrotate(#[from] logrotate::Error),
+    #[cfg(feature = "logrotate_fs")]
     /// Wrapper around [`logrotate_fs::Error`].
     #[error(transparent)]
     LogrotateFs(#[from] logrotate_fs::Error),
@@ -45,6 +47,7 @@ pub enum Config {
     Traditional(traditional::Config),
     /// See [`logrotate::Config`].
     Logrotate(logrotate::Config),
+    #[cfg(feature = "logrotate_fs")]
     /// See [`logrotate_fs::Config`].
     LogrotateFs(logrotate_fs::Config),
 }
@@ -59,6 +62,7 @@ pub enum FileGen {
     Traditional(traditional::Server),
     /// See [`logrotate::Server`] for details.
     Logrotate(logrotate::Server),
+    #[cfg(feature = "logrotate_fs")]
     /// See [`logrotate_fs::Server`] for details.
     LogrotateFs(logrotate_fs::Server),
 }
@@ -85,6 +89,7 @@ impl FileGen {
                 Self::Traditional(traditional::Server::new(general, c, shutdown)?)
             }
             Config::Logrotate(c) => Self::Logrotate(logrotate::Server::new(general, c, shutdown)?),
+            #[cfg(feature = "logrotate_fs")]
             Config::LogrotateFs(c) => {
                 Self::LogrotateFs(logrotate_fs::Server::new(general, c, shutdown)?)
             }
@@ -108,6 +113,7 @@ impl FileGen {
         match self {
             Self::Traditional(inner) => inner.spin().await?,
             Self::Logrotate(inner) => inner.spin().await?,
+            #[cfg(feature = "logrotate_fs")]
             Self::LogrotateFs(inner) => inner.spin().await?,
         };
 


### PR DESCRIPTION
### What does this PR do?

Building logrotate_fs requires special libraries on OSX that are not generally needed by developers on that platform as logrotate_fs cannot run there sans a kernel module. As such, stick the generator behind a feature flag.
