### PR TITLE
Remove procfs CPU percentage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   build. It remains enabled in the release artifact.
 - The build now includes http1 and http2 support. Actual usage and availability may vary.
 - Metrics storage is now generational, expiring unwritten metrics every 3 seconds.
+- CPU data now sourced from cgroup v2 on Linux, memory data expanded significantly. 
 
 ## [0.24.0]
 ## Added

--- a/lading/src/observer/linux/cgroup/v2/cpu.rs
+++ b/lading/src/observer/linux/cgroup/v2/cpu.rs
@@ -95,9 +95,9 @@ pub(crate) async fn poll(group_prefix: &Path, labels: &[(String, String)]) -> Re
         let user_cpu = (delta_user as f64 / delta_time) / allowed_cores * 100.0;
         let system_cpu = (delta_system as f64 / delta_time) / allowed_cores * 100.0;
 
-        gauge!("cgroup_total_cpu_percentage", labels).set(total_cpu);
-        gauge!("cgroup_user_cpu_percentage", labels).set(user_cpu);
-        gauge!("cgroup_system_cpu_percentage", labels).set(system_cpu);
+        gauge!("total_cpu_percentage", labels).set(total_cpu);
+        gauge!("user_cpu_percentage", labels).set(user_cpu);
+        gauge!("kernel_cpu_percentage", labels).set(system_cpu);
     }
 
     Ok(())


### PR DESCRIPTION
### What does this PR do?

This commit adjusts the CPU percentages that make it to the captures
to be founded on cgroup data. This commit primarily removes code as
a result.

### Related issues

Resolves SMPTNG-385