### PR TITLE
Explicitly enable http1 & http2 in the build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Changed
 - logrotate_fs is now behind a feature flag and not enabled in the default
   build. It remains enabled in the release artifact.
+- The build now includes http1 and http2 support. Actual usage and availability may vary.
 
 ## [0.24.0]
 ## Added

--- a/lading/Cargo.toml
+++ b/lading/Cargo.toml
@@ -37,7 +37,7 @@ futures = "0.3.31"
 fuser = { version = "0.15", optional = true }
 http = "0.2"
 http-serde = "1.1"
-hyper = { workspace = true, features = ["client", "backports", "deprecated"] }
+hyper = { workspace = true, features = ["backports", "client", "deprecated", "http1", "http2", "server"] }
 is_executable = "1.0.4"
 metrics = { workspace = true }
 metrics-exporter-prometheus = { workspace = true }


### PR DESCRIPTION
### What does this PR do?

Enable http1 and http2 in the build. This looks like it will get us http2 functionality by default.

### Motivation

Incoming request.

### Additional Notes

[hyper 0.14.30 docs](https://docs.rs/hyper/0.14.30/hyper/)
