### PR TITLE
Avoid potential overflows

### DIFF
--- a/lading/src/observer/linux/procfs/memory/smaps_rollup.rs
+++ b/lading/src/observer/linux/procfs/memory/smaps_rollup.rs
@@ -2,8 +2,6 @@ use heck::ToSnakeCase;
 use metrics::gauge;
 use tokio::fs;
 
-use tracing::info;
-
 use super::{next_token, BYTES_PER_KIBIBYTE};
 
 #[derive(thiserror::Error, Debug)]

--- a/lading/src/observer/linux/procfs/memory/smaps_rollup.rs
+++ b/lading/src/observer/linux/procfs/memory/smaps_rollup.rs
@@ -73,10 +73,6 @@ pub(crate) async fn poll(
             _ => { /* ignore other fields */ }
         }
         let metric_name = format!("smaps_rollup.{field}");
-        info!(
-            "line: {line}, value_bytes: {value_bytes}, bytes: {bytes}",
-            bytes = value_bytes as f64
-        );
         gauge!(metric_name, labels).set(value_bytes as f64);
     }
 


### PR DESCRIPTION
### What does this PR do?

There is a bug in lading where gauge values for smaps_rollup, smaps
come through in the EiB range. The changes here are not a fix but they
don't hurt either and they're a good idea.
