### PR TITLE
Remove target RSS_BYTE tracking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## Removed
+- Removed the unused target-rss-byte-limit from the command line, internal stub of. 
 ## Changed
 - logrotate_fs is now behind a feature flag and not enabled in the default
   build. It remains enabled in the release artifact.

--- a/lading/src/observer.rs
+++ b/lading/src/observer.rs
@@ -8,18 +8,13 @@
 //! writes out key details about memory and CPU consumption into the capture
 //! data. On non-Linux systems the observer, if enabled, will emit a warning.
 
-use std::{io, sync::atomic::AtomicU64};
+use std::io;
 
 use crate::target::TargetPidReceiver;
 use serde::Deserialize;
 
 #[cfg(target_os = "linux")]
 mod linux;
-
-#[allow(dead_code)] // used on Linux
-/// Expose the process' current RSS consumption, allowing abstractions to be
-/// built on top in the Target implementation.
-pub(crate) static RSS_BYTES: AtomicU64 = AtomicU64::new(0);
 
 #[derive(thiserror::Error, Debug)]
 /// Errors produced by [`Server`]


### PR DESCRIPTION
### What does this PR do?

We previously had a mechanism that would allow the generators to back off
if the target was determined to be nearing a preconfigured memory consumption.
We decoupled this at some point -- I'm not sure when -- and then forgot to
remove the interface. It does not appear this was used in practice.
