### PR TITLE
Add support for transparent huge pages in linux memory observer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Changed
 - logrotate_fs is now behind a feature flag and not enabled in the default
   build. It remains enabled in the release artifact.
+- On linux, transparent huge page usage is now collected and available
+  alongside existing `smaps_rollup` and `smaps_by_pathname` data.
 
 ## [0.24.0]
 ## Added

--- a/lading/src/observer/linux.rs
+++ b/lading/src/observer/linux.rs
@@ -357,6 +357,8 @@ impl Sampler {
                         gauge!("smaps.pss.by_pathname", &labels).set(measures.pss as f64);
                         gauge!("smaps.size.by_pathname", &labels).set(measures.size as f64);
                         gauge!("smaps.swap.by_pathname", &labels).set(measures.swap as f64);
+                        gauge!("smaps.anon_huge_pages.by_pathname", &labels)
+                            .set(measures.anon_huge_pages as f64);
                     }
 
                     let measures = memory_regions.aggregate();
@@ -396,6 +398,9 @@ impl Sampler {
                     }
                     if let Some(v) = rollup.pss_shmem {
                         gauge!("smaps_rollup.pss_shmem", &labels).set(v as f64);
+                    }
+                    if let Some(v) = rollup.anon_huge_pages {
+                        gauge!("smaps_rollup.anon_huge_pages", &labels).set(v as f64);
                     }
                 });
             }


### PR DESCRIPTION
### What does this PR do?

Parses out an additional field for `smaps` and `smaps_rollup` to see how much RSS is being consumed by https://docs.kernel.org/admin-guide/mm/transhuge.html

### Motivation

This could potentially explain some of the variance observed when running identical Agent processes.

### Related issues


### Additional Notes

