### PR TITLE
Handle errors on exited processes mid sampling

### DIFF
--- a/lading/src/observer/linux/procfs.rs
+++ b/lading/src/observer/linux/procfs.rs
@@ -367,33 +367,8 @@ impl Sampler {
                     // We don't want to bail out entirely if we can't read smap rollup
                     // which will happen if we don't have permissions or, more
                     // likely, the process has exited.
-
-                    // For the later we expect to see one of two IO errors: The first being "No such process" (linux os error code 3)
-                    // which in Rust's implementation is mapped to std::io::ErrorKind::Uncategorized. The second being
-                    // "No such file or directory" (linux os error code 2) which is mapped to std::io::ErrorKind::NotFound.
-                    // This explanation is justifiaction for checking the raw os error in the subsequent match rather than
-                    // just filtering on ErrorKind::NotFound.
-                    match err {
-                        memory::smaps_rollup::Error::Io(io_err) => {
-                            if let Some(raw_os_error) = io_err.raw_os_error() {
-                                match raw_os_error {
-                                    2 | 3 => {
-                                        // Handle specific linux OS errors: 2 (ENOENT) and 3 (ESRCH)
-                                        warn!("Found linux OS error ({raw_os_error}) while processing `/proc/{pid}/smaps_rollup`, continuing to next pid: {io_err}");
-                                        continue;
-                                    }
-                                    _ => {
-                                        warn!("IO error while processing `/proc/{pid}/smaps_rollup`: {io_err}");
-                                    }
-                                }
-                            } else {
-                                warn!("Unhandled IO error without raw OS error code while processing `/proc/{pid}/smaps_rollup`: {io_err}");
-                            }
-                        }
-                        _ => {
-                            warn!("Couldn't process `/proc/{pid}/smaps_rollup`: {err}");
-                        }
-                    }
+                    warn!("Couldn't process `/proc/{pid}/smaps_rollup`, skipping to next process: {err}");
+                    continue;
                 }
             }
         }

--- a/lading/src/observer/linux/procfs.rs
+++ b/lading/src/observer/linux/procfs.rs
@@ -5,7 +5,7 @@ use std::{collections::VecDeque, io};
 
 use metrics::gauge;
 use nix::errno::Errno;
-use procfs::ProcError::PermissionDenied;
+use procfs::ProcError::{NotFound, PermissionDenied};
 use procfs::{process::Process, Current};
 use rustc_hash::{FxHashMap, FxHashSet};
 use tracing::{error, info, warn};
@@ -178,7 +178,7 @@ impl Sampler {
                     }
                     String::new()
                 }
-                Err(NotFound(_)) => {
+                Err(NotFound(e)) => {
                     // The pid may have exited since we scanned it
                     info!("Failed to read exe symlink from a non-existent process. Skipping to the next process: {:?}", e);
                     continue;
@@ -374,7 +374,7 @@ impl Sampler {
                     // This explanation is justifiaction for checking the raw os error in the subsequent match rather than
                     // just filtering on ErrorKind::NotFound.
                     match err {
-                        Error::Io(io_err) => {
+                        memory::smaps_rollup::Error::Io(io_err) => {
                             if let Some(raw_os_error) = io_err.raw_os_error() {
                                 match raw_os_error {
                                     2 | 3 => {


### PR DESCRIPTION
### What does this PR do?

At any point during the sampling loop, a process may no longer exist on the machine. If this is the case (assuming we dont want to calculate resource usage by these "dead processes") then we need to ensure that we "continue" and start reading from the next process we have in the list. It is vital that we continue before doing any operations on the dead process that could result in an uncaught error, crashing lading, and ruining the experiment run for the replicate. 

### Motivation

During sampling of the procfs if we try to access information (list of relevant functions below) from a process that has already exited we will fail hard (unless we catch this somewhere). We could catch these errors outside of the sample loop but the consequence of this have unclear effects on the active processes that we scrape during the same sample loop.  Thus the solution is to make sure we catch errors from any function call in sample (named "poll" in procfs.rs) that signal the process being absent and continue to reading form the next process in the list.

List of procfs functions that will error if process does not exist.
- Process::new()
- - This can fail if the process doesn’t exist, or if you don’t have permission to access it.
- - For the root pid this should never fail so its ok to have this be ?
- - For child processes we filter on .ok() so thats handled
- Process::status
- - Can fail for same reasons
- - We already continue if this errors so we are good. 
- Process::exe
- - returns NotFound if process no longer exists. We need to catch this error and "continue"
- Process::cmdline
- - fails if process is a zombie
- Process::stat
- - Can fail by way of lack of perms or process has exited

The above are the functions we use at top level in poll. When receiving results from memory::smaps::Regions::from_pid and memory::smaps_rollup::poll, since these are operating on just one process if there are failures we can catch them in poll and skip to the next process 


### Related issues


### Additional Notes

Do we want to include resource usage by processes that exit in the middle of the sampling loop? Considering that we sample every second, excluding the resource usage in the last x seconds of a process's lifetime where 0 < x < 1 seems like a pretty small impact => keep excluding processes that exit mid sampling loop.

I very much dislike the messiness of the big match statement for memory::smaps_rollup::poll. I have this here as an example of improving the warning messages based on the error type. From my current understanding if smaps_rollup::poll returns any error then we should "continue" (please correct me if this is not true) and start scraping the next process. So although this code makes it very clear what we are erroring on I am of the mindset that if we dont need to handle linux os error 2 or 3 uniquely ("No such file or directory" and "No such process") then we should toss a continue after the warn message and call it a day. -- Resolved: in [a724d47](https://github.com/DataDog/lading/pull/1142/commits/a724d4796427f496635787e8c7d30c9fd2dfe525) I updated the error handling logic to not be specifc

