### PR TITLE
Correct a coercion bug in capture manager

### DIFF
--- a/lading/src/captures.rs
+++ b/lading/src/captures.rs
@@ -152,13 +152,14 @@ impl CaptureManager {
                 // TODO we're allocating the same small strings over and over most likely
                 labels.insert(lbl.key().into(), lbl.value().into());
             }
+            let value: f64 = f64::from_bits(counter.get_inner().load(Ordering::Relaxed));
             let line = json::Line {
                 run_id: self.run_id,
                 time: now_ms,
                 fetch_index: self.fetch_index,
                 metric_name: key.name().into(),
                 metric_kind: json::MetricKind::Counter,
-                value: json::LineValue::Int(counter.get_inner().load(Ordering::Relaxed)),
+                value: json::LineValue::Float(value),
                 labels,
             };
             lines.push(line);
@@ -180,13 +181,14 @@ impl CaptureManager {
                 // TODO we're allocating the same small strings over and over most likely
                 labels.insert(lbl.key().into(), lbl.value().into());
             }
+            let value: f64 = f64::from_bits(gauge.get_inner().load(Ordering::Relaxed));
             let line = json::Line {
                 run_id: self.run_id,
                 time: now_ms,
                 fetch_index: self.fetch_index,
                 metric_name: key.name().into(),
                 metric_kind: json::MetricKind::Gauge,
-                value: json::LineValue::Int(gauge.get_inner().load(Ordering::Relaxed)),
+                value: json::LineValue::Float(value),
                 labels,
             };
             lines.push(line);


### PR DESCRIPTION
### What does this PR do?

This commit corrects a bug whereby the capture manager did not coerce the
u64 values up from the registry storage into their f64 representation, meaning
we reported out to captures comically huge values.

Much obliged to @tobz who spotted the bug.
