### PR TITLE
Expand smaps / smaps_rollup parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## Added
+- Parse nearly the complete field list of smaps/smaps_rollup in the Linux observer. 
 ## Removed
 - Removed the unused target-rss-byte-limit from the command line, internal stub of. 
 ## Changed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -483,7 +483,7 @@ version = "3.2.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae6371b8bdc8b7d3959e9cf7b22d4435ef3e79e138688421ec654acf8c81b008"
 dependencies = [
- "heck",
+ "heck 0.4.1",
  "proc-macro-error",
  "proc-macro2",
  "quote",
@@ -1077,6 +1077,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
 name = "hermit-abi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1565,6 +1571,7 @@ dependencies = [
  "flate2",
  "fuser",
  "futures",
+ "heck 0.5.0",
  "http 0.2.12",
  "http-serde",
  "hyper 0.14.31",
@@ -2281,7 +2288,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "119533552c9a7ffacc21e099c24a0ac8bb19c2a2a3f363de84cd9b844feab270"
 dependencies = [
  "bytes",
- "heck",
+ "heck 0.4.1",
  "itertools",
  "lazy_static",
  "log",

--- a/lading/Cargo.toml
+++ b/lading/Cargo.toml
@@ -35,6 +35,7 @@ flate2 = { version = "1.0.34", default-features = false, features = [
 ] }
 futures = "0.3.31"
 fuser = { version = "0.15", optional = true }
+heck  = { version = "0.5", default-features = false }
 http = "0.2"
 http-serde = "1.1"
 hyper = { workspace = true, features = ["backports", "client", "deprecated", "http1", "http2", "server"] }

--- a/lading/src/captures.rs
+++ b/lading/src/captures.rs
@@ -201,7 +201,6 @@ impl CaptureManager {
                 .ok_or(Error::CapturePath)?
         );
         for line in lines.drain(..) {
-            info!("encoding: {line:?}");
             let pyld = serde_json::to_string(&line)?;
             self.capture_fp
                 .write_all(pyld.as_bytes())

--- a/lading/src/observer/linux/cgroup/v2.rs
+++ b/lading/src/observer/linux/cgroup/v2.rs
@@ -66,6 +66,7 @@ pub(crate) async fn poll(file_path: &Path, labels: &[(String, String)]) -> Resul
                                     };
                                     let file_path = entry.path();
 
+                                    // If the file is not readable, skip it.
                                     match fs::read_to_string(&file_path).await {
                                         Ok(content) => {
                                             let content = content.trim();

--- a/lading/src/observer/linux/cgroup/v2.rs
+++ b/lading/src/observer/linux/cgroup/v2.rs
@@ -66,7 +66,6 @@ pub(crate) async fn poll(file_path: &Path, labels: &[(String, String)]) -> Resul
                                     };
                                     let file_path = entry.path();
 
-                                    // If the file is not readable, skip it.
                                     match fs::read_to_string(&file_path).await {
                                         Ok(content) => {
                                             let content = content.trim();

--- a/lading/src/observer/linux/procfs.rs
+++ b/lading/src/observer/linux/procfs.rs
@@ -311,36 +311,60 @@ impl Sampler {
                             ("comm", comm.clone()),
                             ("pathname", pathname),
                         ];
-                        gauge!("smaps.rss.by_pathname", &labels).set(measures.rss as f64);
-                        gauge!("smaps.pss.by_pathname", &labels).set(measures.pss as f64);
-                        gauge!("smaps.size.by_pathname", &labels).set(measures.size as f64);
-                        gauge!("smaps.swap.by_pathname", &labels).set(measures.swap as f64);
-                        gauge!("smaps.private_clean.by_pathname", &labels)
-                            .set(measures.private_clean as f64);
-                        gauge!("smaps.private_dirty.by_pathname", &labels)
-                            .set(measures.private_dirty as f64);
-                        gauge!("smaps.shared_clean.by_pathname", &labels)
-                            .set(measures.shared_clean as f64);
-                        gauge!("smaps.shared_dirty.by_pathname", &labels)
-                            .set(measures.shared_dirty as f64);
-                        gauge!("smaps.referenced.by_pathname", &labels)
-                            .set(measures.referenced as f64);
-                        gauge!("smaps.anonymous.by_pathname", &labels)
-                            .set(measures.anonymous as f64);
-                        gauge!("smaps.lazy_free.by_pathname", &labels)
-                            .set(measures.lazy_free as f64);
-                        gauge!("smaps.anon_huge_pages.by_pathname", &labels)
-                            .set(measures.anon_huge_pages as f64);
-                        gauge!("smaps.shmem_pmd_mapped.by_pathname", &labels)
-                            .set(measures.shmem_pmd_mapped as f64);
-                        gauge!("smaps.shared_hugetlb.by_pathname", &labels)
-                            .set(measures.shared_hugetlb as f64);
-                        gauge!("smaps.private_hugetlb.by_pathname", &labels)
-                            .set(measures.private_hugetlb as f64);
-                        gauge!("smaps.file_pmd_mapped.by_pathname", &labels)
-                            .set(measures.file_pmd_mapped as f64);
-                        gauge!("smaps.locked.by_pathname", &labels).set(measures.locked as f64);
-                        gauge!("smaps.swap_pss.by_pathname", &labels).set(measures.swap_pss as f64);
+                        if let Some(m) = measures.rss {
+                            gauge!("smaps.rss.by_pathname", &labels).set(m as f64);
+                        }
+                        if let Some(m) = measures.pss {
+                            gauge!("smaps.pss.by_pathname", &labels).set(m as f64);
+                        }
+                        if let Some(m) = measures.size {
+                            gauge!("smaps.size.by_pathname", &labels).set(m as f64);
+                        }
+                        if let Some(m) = measures.swap {
+                            gauge!("smaps.swap.by_pathname", &labels).set(m as f64);
+                        }
+                        if let Some(m) = measures.private_clean {
+                            gauge!("smaps.private_clean.by_pathname", &labels).set(m as f64);
+                        }
+                        if let Some(m) = measures.private_dirty {
+                            gauge!("smaps.private_dirty.by_pathname", &labels).set(m as f64);
+                        }
+                        if let Some(m) = measures.shared_clean {
+                            gauge!("smaps.shared_clean.by_pathname", &labels).set(m as f64);
+                        }
+                        if let Some(m) = measures.shared_dirty {
+                            gauge!("smaps.shared_dirty.by_pathname", &labels).set(m as f64);
+                        }
+                        if let Some(m) = measures.referenced {
+                            gauge!("smaps.referenced.by_pathname", &labels).set(m as f64);
+                        }
+                        if let Some(m) = measures.anonymous {
+                            gauge!("smaps.anonymous.by_pathname", &labels).set(m as f64);
+                        }
+                        if let Some(m) = measures.lazy_free {
+                            gauge!("smaps.lazy_free.by_pathname", &labels).set(m as f64);
+                        }
+                        if let Some(m) = measures.anon_huge_pages {
+                            gauge!("smaps.anon_huge_pages.by_pathname", &labels).set(m as f64);
+                        }
+                        if let Some(m) = measures.shmem_pmd_mapped {
+                            gauge!("smaps.shmem_pmd_mapped.by_pathname", &labels).set(m as f64);
+                        }
+                        if let Some(m) = measures.shared_hugetlb {
+                            gauge!("smaps.shared_hugetlb.by_pathname", &labels).set(m as f64);
+                        }
+                        if let Some(m) = measures.private_hugetlb {
+                            gauge!("smaps.private_hugetlb.by_pathname", &labels).set(m as f64);
+                        }
+                        if let Some(m) = measures.file_pmd_mapped {
+                            gauge!("smaps.file_pmd_mapped.by_pathname", &labels).set(m as f64);
+                        }
+                        if let Some(m) = measures.locked {
+                            gauge!("smaps.locked.by_pathname", &labels).set(m as f64);
+                        }
+                        if let Some(m) = measures.swap_pss {
+                            gauge!("smaps.swap_pss.by_pathname", &labels).set(m as f64);
+                        }
                     }
 
                     // `/proc/{pid}/smaps_rollup`

--- a/lading/src/observer/linux/procfs.rs
+++ b/lading/src/observer/linux/procfs.rs
@@ -311,18 +311,11 @@ impl Sampler {
                             ("comm", comm.clone()),
                             ("pathname", pathname),
                         ];
-                        if let Some(m) = measures.rss {
-                            gauge!("smaps.rss.by_pathname", &labels).set(m as f64);
-                        }
-                        if let Some(m) = measures.pss {
-                            gauge!("smaps.pss.by_pathname", &labels).set(m as f64);
-                        }
-                        if let Some(m) = measures.size {
-                            gauge!("smaps.size.by_pathname", &labels).set(m as f64);
-                        }
-                        if let Some(m) = measures.swap {
-                            gauge!("smaps.swap.by_pathname", &labels).set(m as f64);
-                        }
+                        gauge!("smaps.rss.by_pathname", &labels).set(measures.rss as f64);
+                        gauge!("smaps.pss.by_pathname", &labels).set(measures.pss as f64);
+                        gauge!("smaps.swap.by_pathname", &labels).set(measures.swap as f64);
+                        gauge!("smaps.size.by_pathname", &labels).set(measures.size as f64);
+
                         if let Some(m) = measures.private_clean {
                             gauge!("smaps.private_clean.by_pathname", &labels).set(m as f64);
                         }

--- a/lading/src/observer/linux/procfs.rs
+++ b/lading/src/observer/linux/procfs.rs
@@ -343,37 +343,6 @@ impl Sampler {
                         gauge!("smaps.swap_pss.by_pathname", &labels).set(measures.swap_pss as f64);
                     }
 
-                    let measures = memory_regions.aggregate();
-                    let labels = [
-                        (String::from("pid"), format!("{pid}")),
-                        (String::from("exe"), basename.clone()),
-                        (String::from("cmdline"), cmdline.clone()),
-                        (String::from("comm"), comm.clone()),
-                    ];
-
-                    gauge!("smaps.rss.sum", &labels).set(measures.rss as f64);
-                    gauge!("smaps.pss.sum", &labels).set(measures.pss as f64);
-                    gauge!("smaps.size.sum", &labels).set(measures.size as f64);
-                    gauge!("smaps.swap.sum", &labels).set(measures.swap as f64);
-                    gauge!("smaps.shared_clean.sum", &labels).set(measures.shared_clean as f64);
-                    gauge!("smaps.shared_dirty.sum", &labels).set(measures.shared_dirty as f64);
-                    gauge!("smaps.private_clean.sum", &labels).set(measures.private_clean as f64);
-                    gauge!("smaps.private_dirty.sum", &labels).set(measures.private_dirty as f64);
-                    gauge!("smaps.referenced.sum", &labels).set(measures.referenced as f64);
-                    gauge!("smaps.anonymous.sum", &labels).set(measures.anonymous as f64);
-                    gauge!("smaps.lazy_free.sum", &labels).set(measures.lazy_free as f64);
-                    gauge!("smaps.anon_huge_pages.sum", &labels)
-                        .set(measures.anon_huge_pages as f64);
-                    gauge!("smaps.shmem_pmd_mapped.sum", &labels)
-                        .set(measures.shmem_pmd_mapped as f64);
-                    gauge!("smaps.file_pmd_mapped.sum", &labels)
-                        .set(measures.file_pmd_mapped as f64);
-                    gauge!("smaps.shared_hugetlb.sum", &labels).set(measures.shared_hugetlb as f64);
-                    gauge!("smaps.private_hugetlb.sum", &labels)
-                        .set(measures.private_hugetlb as f64);
-                    gauge!("smaps.swap_pss.sum", &labels).set(measures.swap_pss as f64);
-                    gauge!("smaps.locked.sum", &labels).set(measures.locked as f64);
-
                     // `/proc/{pid}/smaps_rollup`
                     if let Err(err) = memory::smaps_rollup::poll(pid, &labels).await {
                         // We don't want to bail out entirely if we can't read smap rollup

--- a/lading/src/observer/linux/procfs.rs
+++ b/lading/src/observer/linux/procfs.rs
@@ -292,7 +292,7 @@ impl Sampler {
             // then we assume smaps operations will fail as well.
             if has_ptrace_perm {
                 joinset.spawn(async move {
-                    // TODO this code reads smaps
+                    // `/proc/{pid}/smaps`
                     let memory_regions = match memory::smaps::Regions::from_pid(pid) {
                         Ok(memory_regions) => memory_regions,
                         Err(e) => {
@@ -315,6 +315,32 @@ impl Sampler {
                         gauge!("smaps.pss.by_pathname", &labels).set(measures.pss as f64);
                         gauge!("smaps.size.by_pathname", &labels).set(measures.size as f64);
                         gauge!("smaps.swap.by_pathname", &labels).set(measures.swap as f64);
+                        gauge!("smaps.private_clean.by_pathname", &labels)
+                            .set(measures.private_clean as f64);
+                        gauge!("smaps.private_dirty.by_pathname", &labels)
+                            .set(measures.private_dirty as f64);
+                        gauge!("smaps.shared_clean.by_pathname", &labels)
+                            .set(measures.shared_clean as f64);
+                        gauge!("smaps.shared_dirty.by_pathname", &labels)
+                            .set(measures.shared_dirty as f64);
+                        gauge!("smaps.referenced.by_pathname", &labels)
+                            .set(measures.referenced as f64);
+                        gauge!("smaps.anonymous.by_pathname", &labels)
+                            .set(measures.anonymous as f64);
+                        gauge!("smaps.lazy_free.by_pathname", &labels)
+                            .set(measures.lazy_free as f64);
+                        gauge!("smaps.anon_huge_pages.by_pathname", &labels)
+                            .set(measures.anon_huge_pages as f64);
+                        gauge!("smaps.shmem_pmd_mapped.by_pathname", &labels)
+                            .set(measures.shmem_pmd_mapped as f64);
+                        gauge!("smaps.shared_hugetlb.by_pathname", &labels)
+                            .set(measures.shared_hugetlb as f64);
+                        gauge!("smaps.private_hugetlb.by_pathname", &labels)
+                            .set(measures.private_hugetlb as f64);
+                        gauge!("smaps.file_pmd_mapped.by_pathname", &labels)
+                            .set(measures.file_pmd_mapped as f64);
+                        gauge!("smaps.locked.by_pathname", &labels).set(measures.locked as f64);
+                        gauge!("smaps.swap_pss.by_pathname", &labels).set(measures.swap_pss as f64);
                     }
 
                     let measures = memory_regions.aggregate();
@@ -329,8 +355,26 @@ impl Sampler {
                     gauge!("smaps.pss.sum", &labels).set(measures.pss as f64);
                     gauge!("smaps.size.sum", &labels).set(measures.size as f64);
                     gauge!("smaps.swap.sum", &labels).set(measures.swap as f64);
+                    gauge!("smaps.shared_clean.sum", &labels).set(measures.shared_clean as f64);
+                    gauge!("smaps.shared_dirty.sum", &labels).set(measures.shared_dirty as f64);
+                    gauge!("smaps.private_clean.sum", &labels).set(measures.private_clean as f64);
+                    gauge!("smaps.private_dirty.sum", &labels).set(measures.private_dirty as f64);
+                    gauge!("smaps.referenced.sum", &labels).set(measures.referenced as f64);
+                    gauge!("smaps.anonymous.sum", &labels).set(measures.anonymous as f64);
+                    gauge!("smaps.lazy_free.sum", &labels).set(measures.lazy_free as f64);
+                    gauge!("smaps.anon_huge_pages.sum", &labels)
+                        .set(measures.anon_huge_pages as f64);
+                    gauge!("smaps.shmem_pmd_mapped.sum", &labels)
+                        .set(measures.shmem_pmd_mapped as f64);
+                    gauge!("smaps.file_pmd_mapped.sum", &labels)
+                        .set(measures.file_pmd_mapped as f64);
+                    gauge!("smaps.shared_hugetlb.sum", &labels).set(measures.shared_hugetlb as f64);
+                    gauge!("smaps.private_hugetlb.sum", &labels)
+                        .set(measures.private_hugetlb as f64);
+                    gauge!("smaps.swap_pss.sum", &labels).set(measures.swap_pss as f64);
+                    gauge!("smaps.locked.sum", &labels).set(measures.locked as f64);
 
-                    // This code reads smaps_rollup
+                    // `/proc/{pid}/smaps_rollup`
                     let rollup = match memory::smaps_rollup::Rollup::from_pid(pid) {
                         Ok(rollup) => rollup,
                         Err(e) => {
@@ -355,6 +399,54 @@ impl Sampler {
                     }
                     if let Some(v) = rollup.pss_shmem {
                         gauge!("smaps_rollup.pss_shmem", &labels).set(v as f64);
+                    }
+                    if let Some(v) = rollup.swap {
+                        gauge!("smaps_rollup.swap", &labels).set(v as f64);
+                    }
+                    if let Some(v) = rollup.swap_pss {
+                        gauge!("smaps_rollup.swap_pss", &labels).set(v as f64);
+                    }
+                    if let Some(v) = rollup.shared_clean {
+                        gauge!("smaps_rollup.shared_clean", &labels).set(v as f64);
+                    }
+                    if let Some(v) = rollup.shared_dirty {
+                        gauge!("smaps_rollup.shared_dirty", &labels).set(v as f64);
+                    }
+                    if let Some(v) = rollup.private_clean {
+                        gauge!("smaps_rollup.private_clean", &labels).set(v as f64);
+                    }
+                    if let Some(v) = rollup.private_dirty {
+                        gauge!("smaps_rollup.private_dirty", &labels).set(v as f64);
+                    }
+                    if let Some(v) = rollup.referenced {
+                        gauge!("smaps_rollup.referenced", &labels).set(v as f64);
+                    }
+                    if let Some(v) = rollup.anonymous {
+                        gauge!("smaps_rollup.anonymous", &labels).set(v as f64);
+                    }
+                    if let Some(v) = rollup.lazy_free {
+                        gauge!("smaps_rollup.lazy_free", &labels).set(v as f64);
+                    }
+                    if let Some(v) = rollup.anon_huge_pages {
+                        gauge!("smaps_rollup.anon_huge_pages", &labels).set(v as f64);
+                    }
+                    if let Some(v) = rollup.shmem_pmd_mapped {
+                        gauge!("smaps_rollup.shmem_pmd_mapped", &labels).set(v as f64);
+                    }
+                    if let Some(v) = rollup.shared_hugetlb {
+                        gauge!("smaps_rollup.shared_hugetlb", &labels).set(v as f64);
+                    }
+                    if let Some(v) = rollup.private_hugetlb {
+                        gauge!("smaps_rollup.private_hugetlb", &labels).set(v as f64);
+                    }
+                    if let Some(v) = rollup.shared_hugetlb {
+                        gauge!("smaps_rollup.shared_hugetlb", &labels).set(v as f64);
+                    }
+                    if let Some(v) = rollup.file_pmd_mapped {
+                        gauge!("smaps_rollup.file_pmd_mapped", &labels).set(v as f64);
+                    }
+                    if let Some(v) = rollup.locked {
+                        gauge!("smaps_rollup.locked", &labels).set(v as f64);
                     }
                 });
             }

--- a/lading/src/observer/linux/procfs/memory/smaps.rs
+++ b/lading/src/observer/linux/procfs/memory/smaps.rs
@@ -350,9 +350,6 @@ fn aggregate_option(aggregate: &mut Option<u64>, value: Option<u64>) {
 }
 
 #[cfg(test)]
-#[allow(clippy::identity_op)]
-#[allow(clippy::erasing_op)]
-#[allow(clippy::unreadable_literal)]
 mod tests {
     use super::*;
 
@@ -416,10 +413,10 @@ VmFlags:               rd ex mr mw me de sd";
         let region_one = &regions.0[0];
 
         assert_eq!(region_one.pathname, "[vvar]");
-        assert_eq!(region_one.size, Some(16 * BYTES_PER_KIBIBYTE));
-        assert_eq!(region_one.pss, Some(0));
-        assert_eq!(region_one.swap, Some(7 * BYTES_PER_KIBIBYTE));
-        assert_eq!(region_one.rss, Some(0));
+        assert_eq!(region_one.size, 16 * BYTES_PER_KIBIBYTE);
+        assert_eq!(region_one.pss, 0);
+        assert_eq!(region_one.swap, 7 * BYTES_PER_KIBIBYTE);
+        assert_eq!(region_one.rss, 0);
         assert_eq!(region_one.pss_dirty, Some(0)); // pss_dirty is optional
         assert_eq!(region_one.shared_clean, Some(0));
         assert_eq!(region_one.shared_dirty, Some(0));
@@ -438,10 +435,10 @@ VmFlags:               rd ex mr mw me de sd";
 
         let region_two = &regions.0[1];
         assert_eq!(region_two.pathname, "[vdso]");
-        assert_eq!(region_two.size, Some(8 * BYTES_PER_KIBIBYTE));
-        assert_eq!(region_two.pss, Some(2 * BYTES_PER_KIBIBYTE));
-        assert_eq!(region_two.swap, Some(0));
-        assert_eq!(region_two.rss, Some(8 * BYTES_PER_KIBIBYTE));
+        assert_eq!(region_two.size, 8 * BYTES_PER_KIBIBYTE);
+        assert_eq!(region_two.pss, 2 * BYTES_PER_KIBIBYTE);
+        assert_eq!(region_two.swap, 0);
+        assert_eq!(region_two.rss, 8 * BYTES_PER_KIBIBYTE);
         assert_eq!(region_two.pss_dirty, Some(0));
         assert_eq!(region_two.shared_clean, Some(8 * BYTES_PER_KIBIBYTE));
         assert_eq!(region_two.shared_dirty, Some(0));
@@ -492,10 +489,10 @@ VmFlags:               rd ex mr mw me de sd";
         let region_one = &regions.0[0];
 
         assert_eq!(region_one.pathname, "");
-        assert_eq!(region_one.size, Some(80000000 * BYTES_PER_KIBIBYTE));
-        assert_eq!(region_one.pss, Some(1 * BYTES_PER_KIBIBYTE));
-        assert_eq!(region_one.swap, Some(100000000000 * BYTES_PER_KIBIBYTE));
-        assert_eq!(region_one.rss, Some(0));
+        assert_eq!(region_one.size, 80000000 * BYTES_PER_KIBIBYTE);
+        assert_eq!(region_one.pss, 1 * BYTES_PER_KIBIBYTE);
+        assert_eq!(region_one.swap, 100000000000 * BYTES_PER_KIBIBYTE);
+        assert_eq!(region_one.rss, 0);
         assert_eq!(region_one.pss_dirty, Some(2 * BYTES_PER_KIBIBYTE));
         assert_eq!(region_one.shared_clean, Some(3 * BYTES_PER_KIBIBYTE));
         assert_eq!(region_one.shared_dirty, Some(4 * BYTES_PER_KIBIBYTE));
@@ -553,10 +550,10 @@ VmFlags:               rd ex mr mw me de sd";
         let region_one = &regions.0[0];
 
         assert_eq!(region_one.pathname, "[stack]");
-        assert_eq!(region_one.size, Some(80000000 * BYTES_PER_KIBIBYTE));
-        assert_eq!(region_one.pss, Some(1 * BYTES_PER_KIBIBYTE));
-        assert_eq!(region_one.swap, Some(100000000000 * BYTES_PER_KIBIBYTE));
-        assert_eq!(region_one.rss, Some(0));
+        assert_eq!(region_one.size, 80000000 * BYTES_PER_KIBIBYTE);
+        assert_eq!(region_one.pss, 1 * BYTES_PER_KIBIBYTE);
+        assert_eq!(region_one.swap, 100000000000 * BYTES_PER_KIBIBYTE);
+        assert_eq!(region_one.rss, 0);
         assert_eq!(region_one.pss_dirty, None); // Still optional and missing
         assert_eq!(region_one.shared_clean, Some(3 * BYTES_PER_KIBIBYTE));
         assert_eq!(region_one.shared_dirty, Some(4 * BYTES_PER_KIBIBYTE));
@@ -611,7 +608,7 @@ VmFlags:               rd ex mr mw me de sd";
         let region = Region::from_str(region).expect("Parsing failed");
 
         assert_eq!(region.pathname, "[vdso]");
-        assert_eq!(region.size.unwrap(), 8 * BYTES_PER_KIBIBYTE);
+        assert_eq!(region.size, 8 * BYTES_PER_KIBIBYTE);
         assert_eq!(region.shared_clean.unwrap(), 8 * BYTES_PER_KIBIBYTE);
 
         let region = "ffff3fddf000-ffff3fde4000 rw-p 0037f000 fe:01 9339677                    /opt/datadog-agent/embedded/lib/python3.9/site-packages/pydantic_core/_pydantic_core.cpython-39-aarch64-linux-gnu.so
@@ -644,7 +641,7 @@ VmFlags:               rd wr mr mw me ac";
         region.pathname,
         "/opt/datadog-agent/embedded/lib/python3.9/site-packages/pydantic_core/_pydantic_core.cpython-39-aarch64-linux-gnu.so"
     );
-        assert_eq!(region.size.unwrap(), 20 * BYTES_PER_KIBIBYTE);
+        assert_eq!(region.size, 20 * BYTES_PER_KIBIBYTE);
         assert_eq!(region.private_dirty.unwrap(), 20 * BYTES_PER_KIBIBYTE);
     }
 

--- a/lading/src/observer/linux/procfs/memory/smaps.rs
+++ b/lading/src/observer/linux/procfs/memory/smaps.rs
@@ -633,7 +633,7 @@ VmFlags:               rd ex mr mw me de sd";
 
         assert_eq!(region.pathname, "[vdso]");
         assert_eq!(region.size, 8 * BYTES_PER_KIBIBYTE);
-        assert_eq!(region.shared_clean, Some(8 * BYTES_PER_KIBIBYTE));
+        assert_eq!(region.shared_clean, 8 * BYTES_PER_KIBIBYTE);
 
         let region = "
 ffff3fddf000-ffff3fde4000 rw-p 0037f000 fe:01 9339677                    /opt/datadog-agent/embedded/lib/python3.9/site-packages/pydantic_core/_pydantic_core.cpython-39-aarch64-linux-gnu.so
@@ -667,7 +667,7 @@ VmFlags:               rd wr mr mw me ac";
         "/opt/datadog-agent/embedded/lib/python3.9/site-packages/pydantic_core/_pydantic_core.cpython-39-aarch64-linux-gnu.so"
     );
         assert_eq!(region.size, 20 * BYTES_PER_KIBIBYTE);
-        assert_eq!(region.private_dirty, Some(20 * BYTES_PER_KIBIBYTE));
+        assert_eq!(region.private_dirty, 20 * BYTES_PER_KIBIBYTE);
     }
 
     #[test]

--- a/lading/src/observer/linux/procfs/memory/smaps.rs
+++ b/lading/src/observer/linux/procfs/memory/smaps.rs
@@ -120,25 +120,25 @@ impl Region {
             )));
         };
 
-        let mut size: Option<u64> = None;
-        let mut pss: Option<u64> = None;
-        let mut rss: Option<u64> = None;
-        let mut swap: Option<u64> = None;
+        let mut size: u64 = 0;
+        let mut pss: u64 = 0;
+        let mut rss: u64 = 0;
+        let mut swap: u64 = 0;
         let mut pss_dirty: Option<u64> = None;
-        let mut shared_clean: Option<u64> = None;
-        let mut shared_dirty: Option<u64> = None;
-        let mut private_clean: Option<u64> = None;
-        let mut private_dirty: Option<u64> = None;
-        let mut referenced: Option<u64> = None;
-        let mut anonymous: Option<u64> = None;
-        let mut lazy_free: Option<u64> = None;
-        let mut anon_huge_pages: Option<u64> = None;
-        let mut shmem_pmd_mapped: Option<u64> = None;
-        let mut file_pmd_mapped: Option<u64> = None;
-        let mut shared_hugetlb: Option<u64> = None;
-        let mut private_hugetlb: Option<u64> = None;
-        let mut swap_pss: Option<u64> = None;
-        let mut locked: Option<u64> = None;
+        let mut shared_clean: u64 = 0;
+        let mut shared_dirty: u64 = 0;
+        let mut private_clean: u64 = 0;
+        let mut private_dirty: u64 = 0;
+        let mut referenced: u64 = 0;
+        let mut anonymous: u64 = 0;
+        let mut lazy_free: u64 = 0;
+        let mut anon_huge_pages: u64 = 0;
+        let mut shmem_pmd_mapped: u64 = 0;
+        let mut file_pmd_mapped: u64 = 0;
+        let mut shared_hugetlb: u64 = 0;
+        let mut private_hugetlb: u64 = 0;
+        let mut swap_pss: u64 = 0;
+        let mut locked: u64 = 0;
 
         for line in lines {
             let mut chars = line.char_indices().peekable();
@@ -166,71 +166,65 @@ impl Region {
 
             match name {
                 "Rss:" => {
-                    rss = Some(value_in_kibibytes()?);
+                    rss = value_in_kibibytes()?;
                 }
                 "Pss:" => {
-                    pss = Some(value_in_kibibytes()?);
+                    pss = value_in_kibibytes()?;
                 }
                 "Size:" => {
-                    size = Some(value_in_kibibytes()?);
+                    size = value_in_kibibytes()?;
                 }
                 "Swap:" => {
-                    swap = Some(value_in_kibibytes()?);
+                    swap = value_in_kibibytes()?;
                 }
                 "Pss_Dirty:" => {
                     pss_dirty = Some(value_in_kibibytes()?);
                 }
                 "Shared_Clean:" => {
-                    shared_clean = Some(value_in_kibibytes()?);
+                    shared_clean = value_in_kibibytes()?;
                 }
                 "Shared_Dirty:" => {
-                    shared_dirty = Some(value_in_kibibytes()?);
+                    shared_dirty = value_in_kibibytes()?;
                 }
                 "Private_Clean:" => {
-                    private_clean = Some(value_in_kibibytes()?);
+                    private_clean = value_in_kibibytes()?;
                 }
                 "Private_Dirty:" => {
-                    private_dirty = Some(value_in_kibibytes()?);
+                    private_dirty = value_in_kibibytes()?;
                 }
                 "Referenced:" => {
-                    referenced = Some(value_in_kibibytes()?);
+                    referenced = value_in_kibibytes()?;
                 }
                 "Anonymous:" => {
-                    anonymous = Some(value_in_kibibytes()?);
+                    anonymous = value_in_kibibytes()?;
                 }
                 "LazyFree:" => {
-                    lazy_free = Some(value_in_kibibytes()?);
+                    lazy_free = value_in_kibibytes()?;
                 }
                 "AnonHugePages:" => {
-                    anon_huge_pages = Some(value_in_kibibytes()?);
+                    anon_huge_pages = value_in_kibibytes()?;
                 }
                 "ShmemPmdMapped:" => {
-                    shmem_pmd_mapped = Some(value_in_kibibytes()?);
+                    shmem_pmd_mapped = value_in_kibibytes()?;
                 }
                 "FilePmdMapped:" => {
-                    file_pmd_mapped = Some(value_in_kibibytes()?);
+                    file_pmd_mapped = value_in_kibibytes()?;
                 }
                 "Shared_Hugetlb:" => {
-                    shared_hugetlb = Some(value_in_kibibytes()?);
+                    shared_hugetlb = value_in_kibibytes()?;
                 }
                 "Private_Hugetlb:" => {
-                    private_hugetlb = Some(value_in_kibibytes()?);
+                    private_hugetlb = value_in_kibibytes()?;
                 }
                 "SwapPss:" => {
-                    swap_pss = Some(value_in_kibibytes()?);
+                    swap_pss = value_in_kibibytes()?;
                 }
                 "Locked:" => {
-                    locked = Some(value_in_kibibytes()?);
+                    locked = value_in_kibibytes()?;
                 }
                 _ => {}
             }
         }
-
-        let (Some(size), Some(pss), Some(rss), Some(swap)) = (size, pss, rss, swap) else {
-            return Err(Error::Parsing(format!(
-                "Could not parse all value fields from region: '{contents}'"
-            )));
-        };
 
         Ok(Region {
             start,
@@ -245,20 +239,20 @@ impl Region {
             swap,
             rss,
             pss_dirty,
-            shared_clean: shared_clean.unwrap_or(0),
-            shared_dirty: shared_dirty.unwrap_or(0),
-            private_clean: private_clean.unwrap_or(0),
-            private_dirty: private_dirty.unwrap_or(0),
-            referenced: referenced.unwrap_or(0),
-            anonymous: anonymous.unwrap_or(0),
-            lazy_free: lazy_free.unwrap_or(0),
-            anon_huge_pages: anon_huge_pages.unwrap_or(0),
-            shmem_pmd_mapped: shmem_pmd_mapped.unwrap_or(0),
-            file_pmd_mapped: file_pmd_mapped.unwrap_or(0),
-            shared_hugetlb: shared_hugetlb.unwrap_or(0),
-            private_hugetlb: private_hugetlb.unwrap_or(0),
-            swap_pss: swap_pss.unwrap_or(0),
-            locked: locked.unwrap_or(0),
+            shared_clean,
+            shared_dirty,
+            private_clean,
+            private_dirty,
+            referenced,
+            anonymous,
+            lazy_free,
+            anon_huge_pages,
+            shmem_pmd_mapped,
+            file_pmd_mapped,
+            shared_hugetlb,
+            private_hugetlb,
+            swap_pss,
+            locked,
         })
     }
 }
@@ -288,39 +282,23 @@ pub(crate) struct AggrMeasure {
 
 impl Regions {
     pub(crate) fn from_pid(pid: i32) -> Result<Self, Error> {
-        Regions::from_file(&format!("/proc/{pid}/smaps"))
+        let path = format!("/proc/{pid}/smaps");
+        let mut file: std::fs::File = std::fs::OpenOptions::new().read(true).open(path)?;
+
+        let mut contents = String::new();
+        file.read_to_string(&mut contents)?;
+
+        Self::from_str(&contents)
     }
 
-    /// Returns a sum of all the fields from each region within this Regions
-    pub(crate) fn aggregate(&self) -> AggrMeasure {
-        let mut aggr = AggrMeasure::default();
+    fn from_str(contents: &str) -> Result<Self, Error> {
+        let str_regions = Self::into_region_strs(contents);
+        let regions = str_regions
+            .iter()
+            .map(|s| Region::from_str(s))
+            .collect::<Result<Vec<_>, _>>()?;
 
-        for region in &self.0 {
-            aggr.size = aggr.size.saturating_add(region.size);
-            aggr.pss = aggr.pss.saturating_add(region.pss);
-            aggr.swap = aggr.swap.saturating_add(region.swap);
-            aggr.rss = aggr.rss.saturating_add(region.rss);
-
-            aggr.pss_dirty = aggr.pss_dirty.saturating_add(region.pss_dirty.unwrap_or(0));
-            aggr.shared_clean = aggr.shared_clean.saturating_add(region.shared_clean);
-            aggr.shared_dirty = aggr.shared_dirty.saturating_add(region.shared_dirty);
-            aggr.private_clean = aggr.private_clean.saturating_add(region.private_clean);
-            aggr.private_dirty = aggr.private_dirty.saturating_add(region.private_dirty);
-            aggr.referenced = aggr.referenced.saturating_add(region.referenced);
-            aggr.anonymous = aggr.anonymous.saturating_add(region.anonymous);
-            aggr.lazy_free = aggr.lazy_free.saturating_add(region.lazy_free);
-            aggr.anon_huge_pages = aggr.anon_huge_pages.saturating_add(region.anon_huge_pages);
-            aggr.shmem_pmd_mapped = aggr
-                .shmem_pmd_mapped
-                .saturating_add(region.shmem_pmd_mapped);
-            aggr.file_pmd_mapped = aggr.file_pmd_mapped.saturating_add(region.file_pmd_mapped);
-            aggr.shared_hugetlb = aggr.shared_hugetlb.saturating_add(region.shared_hugetlb);
-            aggr.private_hugetlb = aggr.private_hugetlb.saturating_add(region.private_hugetlb);
-            aggr.swap_pss = aggr.swap_pss.saturating_add(region.swap_pss);
-            aggr.locked = aggr.locked.saturating_add(region.locked);
-        }
-
-        aggr
+        Ok(Regions(regions))
     }
 
     pub(crate) fn aggregate_by_pathname(&self) -> Vec<(String, AggrMeasure)> {
@@ -354,15 +332,6 @@ impl Regions {
         map.into_iter().collect()
     }
 
-    fn from_file(path: &str) -> Result<Self, Error> {
-        let mut file: std::fs::File = std::fs::OpenOptions::new().read(true).open(path)?;
-
-        let mut contents = String::new();
-        file.read_to_string(&mut contents)?;
-
-        Self::from_str(&contents)
-    }
-
     fn into_region_strs(contents: &str) -> Vec<&str> {
         let mut str_regions = Vec::new();
         // split this smaps file into regions
@@ -382,16 +351,6 @@ impl Regions {
         };
 
         str_regions
-    }
-
-    fn from_str(contents: &str) -> Result<Self, Error> {
-        let str_regions = Self::into_region_strs(contents);
-        let regions = str_regions
-            .iter()
-            .map(|s| Region::from_str(s))
-            .collect::<Result<Vec<_>, _>>()?;
-
-        Ok(Regions(regions))
     }
 }
 

--- a/lading/src/observer/linux/procfs/memory/smaps.rs
+++ b/lading/src/observer/linux/procfs/memory/smaps.rs
@@ -43,16 +43,21 @@ pub(crate) struct Region {
     pub(crate) swap: u64,
     pub(crate) rss: u64,
     pub(crate) pss_dirty: Option<u64>, // only present in 6.0+
+    pub(crate) shared_clean: Option<u64>,
+    pub(crate) shared_dirty: Option<u64>,
+    pub(crate) private_clean: Option<u64>,
+    pub(crate) private_dirty: Option<u64>,
+    pub(crate) referenced: Option<u64>,
+    pub(crate) anonymous: Option<u64>,
+    pub(crate) lazy_free: Option<u64>,
+    pub(crate) anon_huge_pages: Option<u64>,
+    pub(crate) shmem_pmd_mapped: Option<u64>,
+    pub(crate) file_pmd_mapped: Option<u64>,
+    pub(crate) shared_hugetlb: Option<u64>,
+    pub(crate) private_hugetlb: Option<u64>,
+    pub(crate) swap_pss: Option<u64>,
+    pub(crate) locked: Option<u64>,
 }
-// Best docs ref I have:
-// https://docs.kernel.org/filesystems/proc.html
-//
-// Future improvement: clean up the naming to match man proc
-// The /proc/PID/smaps is an extension based on maps, showing
-// the memory consumption for each of the process's mappings.
-// For each mapping (aka Virtual Memory Area, or VMA) there is a series of lines such as the following:
-//
-// So what I'm calling "Region" is more accurately referred to as a Virtual Memory Area or VMA
 
 impl Region {
     #[allow(clippy::similar_names)]
@@ -120,6 +125,20 @@ impl Region {
         let mut rss: Option<u64> = None;
         let mut swap: Option<u64> = None;
         let mut pss_dirty: Option<u64> = None;
+        let mut shared_clean: Option<u64> = None;
+        let mut shared_dirty: Option<u64> = None;
+        let mut private_clean: Option<u64> = None;
+        let mut private_dirty: Option<u64> = None;
+        let mut referenced: Option<u64> = None;
+        let mut anonymous: Option<u64> = None;
+        let mut lazy_free: Option<u64> = None;
+        let mut anon_huge_pages: Option<u64> = None;
+        let mut shmem_pmd_mapped: Option<u64> = None;
+        let mut file_pmd_mapped: Option<u64> = None;
+        let mut shared_hugetlb: Option<u64> = None;
+        let mut private_hugetlb: Option<u64> = None;
+        let mut swap_pss: Option<u64> = None;
+        let mut locked: Option<u64> = None;
 
         for line in lines {
             let mut chars = line.char_indices().peekable();
@@ -161,6 +180,48 @@ impl Region {
                 "Pss_Dirty:" => {
                     pss_dirty = Some(value_in_kibibytes()?);
                 }
+                "Shared_Clean:" => {
+                    shared_clean = Some(value_in_kibibytes()?);
+                }
+                "Shared_Dirty:" => {
+                    shared_dirty = Some(value_in_kibibytes()?);
+                }
+                "Private_Clean:" => {
+                    private_clean = Some(value_in_kibibytes()?);
+                }
+                "Private_Dirty:" => {
+                    private_dirty = Some(value_in_kibibytes()?);
+                }
+                "Referenced:" => {
+                    referenced = Some(value_in_kibibytes()?);
+                }
+                "Anonymous:" => {
+                    anonymous = Some(value_in_kibibytes()?);
+                }
+                "LazyFree:" => {
+                    lazy_free = Some(value_in_kibibytes()?);
+                }
+                "AnonHugePages:" => {
+                    anon_huge_pages = Some(value_in_kibibytes()?);
+                }
+                "ShmemPmdMapped:" => {
+                    shmem_pmd_mapped = Some(value_in_kibibytes()?);
+                }
+                "FilePmdMapped:" => {
+                    file_pmd_mapped = Some(value_in_kibibytes()?);
+                }
+                "Shared_Hugetlb:" => {
+                    shared_hugetlb = Some(value_in_kibibytes()?);
+                }
+                "Private_Hugetlb:" => {
+                    private_hugetlb = Some(value_in_kibibytes()?);
+                }
+                "SwapPss:" => {
+                    swap_pss = Some(value_in_kibibytes()?);
+                }
+                "Locked:" => {
+                    locked = Some(value_in_kibibytes()?);
+                }
                 _ => {}
             }
         }
@@ -184,6 +245,20 @@ impl Region {
             swap,
             rss,
             pss_dirty,
+            shared_clean,
+            shared_dirty,
+            private_clean,
+            private_dirty,
+            referenced,
+            anonymous,
+            lazy_free,
+            anon_huge_pages,
+            shmem_pmd_mapped,
+            file_pmd_mapped,
+            shared_hugetlb,
+            private_hugetlb,
+            swap_pss,
+            locked,
         })
     }
 }
@@ -208,7 +283,7 @@ impl Regions {
         for region in &self.0 {
             aggr.size = aggr.size.saturating_add(region.size);
             aggr.pss = aggr.pss.saturating_add(region.pss);
-            aggr.swap = aggr.swap.saturating_add(aggr.swap);
+            aggr.swap = aggr.swap.saturating_add(region.swap);
             aggr.rss = aggr.rss.saturating_add(region.rss);
         }
 
@@ -221,7 +296,7 @@ impl Regions {
         for region in &self.0 {
             let pathname = region.pathname.clone();
 
-            let entry = map.entry(pathname).or_insert(AggrMeasure {
+            let entry = map.entry(pathname).or_insert_with(|| AggrMeasure {
                 size: 0,
                 pss: 0,
                 swap: 0,
@@ -305,11 +380,11 @@ FilePmdMapped:         0 kB
 Shared_Hugetlb:        0 kB
 Private_Hugetlb:       0 kB
 Swap:                  7 kB
-SwapPss:               0 kB
+SwapPss:               1 kB
 Locked:                0 kB
-THPeligible:    0
+THPeligible:           0
 ProtectionKey:         0
-VmFlags: rd mr pf io de dd sd
+VmFlags:               rd mr pf io de dd sd
 7fffa9f39000-7fffa9f3b000 r-xp 00000000 00:00 0                          [vdso]
 Size:                  8 kB
 KernelPageSize:        4 kB
@@ -332,9 +407,9 @@ Private_Hugetlb:       0 kB
 Swap:                  0 kB
 SwapPss:               0 kB
 Locked:                0 kB
-THPeligible:    0
+THPeligible:           0
 ProtectionKey:         0
-VmFlags: rd ex mr mw me de sd";
+VmFlags:               rd ex mr mw me de sd";
 
     #[test]
     fn test_basic_case() {
@@ -354,6 +429,20 @@ VmFlags: rd ex mr mw me de sd";
         assert_eq!(region_one.swap, 7 * BYTES_PER_KIBIBYTE);
         assert_eq!(region_one.rss, 0);
         assert_eq!(region_one.pss_dirty, Some(0));
+        assert_eq!(region_one.shared_clean, Some(0));
+        assert_eq!(region_one.shared_dirty, Some(0));
+        assert_eq!(region_one.private_clean, Some(0));
+        assert_eq!(region_one.private_dirty, Some(0));
+        assert_eq!(region_one.referenced, Some(0));
+        assert_eq!(region_one.anonymous, Some(0));
+        assert_eq!(region_one.lazy_free, Some(0));
+        assert_eq!(region_one.anon_huge_pages, Some(0));
+        assert_eq!(region_one.shmem_pmd_mapped, Some(0));
+        assert_eq!(region_one.file_pmd_mapped, Some(0));
+        assert_eq!(region_one.shared_hugetlb, Some(0));
+        assert_eq!(region_one.private_hugetlb, Some(0));
+        assert_eq!(region_one.swap_pss, Some(1 * BYTES_PER_KIBIBYTE));
+        assert_eq!(region_one.locked, Some(0));
 
         let region_two = &regions.0[1];
         assert_eq!(region_two.start, 0x7fffa9f39000);
@@ -365,9 +454,23 @@ VmFlags: rd ex mr mw me de sd";
         assert_eq!(region_two.pathname, "[vdso]");
         assert_eq!(region_two.size, 8 * BYTES_PER_KIBIBYTE);
         assert_eq!(region_two.pss, 2 * BYTES_PER_KIBIBYTE);
-        assert_eq!(region_two.swap, 0 * BYTES_PER_KIBIBYTE);
+        assert_eq!(region_two.swap, 0);
         assert_eq!(region_two.rss, 8 * BYTES_PER_KIBIBYTE);
         assert_eq!(region_two.pss_dirty, Some(0));
+        assert_eq!(region_two.shared_clean, Some(8 * BYTES_PER_KIBIBYTE));
+        assert_eq!(region_two.shared_dirty, Some(0));
+        assert_eq!(region_two.private_clean, Some(0));
+        assert_eq!(region_two.private_dirty, Some(0));
+        assert_eq!(region_two.referenced, Some(8 * BYTES_PER_KIBIBYTE));
+        assert_eq!(region_two.anonymous, Some(0));
+        assert_eq!(region_two.lazy_free, Some(0));
+        assert_eq!(region_two.anon_huge_pages, Some(0));
+        assert_eq!(region_two.shmem_pmd_mapped, Some(0));
+        assert_eq!(region_two.file_pmd_mapped, Some(0));
+        assert_eq!(region_two.shared_hugetlb, Some(0));
+        assert_eq!(region_two.private_hugetlb, Some(0));
+        assert_eq!(region_two.swap_pss, Some(0));
+        assert_eq!(region_two.locked, Some(0));
     }
 
     #[test]
@@ -395,9 +498,9 @@ Private_Hugetlb:       140140140140 kB
 Swap:                  100000000000 kB
 SwapPss:               10000000000000000 kB
 Locked:                1000000000 kB
-THPeligible:    0
+THPeligible:           0
 ProtectionKey:         0
-VmFlags: rd ex mr mw me de sd";
+VmFlags:               rd ex mr mw me de sd";
         let regions = Regions::from_str(smap_region).expect("Parsing failed");
         assert_eq!(regions.0.len(), 1);
 
@@ -414,6 +517,26 @@ VmFlags: rd ex mr mw me de sd";
         assert_eq!(region_one.swap, 100000000000 * BYTES_PER_KIBIBYTE);
         assert_eq!(region_one.rss, 0);
         assert_eq!(region_one.pss_dirty, Some(2 * BYTES_PER_KIBIBYTE));
+        assert_eq!(region_one.shared_clean, Some(3 * BYTES_PER_KIBIBYTE));
+        assert_eq!(region_one.shared_dirty, Some(4 * BYTES_PER_KIBIBYTE));
+        assert_eq!(region_one.private_clean, Some(5 * BYTES_PER_KIBIBYTE));
+        assert_eq!(region_one.private_dirty, Some(6 * BYTES_PER_KIBIBYTE));
+        assert_eq!(region_one.referenced, Some(7 * BYTES_PER_KIBIBYTE));
+        assert_eq!(region_one.anonymous, Some(8 * BYTES_PER_KIBIBYTE));
+        assert_eq!(region_one.lazy_free, Some(9 * BYTES_PER_KIBIBYTE));
+        assert_eq!(region_one.anon_huge_pages, Some(10 * BYTES_PER_KIBIBYTE));
+        assert_eq!(region_one.shmem_pmd_mapped, Some(110 * BYTES_PER_KIBIBYTE));
+        assert_eq!(region_one.file_pmd_mapped, Some(120 * BYTES_PER_KIBIBYTE));
+        assert_eq!(region_one.shared_hugetlb, Some(130 * BYTES_PER_KIBIBYTE));
+        assert_eq!(
+            region_one.private_hugetlb,
+            Some(140140140140 * BYTES_PER_KIBIBYTE)
+        );
+        assert_eq!(
+            region_one.swap_pss,
+            Some(10000000000000000 * BYTES_PER_KIBIBYTE)
+        );
+        assert_eq!(region_one.locked, Some(1000000000 * BYTES_PER_KIBIBYTE));
     }
 
     #[test]
@@ -440,9 +563,9 @@ Private_Hugetlb:       140140140140 kB
 Swap:                  100000000000 kB
 SwapPss:               10000000000000000 kB
 Locked:                1000000000 kB
-THPeligible:    0
+THPeligible:           0
 ProtectionKey:         0
-VmFlags: rd ex mr mw me de sd";
+VmFlags:               rd ex mr mw me de sd";
         let regions = Regions::from_str(smap_region).expect("Parsing failed");
         assert_eq!(regions.0.len(), 1);
 
@@ -459,160 +582,188 @@ VmFlags: rd ex mr mw me de sd";
         assert_eq!(region_one.swap, 100000000000 * BYTES_PER_KIBIBYTE);
         assert_eq!(region_one.rss, 0 * BYTES_PER_KIBIBYTE);
         assert_eq!(region_one.pss_dirty, None);
+        assert_eq!(region_one.shared_clean, Some(3 * BYTES_PER_KIBIBYTE));
+        assert_eq!(region_one.shared_dirty, Some(4 * BYTES_PER_KIBIBYTE));
+        assert_eq!(region_one.private_clean, Some(5 * BYTES_PER_KIBIBYTE));
+        assert_eq!(region_one.private_dirty, Some(6 * BYTES_PER_KIBIBYTE));
+        assert_eq!(region_one.referenced, Some(7 * BYTES_PER_KIBIBYTE));
+        assert_eq!(region_one.anonymous, Some(8 * BYTES_PER_KIBIBYTE));
+        assert_eq!(region_one.lazy_free, Some(9 * BYTES_PER_KIBIBYTE));
+        assert_eq!(region_one.anon_huge_pages, Some(10 * BYTES_PER_KIBIBYTE));
+        assert_eq!(region_one.shmem_pmd_mapped, Some(110 * BYTES_PER_KIBIBYTE));
+        assert_eq!(region_one.file_pmd_mapped, Some(120 * BYTES_PER_KIBIBYTE));
+        assert_eq!(region_one.shared_hugetlb, Some(130 * BYTES_PER_KIBIBYTE));
+        assert_eq!(
+            region_one.private_hugetlb,
+            Some(140140140140 * BYTES_PER_KIBIBYTE)
+        );
+        assert_eq!(
+            region_one.swap_pss,
+            Some(10000000000000000 * BYTES_PER_KIBIBYTE)
+        );
+        assert_eq!(region_one.locked, Some(1000000000 * BYTES_PER_KIBIBYTE));
     }
 
     #[test]
     fn test_agent_regions() {
-        let region =
-            " 7fffa9f39000-7fffa9f3b000 r-xp 00000000 00:00 0                          [vdso]
-        Size:                  8 kB
-        KernelPageSize:        4 kB
-        MMUPageSize:           4 kB
-        Rss:                   8 kB
-        Pss:                   2 kB
-        Pss_Dirty:             0 kB
-        Shared_Clean:          8 kB
-        Shared_Dirty:          0 kB
-        Private_Clean:         0 kB
-        Private_Dirty:         0 kB
-        Referenced:            8 kB
-        Anonymous:             0 kB
-        LazyFree:              0 kB
-        AnonHugePages:         0 kB
-        ShmemPmdMapped:        0 kB
-        FilePmdMapped:         0 kB
-        Shared_Hugetlb:        0 kB
-        Private_Hugetlb:       0 kB
-        Swap:                  0 kB
-        SwapPss:               0 kB
-        Locked:                0 kB
-        THPeligible:    0
-        ProtectionKey:         0
-        VmFlags: rd ex mr mw me de sd";
+        let region = "
+7fffa9f39000-7fffa9f3b000 r-xp 00000000 00:00 0                          [vdso]
+Size:                  8 kB
+KernelPageSize:        4 kB
+MMUPageSize:           4 kB
+Rss:                   8 kB
+Pss:                   2 kB
+Pss_Dirty:             0 kB
+Shared_Clean:          8 kB
+Shared_Dirty:          0 kB
+Private_Clean:         0 kB
+Private_Dirty:         0 kB
+Referenced:            8 kB
+Anonymous:             0 kB
+LazyFree:              0 kB
+AnonHugePages:         0 kB
+ShmemPmdMapped:        0 kB
+FilePmdMapped:         0 kB
+Shared_Hugetlb:        0 kB
+Private_Hugetlb:       0 kB
+Swap:                  0 kB
+SwapPss:               0 kB
+Locked:                0 kB
+THPeligible:           0
+ProtectionKey:         0
+VmFlags:               rd ex mr mw me de sd";
         let region = Region::from_str(region).expect("Parsing failed");
 
         assert_eq!(region.pathname, "[vdso]");
         assert_eq!(region.size, 8 * BYTES_PER_KIBIBYTE);
+        assert_eq!(region.shared_clean, Some(8 * BYTES_PER_KIBIBYTE));
 
-        let region = "ffff3fddf000-ffff3fde4000 rw-p 0037f000 fe:01 9339677                    /opt/datadog-agent/embedded/lib/python3.9/site-packages/pydantic_core/_pydantic_core.cpython-39-aarch64-linux-gnu.so
-        Size:                 20 kB
-        KernelPageSize:        4 kB
-        MMUPageSize:           4 kB
-        Rss:                  20 kB
-        Pss:                  20 kB
-        Shared_Clean:          0 kB
-        Shared_Dirty:          0 kB
-        Private_Clean:         0 kB
-        Private_Dirty:        20 kB
-        Referenced:           20 kB
-        Anonymous:            20 kB
-        LazyFree:              0 kB
-        AnonHugePages:         0 kB
-        ShmemPmdMapped:        0 kB
-        FilePmdMapped:         0 kB
-        Shared_Hugetlb:        0 kB
-        Private_Hugetlb:       0 kB
-        Swap:                  0 kB
-        SwapPss:               0 kB
-        Locked:                0 kB
-        THPeligible:    0
-        VmFlags: rd wr mr mw me ac";
+        let region = "
+ffff3fddf000-ffff3fde4000 rw-p 0037f000 fe:01 9339677                    /opt/datadog-agent/embedded/lib/python3.9/site-packages/pydantic_core/_pydantic_core.cpython-39-aarch64-linux-gnu.so
+Size:                 20 kB
+KernelPageSize:        4 kB
+MMUPageSize:           4 kB
+Rss:                  20 kB
+Pss:                  20 kB
+Shared_Clean:          0 kB
+Shared_Dirty:          0 kB
+Private_Clean:         0 kB
+Private_Dirty:        20 kB
+Referenced:           20 kB
+Anonymous:            20 kB
+LazyFree:              0 kB
+AnonHugePages:         0 kB
+ShmemPmdMapped:        0 kB
+FilePmdMapped:         0 kB
+Shared_Hugetlb:        0 kB
+Private_Hugetlb:       0 kB
+Swap:                  0 kB
+SwapPss:               0 kB
+Locked:                0 kB
+THPeligible:           0
+ProtectionKey:         0
+VmFlags:               rd wr mr mw me ac";
 
         let region = Region::from_str(region).expect("Parsing failed");
-        assert_eq!(region.pathname, "/opt/datadog-agent/embedded/lib/python3.9/site-packages/pydantic_core/_pydantic_core.cpython-39-aarch64-linux-gnu.so");
+        assert_eq!(
+            region.pathname,
+            "/opt/datadog-agent/embedded/lib/python3.9/site-packages/pydantic_core/_pydantic_core.cpython-39-aarch64-linux-gnu.so"
+        );
         assert_eq!(region.size, 20 * BYTES_PER_KIBIBYTE);
+        assert_eq!(region.private_dirty, Some(20 * BYTES_PER_KIBIBYTE));
     }
 
     #[test]
     fn test_varying_hex_len_mappings() {
-        let region =
-            " 7fffa9f39000-7fffa9f3b000 r-xp 00000000 00:00 0                          [vdso]
-        Size:                  8 kB
-        KernelPageSize:        4 kB
-        MMUPageSize:           4 kB
-        Rss:                   8 kB
-        Pss:                   2 kB
-        Pss_Dirty:             0 kB
-        Shared_Clean:          8 kB
-        Shared_Dirty:          0 kB
-        Private_Clean:         0 kB
-        Private_Dirty:         0 kB
-        Referenced:            8 kB
-        Anonymous:             0 kB
-        LazyFree:              0 kB
-        AnonHugePages:         0 kB
-        ShmemPmdMapped:        0 kB
-        FilePmdMapped:         0 kB
-        Shared_Hugetlb:        0 kB
-        Private_Hugetlb:       0 kB
-        Swap:                  0 kB
-        SwapPss:               0 kB
-        Locked:                0 kB
-        THPeligible:    0
-        ProtectionKey:         0
-        VmFlags: rd ex mr mw me de sd";
+        let region = "
+7fffa9f39000-7fffa9f3b000 r-xp 00000000 00:00 0                          [vdso]
+Size:                  8 kB
+KernelPageSize:        4 kB
+MMUPageSize:           4 kB
+Rss:                   8 kB
+Pss:                   2 kB
+Pss_Dirty:             0 kB
+Shared_Clean:          8 kB
+Shared_Dirty:          0 kB
+Private_Clean:         0 kB
+Private_Dirty:         0 kB
+Referenced:            8 kB
+Anonymous:             0 kB
+LazyFree:              0 kB
+AnonHugePages:         0 kB
+ShmemPmdMapped:        0 kB
+FilePmdMapped:         0 kB
+Shared_Hugetlb:        0 kB
+Private_Hugetlb:       0 kB
+Swap:                  0 kB
+SwapPss:               0 kB
+Locked:                0 kB
+THPeligible:           0
+ProtectionKey:         0
+VmFlags:               rd ex mr mw me de sd";
         let region = Region::from_str(region).expect("Parsing failed");
 
         assert_eq!(region.start, 0x7fffa9f39000);
         assert_eq!(region.end, 0x7fffa9f3b000);
 
-        let region = "00400000-0e8dd000 r-xp 00000000 00:00 0                          [vdso]
-        Size:                  8 kB
-        KernelPageSize:        4 kB
-        MMUPageSize:           4 kB
-        Rss:                   8 kB
-        Pss:                   2 kB
-        Pss_Dirty:             0 kB
-        Shared_Clean:          8 kB
-        Shared_Dirty:          0 kB
-        Private_Clean:         0 kB
-        Private_Dirty:         0 kB
-        Referenced:            8 kB
-        Anonymous:             0 kB
-        LazyFree:              0 kB
-        AnonHugePages:         0 kB
-        ShmemPmdMapped:        0 kB
-        FilePmdMapped:         0 kB
-        Shared_Hugetlb:        0 kB
-        Private_Hugetlb:       0 kB
-        Swap:                  0 kB
-        SwapPss:               0 kB
-        Locked:                0 kB
-        THPeligible:    0
-        ProtectionKey:         0
-        VmFlags: rd ex mr mw me de sd";
+        let region = "
+00400000-0e8dd000 r-xp 00000000 00:00 0                          [vdso]
+Size:                  8 kB
+KernelPageSize:        4 kB
+MMUPageSize:           4 kB
+Rss:                   8 kB
+Pss:                   2 kB
+Pss_Dirty:             0 kB
+Shared_Clean:          8 kB
+Shared_Dirty:          0 kB
+Private_Clean:         0 kB
+Private_Dirty:         0 kB
+Referenced:            8 kB
+Anonymous:             0 kB
+LazyFree:              0 kB
+AnonHugePages:         0 kB
+ShmemPmdMapped:        0 kB
+FilePmdMapped:         0 kB
+Shared_Hugetlb:        0 kB
+Private_Hugetlb:       0 kB
+Swap:                  0 kB
+SwapPss:               0 kB
+Locked:                0 kB
+THPeligible:           0
+ProtectionKey:         0
+VmFlags:               rd ex mr mw me de sd";
 
         let region = Region::from_str(region).expect("Parsing failed");
 
         assert_eq!(region.start, 0x00400000);
         assert_eq!(region.end, 0x0e8dd000);
 
-        let region =
-            "ffffffffff600000-ffffffffff601000 r-xp 00000000 00:00 0                          [vdso]
-        Size:                  8 kB
-        KernelPageSize:        4 kB
-        MMUPageSize:           4 kB
-        Rss:                   8 kB
-        Pss:                   2 kB
-        Pss_Dirty:             0 kB
-        Shared_Clean:          8 kB
-        Shared_Dirty:          0 kB
-        Private_Clean:         0 kB
-        Private_Dirty:         0 kB
-        Referenced:            8 kB
-        Anonymous:             0 kB
-        LazyFree:              0 kB
-        AnonHugePages:         0 kB
-        ShmemPmdMapped:        0 kB
-        FilePmdMapped:         0 kB
-        Shared_Hugetlb:        0 kB
-        Private_Hugetlb:       0 kB
-        Swap:                  0 kB
-        SwapPss:               0 kB
-        Locked:                0 kB
-        THPeligible:    0
-        ProtectionKey:         0
-        VmFlags: rd ex mr mw me de sd";
+        let region = "
+ffffffffff600000-ffffffffff601000 r-xp 00000000 00:00 0                          [vdso]
+Size:                  8 kB
+KernelPageSize:        4 kB
+MMUPageSize:           4 kB
+Rss:                   8 kB
+Pss:                   2 kB
+Pss_Dirty:             0 kB
+Shared_Clean:          8 kB
+Shared_Dirty:          0 kB
+Private_Clean:         0 kB
+Private_Dirty:         0 kB
+Referenced:            8 kB
+Anonymous:             0 kB
+LazyFree:              0 kB
+AnonHugePages:         0 kB
+ShmemPmdMapped:        0 kB
+FilePmdMapped:         0 kB
+Shared_Hugetlb:        0 kB
+Private_Hugetlb:       0 kB
+Swap:                  0 kB
+SwapPss:               0 kB
+Locked:                0 kB
+THPeligible:           0
+ProtectionKey:         0
+VmFlags:               rd ex mr mw me de sd";
 
         let region = Region::from_str(region).expect("Parsing failed");
 

--- a/lading/src/observer/linux/procfs/memory/smaps.rs
+++ b/lading/src/observer/linux/procfs/memory/smaps.rs
@@ -430,21 +430,21 @@ VmFlags:               rd ex mr mw me de sd";
         assert_eq!(region_one.pss, 0);
         assert_eq!(region_one.swap, 7 * BYTES_PER_KIBIBYTE);
         assert_eq!(region_one.rss, 0);
-        assert_eq!(region_one.pss_dirty, Some(0));
-        assert_eq!(region_one.shared_clean, Some(0));
-        assert_eq!(region_one.shared_dirty, Some(0));
-        assert_eq!(region_one.private_clean, Some(0));
-        assert_eq!(region_one.private_dirty, Some(0));
-        assert_eq!(region_one.referenced, Some(0));
-        assert_eq!(region_one.anonymous, Some(0));
-        assert_eq!(region_one.lazy_free, Some(0));
-        assert_eq!(region_one.anon_huge_pages, Some(0));
-        assert_eq!(region_one.shmem_pmd_mapped, Some(0));
-        assert_eq!(region_one.file_pmd_mapped, Some(0));
-        assert_eq!(region_one.shared_hugetlb, Some(0));
-        assert_eq!(region_one.private_hugetlb, Some(0));
-        assert_eq!(region_one.swap_pss, Some(1 * BYTES_PER_KIBIBYTE));
-        assert_eq!(region_one.locked, Some(0));
+        assert_eq!(region_one.pss_dirty, Some(0)); // pss_dirty is optional
+        assert_eq!(region_one.shared_clean, 0);
+        assert_eq!(region_one.shared_dirty, 0);
+        assert_eq!(region_one.private_clean, 0);
+        assert_eq!(region_one.private_dirty, 0);
+        assert_eq!(region_one.referenced, 0);
+        assert_eq!(region_one.anonymous, 0);
+        assert_eq!(region_one.lazy_free, 0);
+        assert_eq!(region_one.anon_huge_pages, 0);
+        assert_eq!(region_one.shmem_pmd_mapped, 0);
+        assert_eq!(region_one.file_pmd_mapped, 0);
+        assert_eq!(region_one.shared_hugetlb, 0);
+        assert_eq!(region_one.private_hugetlb, 0);
+        assert_eq!(region_one.swap_pss, 1 * BYTES_PER_KIBIBYTE);
+        assert_eq!(region_one.locked, 0);
 
         let region_two = &regions.0[1];
         assert_eq!(region_two.start, 0x7fffa9f39000);
@@ -459,20 +459,20 @@ VmFlags:               rd ex mr mw me de sd";
         assert_eq!(region_two.swap, 0);
         assert_eq!(region_two.rss, 8 * BYTES_PER_KIBIBYTE);
         assert_eq!(region_two.pss_dirty, Some(0));
-        assert_eq!(region_two.shared_clean, Some(8 * BYTES_PER_KIBIBYTE));
-        assert_eq!(region_two.shared_dirty, Some(0));
-        assert_eq!(region_two.private_clean, Some(0));
-        assert_eq!(region_two.private_dirty, Some(0));
-        assert_eq!(region_two.referenced, Some(8 * BYTES_PER_KIBIBYTE));
-        assert_eq!(region_two.anonymous, Some(0));
-        assert_eq!(region_two.lazy_free, Some(0));
-        assert_eq!(region_two.anon_huge_pages, Some(0));
-        assert_eq!(region_two.shmem_pmd_mapped, Some(0));
-        assert_eq!(region_two.file_pmd_mapped, Some(0));
-        assert_eq!(region_two.shared_hugetlb, Some(0));
-        assert_eq!(region_two.private_hugetlb, Some(0));
-        assert_eq!(region_two.swap_pss, Some(0));
-        assert_eq!(region_two.locked, Some(0));
+        assert_eq!(region_two.shared_clean, 8 * BYTES_PER_KIBIBYTE);
+        assert_eq!(region_two.shared_dirty, 0);
+        assert_eq!(region_two.private_clean, 0);
+        assert_eq!(region_two.private_dirty, 0);
+        assert_eq!(region_two.referenced, 8 * BYTES_PER_KIBIBYTE);
+        assert_eq!(region_two.anonymous, 0);
+        assert_eq!(region_two.lazy_free, 0);
+        assert_eq!(region_two.anon_huge_pages, 0);
+        assert_eq!(region_two.shmem_pmd_mapped, 0);
+        assert_eq!(region_two.file_pmd_mapped, 0);
+        assert_eq!(region_two.shared_hugetlb, 0);
+        assert_eq!(region_two.private_hugetlb, 0);
+        assert_eq!(region_two.swap_pss, 0);
+        assert_eq!(region_two.locked, 0);
     }
 
     #[test]
@@ -519,26 +519,23 @@ VmFlags:               rd ex mr mw me de sd";
         assert_eq!(region_one.swap, 100000000000 * BYTES_PER_KIBIBYTE);
         assert_eq!(region_one.rss, 0);
         assert_eq!(region_one.pss_dirty, Some(2 * BYTES_PER_KIBIBYTE));
-        assert_eq!(region_one.shared_clean, Some(3 * BYTES_PER_KIBIBYTE));
-        assert_eq!(region_one.shared_dirty, Some(4 * BYTES_PER_KIBIBYTE));
-        assert_eq!(region_one.private_clean, Some(5 * BYTES_PER_KIBIBYTE));
-        assert_eq!(region_one.private_dirty, Some(6 * BYTES_PER_KIBIBYTE));
-        assert_eq!(region_one.referenced, Some(7 * BYTES_PER_KIBIBYTE));
-        assert_eq!(region_one.anonymous, Some(8 * BYTES_PER_KIBIBYTE));
-        assert_eq!(region_one.lazy_free, Some(9 * BYTES_PER_KIBIBYTE));
-        assert_eq!(region_one.anon_huge_pages, Some(10 * BYTES_PER_KIBIBYTE));
-        assert_eq!(region_one.shmem_pmd_mapped, Some(110 * BYTES_PER_KIBIBYTE));
-        assert_eq!(region_one.file_pmd_mapped, Some(120 * BYTES_PER_KIBIBYTE));
-        assert_eq!(region_one.shared_hugetlb, Some(130 * BYTES_PER_KIBIBYTE));
+        assert_eq!(region_one.shared_clean, 3 * BYTES_PER_KIBIBYTE);
+        assert_eq!(region_one.shared_dirty, 4 * BYTES_PER_KIBIBYTE);
+        assert_eq!(region_one.private_clean, 5 * BYTES_PER_KIBIBYTE);
+        assert_eq!(region_one.private_dirty, 6 * BYTES_PER_KIBIBYTE);
+        assert_eq!(region_one.referenced, 7 * BYTES_PER_KIBIBYTE);
+        assert_eq!(region_one.anonymous, 8 * BYTES_PER_KIBIBYTE);
+        assert_eq!(region_one.lazy_free, 9 * BYTES_PER_KIBIBYTE);
+        assert_eq!(region_one.anon_huge_pages, 10 * BYTES_PER_KIBIBYTE);
+        assert_eq!(region_one.shmem_pmd_mapped, 110 * BYTES_PER_KIBIBYTE);
+        assert_eq!(region_one.file_pmd_mapped, 120 * BYTES_PER_KIBIBYTE);
+        assert_eq!(region_one.shared_hugetlb, 130 * BYTES_PER_KIBIBYTE);
         assert_eq!(
             region_one.private_hugetlb,
-            Some(140140140140 * BYTES_PER_KIBIBYTE)
+            140140140140 * BYTES_PER_KIBIBYTE
         );
-        assert_eq!(
-            region_one.swap_pss,
-            Some(10000000000000000 * BYTES_PER_KIBIBYTE)
-        );
-        assert_eq!(region_one.locked, Some(1000000000 * BYTES_PER_KIBIBYTE));
+        assert_eq!(region_one.swap_pss, 10000000000000000 * BYTES_PER_KIBIBYTE);
+        assert_eq!(region_one.locked, 1000000000 * BYTES_PER_KIBIBYTE);
     }
 
     #[test]
@@ -568,6 +565,7 @@ Locked:                1000000000 kB
 THPeligible:           0
 ProtectionKey:         0
 VmFlags:               rd ex mr mw me de sd";
+
         let regions = Regions::from_str(smap_region).expect("Parsing failed");
         assert_eq!(regions.0.len(), 1);
 
@@ -582,28 +580,25 @@ VmFlags:               rd ex mr mw me de sd";
         assert_eq!(region_one.size, 80000000 * BYTES_PER_KIBIBYTE);
         assert_eq!(region_one.pss, 1 * BYTES_PER_KIBIBYTE);
         assert_eq!(region_one.swap, 100000000000 * BYTES_PER_KIBIBYTE);
-        assert_eq!(region_one.rss, 0 * BYTES_PER_KIBIBYTE);
-        assert_eq!(region_one.pss_dirty, None);
-        assert_eq!(region_one.shared_clean, Some(3 * BYTES_PER_KIBIBYTE));
-        assert_eq!(region_one.shared_dirty, Some(4 * BYTES_PER_KIBIBYTE));
-        assert_eq!(region_one.private_clean, Some(5 * BYTES_PER_KIBIBYTE));
-        assert_eq!(region_one.private_dirty, Some(6 * BYTES_PER_KIBIBYTE));
-        assert_eq!(region_one.referenced, Some(7 * BYTES_PER_KIBIBYTE));
-        assert_eq!(region_one.anonymous, Some(8 * BYTES_PER_KIBIBYTE));
-        assert_eq!(region_one.lazy_free, Some(9 * BYTES_PER_KIBIBYTE));
-        assert_eq!(region_one.anon_huge_pages, Some(10 * BYTES_PER_KIBIBYTE));
-        assert_eq!(region_one.shmem_pmd_mapped, Some(110 * BYTES_PER_KIBIBYTE));
-        assert_eq!(region_one.file_pmd_mapped, Some(120 * BYTES_PER_KIBIBYTE));
-        assert_eq!(region_one.shared_hugetlb, Some(130 * BYTES_PER_KIBIBYTE));
+        assert_eq!(region_one.rss, 0);
+        assert_eq!(region_one.pss_dirty, None); // Still optional and missing
+        assert_eq!(region_one.shared_clean, 3 * BYTES_PER_KIBIBYTE);
+        assert_eq!(region_one.shared_dirty, 4 * BYTES_PER_KIBIBYTE);
+        assert_eq!(region_one.private_clean, 5 * BYTES_PER_KIBIBYTE);
+        assert_eq!(region_one.private_dirty, 6 * BYTES_PER_KIBIBYTE);
+        assert_eq!(region_one.referenced, 7 * BYTES_PER_KIBIBYTE);
+        assert_eq!(region_one.anonymous, 8 * BYTES_PER_KIBIBYTE);
+        assert_eq!(region_one.lazy_free, 9 * BYTES_PER_KIBIBYTE);
+        assert_eq!(region_one.anon_huge_pages, 10 * BYTES_PER_KIBIBYTE);
+        assert_eq!(region_one.shmem_pmd_mapped, 110 * BYTES_PER_KIBIBYTE);
+        assert_eq!(region_one.file_pmd_mapped, 120 * BYTES_PER_KIBIBYTE);
+        assert_eq!(region_one.shared_hugetlb, 130 * BYTES_PER_KIBIBYTE);
         assert_eq!(
             region_one.private_hugetlb,
-            Some(140140140140 * BYTES_PER_KIBIBYTE)
+            140140140140 * BYTES_PER_KIBIBYTE
         );
-        assert_eq!(
-            region_one.swap_pss,
-            Some(10000000000000000 * BYTES_PER_KIBIBYTE)
-        );
-        assert_eq!(region_one.locked, Some(1000000000 * BYTES_PER_KIBIBYTE));
+        assert_eq!(region_one.swap_pss, 10000000000000000 * BYTES_PER_KIBIBYTE);
+        assert_eq!(region_one.locked, 1000000000 * BYTES_PER_KIBIBYTE);
     }
 
     #[test]
@@ -668,9 +663,9 @@ VmFlags:               rd wr mr mw me ac";
 
         let region = Region::from_str(region).expect("Parsing failed");
         assert_eq!(
-            region.pathname,
-            "/opt/datadog-agent/embedded/lib/python3.9/site-packages/pydantic_core/_pydantic_core.cpython-39-aarch64-linux-gnu.so"
-        );
+        region.pathname,
+        "/opt/datadog-agent/embedded/lib/python3.9/site-packages/pydantic_core/_pydantic_core.cpython-39-aarch64-linux-gnu.so"
+    );
         assert_eq!(region.size, 20 * BYTES_PER_KIBIBYTE);
         assert_eq!(region.private_dirty, Some(20 * BYTES_PER_KIBIBYTE));
     }

--- a/lading/src/observer/linux/procfs/memory/smaps.rs
+++ b/lading/src/observer/linux/procfs/memory/smaps.rs
@@ -361,8 +361,8 @@ impl Regions {
 mod tests {
     use super::*;
 
-    const KERNEL_6_TWO_REGIONS: &str = "
-7fffa9f35000-7fffa9f39000 r--p 00000000 12:11 0                          [vvar]
+    const KERNEL_6_TWO_REGIONS: &str =
+        "7fffa9f35000-7fffa9f39000 r--p 00000000 12:11 0                          [vvar]
 Size:                 16 kB
 KernelPageSize:        4 kB
 MMUPageSize:           4 kB
@@ -477,8 +477,7 @@ VmFlags:               rd ex mr mw me de sd";
 
     #[test]
     fn test_empty_pathname() {
-        let smap_region = "
-abcdefabcfed-abdcef123450 r-xp 10101010 12:34 0
+        let smap_region = "abcdefabcfed-abdcef123450 r-xp 10101010 12:34 0
 Size:                  80000000 kB
 KernelPageSize:        400 kB
 MMUPageSize:           4 kB
@@ -540,8 +539,8 @@ VmFlags:               rd ex mr mw me de sd";
 
     #[test]
     fn test_no_pss_dirty() {
-        let smap_region = "
-7ffeb825c000-7ffeb827d000 rw-p 00000000 00:00 0                          [stack]
+        let smap_region =
+            "7ffeb825c000-7ffeb827d000 rw-p 00000000 00:00 0                          [stack]
 Size:                  80000000 kB
 KernelPageSize:        400 kB
 MMUPageSize:           4 kB
@@ -603,8 +602,8 @@ VmFlags:               rd ex mr mw me de sd";
 
     #[test]
     fn test_agent_regions() {
-        let region = "
-7fffa9f39000-7fffa9f3b000 r-xp 00000000 00:00 0                          [vdso]
+        let region =
+            "7fffa9f39000-7fffa9f3b000 r-xp 00000000 00:00 0                          [vdso]
 Size:                  8 kB
 KernelPageSize:        4 kB
 MMUPageSize:           4 kB
@@ -635,8 +634,7 @@ VmFlags:               rd ex mr mw me de sd";
         assert_eq!(region.size, 8 * BYTES_PER_KIBIBYTE);
         assert_eq!(region.shared_clean, 8 * BYTES_PER_KIBIBYTE);
 
-        let region = "
-ffff3fddf000-ffff3fde4000 rw-p 0037f000 fe:01 9339677                    /opt/datadog-agent/embedded/lib/python3.9/site-packages/pydantic_core/_pydantic_core.cpython-39-aarch64-linux-gnu.so
+        let region = "ffff3fddf000-ffff3fde4000 rw-p 0037f000 fe:01 9339677                    /opt/datadog-agent/embedded/lib/python3.9/site-packages/pydantic_core/_pydantic_core.cpython-39-aarch64-linux-gnu.so
 Size:                 20 kB
 KernelPageSize:        4 kB
 MMUPageSize:           4 kB
@@ -672,8 +670,8 @@ VmFlags:               rd wr mr mw me ac";
 
     #[test]
     fn test_varying_hex_len_mappings() {
-        let region = "
-7fffa9f39000-7fffa9f3b000 r-xp 00000000 00:00 0                          [vdso]
+        let region =
+            "7fffa9f39000-7fffa9f3b000 r-xp 00000000 00:00 0                          [vdso]
 Size:                  8 kB
 KernelPageSize:        4 kB
 MMUPageSize:           4 kB
@@ -703,8 +701,7 @@ VmFlags:               rd ex mr mw me de sd";
         assert_eq!(region.start, 0x7fffa9f39000);
         assert_eq!(region.end, 0x7fffa9f3b000);
 
-        let region = "
-00400000-0e8dd000 r-xp 00000000 00:00 0                          [vdso]
+        let region = "00400000-0e8dd000 r-xp 00000000 00:00 0                          [vdso]
 Size:                  8 kB
 KernelPageSize:        4 kB
 MMUPageSize:           4 kB
@@ -735,8 +732,7 @@ VmFlags:               rd ex mr mw me de sd";
         assert_eq!(region.start, 0x00400000);
         assert_eq!(region.end, 0x0e8dd000);
 
-        let region = "
-ffffffffff600000-ffffffffff601000 r-xp 00000000 00:00 0                          [vdso]
+        let region = "ffffffffff600000-ffffffffff601000 r-xp 00000000 00:00 0                          [vdso]
 Size:                  8 kB
 KernelPageSize:        4 kB
 MMUPageSize:           4 kB

--- a/lading/src/observer/linux/procfs/memory/smaps_rollup.rs
+++ b/lading/src/observer/linux/procfs/memory/smaps_rollup.rs
@@ -1,4 +1,6 @@
-use std::io::Read;
+use heck::ToSnakeCase;
+use metrics::gauge;
+use tokio::fs;
 
 use super::{next_token, BYTES_PER_KIBIBYTE};
 
@@ -14,277 +16,48 @@ pub(crate) enum Error {
     Parsing(String),
 }
 
-pub(crate) struct Rollup {
-    pub(crate) rss: u64,
-    pub(crate) pss: u64,
-    pub(crate) pss_dirty: Option<u64>,
-    pub(crate) pss_anon: Option<u64>,
-    pub(crate) pss_file: Option<u64>,
-    pub(crate) pss_shmem: Option<u64>,
-    pub(crate) shared_clean: Option<u64>,
-    pub(crate) shared_dirty: Option<u64>,
-    pub(crate) private_clean: Option<u64>,
-    pub(crate) private_dirty: Option<u64>,
-    pub(crate) referenced: Option<u64>,
-    pub(crate) anonymous: Option<u64>,
-    pub(crate) lazy_free: Option<u64>,
-    pub(crate) anon_huge_pages: Option<u64>,
-    pub(crate) shmem_pmd_mapped: Option<u64>,
-    pub(crate) file_pmd_mapped: Option<u64>,
-    pub(crate) shared_hugetlb: Option<u64>,
-    pub(crate) private_hugetlb: Option<u64>,
-    pub(crate) swap: Option<u64>,
-    pub(crate) swap_pss: Option<u64>,
-    pub(crate) locked: Option<u64>,
-}
+// Read `/proc/{pid}/smaps_rollup` and parse it directly into metrics.
+pub(crate) async fn poll(pid: i32, labels: &[(String, String)]) -> Result<(), Error> {
+    let path = format!("/proc/{pid}/smaps_rollup");
+    // NOTE `read_to_string` uses as few IO operations as possible in its
+    // implementation, so we might get the contents here in one go.
+    let contents: String = fs::read_to_string(path).await?;
+    let mut lines = contents.lines();
 
-impl Rollup {
-    pub(crate) fn from_pid(pid: i32) -> Result<Self, Error> {
-        Self::from_file(&format!("/proc/{pid}/smaps_rollup"))
-    }
+    lines.next(); // skip header, doesn't have any useful information
+                  // looks like this:
+                  // 00400000-7fff03d61000 ---p 00000000 00:00 0                              [rollup]
 
-    pub(crate) fn from_file(path: &str) -> Result<Self, Error> {
-        let mut file: std::fs::File = std::fs::OpenOptions::new().read(true).open(path)?;
-
-        let mut contents = String::new();
-        file.read_to_string(&mut contents)?;
-
-        Self::from_str(&contents)
-    }
-
-    #[allow(clippy::similar_names)]
-    #[allow(clippy::too_many_lines)]
-    pub(crate) fn from_str(contents: &str) -> Result<Self, Error> {
-        let mut lines = contents.lines();
-        lines.next(); // skip header, doesn't have any useful information
-                      // looks like this:
-                      // 00400000-7fff03d61000 ---p 00000000 00:00 0                              [rollup]
-        let mut rss = None;
-        let mut pss = None;
-        let mut pss_dirty = None;
-        let mut pss_anon = None;
-        let mut pss_file = None;
-        let mut pss_shmem = None;
-        let mut shared_clean = None;
-        let mut shared_dirty = None;
-        let mut private_clean = None;
-        let mut private_dirty = None;
-        let mut referenced = None;
-        let mut anonymous = None;
-        let mut lazy_free = None;
-        let mut anon_huge_pages = None;
-        let mut shmem_pmd_mapped = None;
-        let mut file_pmd_mapped = None;
-        let mut shared_hugetlb = None;
-        let mut private_hugetlb = None;
-        let mut swap = None;
-        let mut swap_pss = None;
-        let mut locked = None;
-
-        for line in lines {
-            let mut chars = line.char_indices().peekable();
-            let Some(name) = next_token(line, &mut chars) else {
-                // if there is no token on the line, that means empty line, that's fine
-                continue;
-            };
-
-            let mut value_in_kibibytes = || -> Result<u64, Error> {
-                let value_token = next_token(line, &mut chars).ok_or(Error::Parsing(format!(
-                    "Could not parse numeric value from line: {line}"
-                )))?;
-                let unit = next_token(line, &mut chars).ok_or(Error::Parsing(format!(
-                    "Could not parse unit from line: {line}"
-                )))?;
-                let numeric = value_token.parse::<u64>()?;
-
-                match unit {
-                    "kB" => Ok(numeric * BYTES_PER_KIBIBYTE),
-                    unknown => Err(Error::Parsing(format!(
-                        "Unknown unit: {unknown} in line: {line}"
-                    ))),
-                }
-            };
-
-            match name {
-                "Rss:" => {
-                    rss = Some(value_in_kibibytes()?);
-                }
-                "Pss:" => {
-                    pss = Some(value_in_kibibytes()?);
-                }
-                "Pss_Dirty:" => {
-                    pss_dirty = Some(value_in_kibibytes()?);
-                }
-                "Pss_Anon:" => {
-                    pss_anon = Some(value_in_kibibytes()?);
-                }
-                "Pss_File:" => {
-                    pss_file = Some(value_in_kibibytes()?);
-                }
-                "Pss_Shmem:" => {
-                    pss_shmem = Some(value_in_kibibytes()?);
-                }
-                "Shared_Clean:" => {
-                    shared_clean = Some(value_in_kibibytes()?);
-                }
-                "Shared_Dirty:" => {
-                    shared_dirty = Some(value_in_kibibytes()?);
-                }
-                "Private_Clean:" => {
-                    private_clean = Some(value_in_kibibytes()?);
-                }
-                "Private_Dirty:" => {
-                    private_dirty = Some(value_in_kibibytes()?);
-                }
-                "Referenced:" => {
-                    referenced = Some(value_in_kibibytes()?);
-                }
-                "Anonymous:" => {
-                    anonymous = Some(value_in_kibibytes()?);
-                }
-                "LazyFree:" => {
-                    lazy_free = Some(value_in_kibibytes()?);
-                }
-                "AnonHugePages:" => {
-                    anon_huge_pages = Some(value_in_kibibytes()?);
-                }
-                "ShmemPmdMapped:" => {
-                    shmem_pmd_mapped = Some(value_in_kibibytes()?);
-                }
-                "FilePmdMapped:" => {
-                    file_pmd_mapped = Some(value_in_kibibytes()?);
-                }
-                "Shared_Hugetlb:" => {
-                    shared_hugetlb = Some(value_in_kibibytes()?);
-                }
-                "Private_Hugetlb:" => {
-                    private_hugetlb = Some(value_in_kibibytes()?);
-                }
-                "Swap:" => {
-                    swap = Some(value_in_kibibytes()?);
-                }
-                "SwapPss:" => {
-                    swap_pss = Some(value_in_kibibytes()?);
-                }
-                "Locked:" => {
-                    locked = Some(value_in_kibibytes()?);
-                }
-                _ => {}
-            }
-        }
-
-        let (Some(rss), Some(pss)) = (rss, pss) else {
-            return Err(Error::Parsing(format!(
-                "Could not parse all value fields from rollup: '{contents}'"
-            )));
+    for line in lines {
+        let mut chars = line.char_indices().peekable();
+        let Some(name) = next_token(line, &mut chars) else {
+            // if there is no token on the line, that means empty line, that's fine
+            continue;
         };
 
-        Ok(Rollup {
-            rss,
-            pss,
-            pss_dirty,
-            pss_anon,
-            pss_file,
-            pss_shmem,
-            shared_clean,
-            shared_dirty,
-            private_clean,
-            private_dirty,
-            referenced,
-            anonymous,
-            lazy_free,
-            anon_huge_pages,
-            shmem_pmd_mapped,
-            file_pmd_mapped,
-            shared_hugetlb,
-            private_hugetlb,
-            swap,
-            swap_pss,
-            locked,
-        })
-    }
-}
+        let value_kb = {
+            let value_token = next_token(line, &mut chars).ok_or(Error::Parsing(format!(
+                "Could not parse numeric value from line: {line}"
+            )))?;
+            let unit = next_token(line, &mut chars).ok_or(Error::Parsing(format!(
+                "Could not parse unit from line: {line}"
+            )))?;
+            let numeric = value_token.parse::<u64>()?;
 
-#[cfg(test)]
-mod test {
-    use crate::observer::linux::procfs::memory::smaps_rollup::Rollup;
-    use crate::observer::linux::procfs::memory::BYTES_PER_KIBIBYTE;
+            match unit {
+                "kB" => Ok(numeric * BYTES_PER_KIBIBYTE),
+                unknown => Err(Error::Parsing(format!(
+                    "Unknown unit: {unknown} in line: {line}"
+                ))),
+            }
+        }?;
 
-    #[test]
-    fn test_rollup() {
-        let rollup =
-            "00400000-7fff03d61000 ---p 00000000 00:00 0                              [rollup]
-        Rss:              312048 kB
-        Pss:              312044 kB
-        Pss_Dirty:        310508 kB
-        Pss_Anon:         310508 kB
-        Pss_File:           1536 kB
-        Pss_Shmem:             0 kB
-        Shared_Clean:          4 kB
-        Shared_Dirty:          0 kB
-        Private_Clean:      1536 kB
-        Private_Dirty:    310508 kB
-        Referenced:       312048 kB
-        Anonymous:        310508 kB
-        LazyFree:              0 kB
-        AnonHugePages:         0 kB
-        ShmemPmdMapped:        0 kB
-        FilePmdMapped:         0 kB
-        Shared_Hugetlb:        0 kB
-        Private_Hugetlb:       0 kB
-        Swap:                  0 kB
-        SwapPss:               0 kB
-        Locked:                0 kB";
-        let rollup = Rollup::from_str(rollup).expect("Parsing failed");
-        assert_eq!(rollup.pss, 312044 * BYTES_PER_KIBIBYTE);
-        assert_eq!(rollup.rss, 312048 * BYTES_PER_KIBIBYTE);
-        assert_eq!(rollup.pss_dirty, Some(310508 * BYTES_PER_KIBIBYTE));
-        assert_eq!(rollup.pss_anon, Some(310508 * BYTES_PER_KIBIBYTE));
-        assert_eq!(rollup.pss_file, Some(1536 * BYTES_PER_KIBIBYTE));
-        assert_eq!(rollup.pss_shmem, Some(0));
-        assert_eq!(rollup.shared_clean, Some(4 * BYTES_PER_KIBIBYTE));
-        assert_eq!(rollup.shared_dirty, Some(0));
-        assert_eq!(rollup.private_clean, Some(1536 * BYTES_PER_KIBIBYTE));
-        assert_eq!(rollup.private_dirty, Some(310508 * BYTES_PER_KIBIBYTE));
-        assert_eq!(rollup.referenced, Some(312048 * BYTES_PER_KIBIBYTE));
-        assert_eq!(rollup.anonymous, Some(310508 * BYTES_PER_KIBIBYTE));
-        assert_eq!(rollup.lazy_free, Some(0));
-        assert_eq!(rollup.anon_huge_pages, Some(0));
-        assert_eq!(rollup.shmem_pmd_mapped, Some(0));
-        assert_eq!(rollup.file_pmd_mapped, Some(0));
-        assert_eq!(rollup.shared_hugetlb, Some(0));
-        assert_eq!(rollup.private_hugetlb, Some(0));
-        assert_eq!(rollup.swap, Some(0));
-        assert_eq!(rollup.swap_pss, Some(0));
-        assert_eq!(rollup.locked, Some(0));
+        let name_len = name.len();
+        // Last character is a :, skip it.
+        let field = name[..name_len - 1].to_snake_case();
+        let metric_name = format!("smaps_rollup.{field}");
+        gauge!(metric_name, labels).set(value_kb as f64);
     }
 
-    #[test]
-    fn test_rollup_missing_data() {
-        let rollup =
-            "00400000-7fff03d61000 ---p 00000000 00:00 0                              [rollup]
-        Rss:              312048 kB
-        Pss:              312044 kB
-        ShmemPmdMapped:        0 kB
-        FilePmdMapped:         0 kB
-        Shared_Hugetlb:        0 kB
-        Private_Hugetlb:       0 kB
-        Swap:                  0 kB
-        SwapPss:               0 kB
-        Locked:                0 kB";
-        let rollup = Rollup::from_str(rollup).expect("Parsing failed");
-        assert_eq!(rollup.pss, 312044 * BYTES_PER_KIBIBYTE);
-        assert_eq!(rollup.rss, 312048 * BYTES_PER_KIBIBYTE);
-        assert_eq!(rollup.pss_dirty, None);
-        assert_eq!(rollup.pss_anon, None);
-        assert_eq!(rollup.pss_file, None);
-        assert_eq!(rollup.pss_shmem, None);
-        assert_eq!(rollup.shmem_pmd_mapped, Some(0));
-        assert_eq!(rollup.file_pmd_mapped, Some(0));
-        assert_eq!(rollup.shared_hugetlb, Some(0));
-        assert_eq!(rollup.private_hugetlb, Some(0));
-        assert_eq!(rollup.swap, Some(0));
-        assert_eq!(rollup.swap_pss, Some(0));
-        assert_eq!(rollup.locked, Some(0));
-    }
+    Ok(())
 }

--- a/lading/src/observer/linux/procfs/memory/smaps_rollup.rs
+++ b/lading/src/observer/linux/procfs/memory/smaps_rollup.rs
@@ -21,6 +21,21 @@ pub(crate) struct Rollup {
     pub(crate) pss_anon: Option<u64>,
     pub(crate) pss_file: Option<u64>,
     pub(crate) pss_shmem: Option<u64>,
+    pub(crate) shared_clean: Option<u64>,
+    pub(crate) shared_dirty: Option<u64>,
+    pub(crate) private_clean: Option<u64>,
+    pub(crate) private_dirty: Option<u64>,
+    pub(crate) referenced: Option<u64>,
+    pub(crate) anonymous: Option<u64>,
+    pub(crate) lazy_free: Option<u64>,
+    pub(crate) anon_huge_pages: Option<u64>,
+    pub(crate) shmem_pmd_mapped: Option<u64>,
+    pub(crate) file_pmd_mapped: Option<u64>,
+    pub(crate) shared_hugetlb: Option<u64>,
+    pub(crate) private_hugetlb: Option<u64>,
+    pub(crate) swap: Option<u64>,
+    pub(crate) swap_pss: Option<u64>,
+    pub(crate) locked: Option<u64>,
 }
 
 impl Rollup {
@@ -38,6 +53,7 @@ impl Rollup {
     }
 
     #[allow(clippy::similar_names)]
+    #[allow(clippy::too_many_lines)]
     pub(crate) fn from_str(contents: &str) -> Result<Self, Error> {
         let mut lines = contents.lines();
         lines.next(); // skip header, doesn't have any useful information
@@ -49,6 +65,21 @@ impl Rollup {
         let mut pss_anon = None;
         let mut pss_file = None;
         let mut pss_shmem = None;
+        let mut shared_clean = None;
+        let mut shared_dirty = None;
+        let mut private_clean = None;
+        let mut private_dirty = None;
+        let mut referenced = None;
+        let mut anonymous = None;
+        let mut lazy_free = None;
+        let mut anon_huge_pages = None;
+        let mut shmem_pmd_mapped = None;
+        let mut file_pmd_mapped = None;
+        let mut shared_hugetlb = None;
+        let mut private_hugetlb = None;
+        let mut swap = None;
+        let mut swap_pss = None;
+        let mut locked = None;
 
         for line in lines {
             let mut chars = line.char_indices().peekable();
@@ -93,6 +124,51 @@ impl Rollup {
                 "Pss_Shmem:" => {
                     pss_shmem = Some(value_in_kibibytes()?);
                 }
+                "Shared_Clean:" => {
+                    shared_clean = Some(value_in_kibibytes()?);
+                }
+                "Shared_Dirty:" => {
+                    shared_dirty = Some(value_in_kibibytes()?);
+                }
+                "Private_Clean:" => {
+                    private_clean = Some(value_in_kibibytes()?);
+                }
+                "Private_Dirty:" => {
+                    private_dirty = Some(value_in_kibibytes()?);
+                }
+                "Referenced:" => {
+                    referenced = Some(value_in_kibibytes()?);
+                }
+                "Anonymous:" => {
+                    anonymous = Some(value_in_kibibytes()?);
+                }
+                "LazyFree:" => {
+                    lazy_free = Some(value_in_kibibytes()?);
+                }
+                "AnonHugePages:" => {
+                    anon_huge_pages = Some(value_in_kibibytes()?);
+                }
+                "ShmemPmdMapped:" => {
+                    shmem_pmd_mapped = Some(value_in_kibibytes()?);
+                }
+                "FilePmdMapped:" => {
+                    file_pmd_mapped = Some(value_in_kibibytes()?);
+                }
+                "Shared_Hugetlb:" => {
+                    shared_hugetlb = Some(value_in_kibibytes()?);
+                }
+                "Private_Hugetlb:" => {
+                    private_hugetlb = Some(value_in_kibibytes()?);
+                }
+                "Swap:" => {
+                    swap = Some(value_in_kibibytes()?);
+                }
+                "SwapPss:" => {
+                    swap_pss = Some(value_in_kibibytes()?);
+                }
+                "Locked:" => {
+                    locked = Some(value_in_kibibytes()?);
+                }
                 _ => {}
             }
         }
@@ -110,6 +186,21 @@ impl Rollup {
             pss_anon,
             pss_file,
             pss_shmem,
+            shared_clean,
+            shared_dirty,
+            private_clean,
+            private_dirty,
+            referenced,
+            anonymous,
+            lazy_free,
+            anon_huge_pages,
+            shmem_pmd_mapped,
+            file_pmd_mapped,
+            shared_hugetlb,
+            private_hugetlb,
+            swap,
+            swap_pss,
+            locked,
         })
     }
 }
@@ -151,6 +242,21 @@ mod test {
         assert_eq!(rollup.pss_anon, Some(310508 * BYTES_PER_KIBIBYTE));
         assert_eq!(rollup.pss_file, Some(1536 * BYTES_PER_KIBIBYTE));
         assert_eq!(rollup.pss_shmem, Some(0));
+        assert_eq!(rollup.shared_clean, Some(4 * BYTES_PER_KIBIBYTE));
+        assert_eq!(rollup.shared_dirty, Some(0));
+        assert_eq!(rollup.private_clean, Some(1536 * BYTES_PER_KIBIBYTE));
+        assert_eq!(rollup.private_dirty, Some(310508 * BYTES_PER_KIBIBYTE));
+        assert_eq!(rollup.referenced, Some(312048 * BYTES_PER_KIBIBYTE));
+        assert_eq!(rollup.anonymous, Some(310508 * BYTES_PER_KIBIBYTE));
+        assert_eq!(rollup.lazy_free, Some(0));
+        assert_eq!(rollup.anon_huge_pages, Some(0));
+        assert_eq!(rollup.shmem_pmd_mapped, Some(0));
+        assert_eq!(rollup.file_pmd_mapped, Some(0));
+        assert_eq!(rollup.shared_hugetlb, Some(0));
+        assert_eq!(rollup.private_hugetlb, Some(0));
+        assert_eq!(rollup.swap, Some(0));
+        assert_eq!(rollup.swap_pss, Some(0));
+        assert_eq!(rollup.locked, Some(0));
     }
 
     #[test]
@@ -173,5 +279,12 @@ mod test {
         assert_eq!(rollup.pss_anon, None);
         assert_eq!(rollup.pss_file, None);
         assert_eq!(rollup.pss_shmem, None);
+        assert_eq!(rollup.shmem_pmd_mapped, Some(0));
+        assert_eq!(rollup.file_pmd_mapped, Some(0));
+        assert_eq!(rollup.shared_hugetlb, Some(0));
+        assert_eq!(rollup.private_hugetlb, Some(0));
+        assert_eq!(rollup.swap, Some(0));
+        assert_eq!(rollup.swap_pss, Some(0));
+        assert_eq!(rollup.locked, Some(0));
     }
 }


### PR DESCRIPTION
### What does this PR do?

This commit expands the number of fields we parse from the smaps/smaps_rollup
files. I have not hooked these up yet to metrics emission but will in a follow-up
commit to this PR.
