### PR TITLE
Introduce k8s style millicore CPU data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The build now includes http1 and http2 support. Actual usage and availability may vary.
 - Metrics storage is now generational, expiring unwritten metrics every 3 seconds.
 - CPU data now sourced from cgroup v2 on Linux, memory data expanded significantly. 
+- CPU data now also includes kubernetes style 'millicore' calculations.
 
 ## [0.24.0]
 ## Added


### PR DESCRIPTION
### What does this PR do?

This commit introduces a millicore calculation of consumption and
limits into the cpu Linux observer. All data is sourced from cgroups.

### Related Issues

REF SMPTNG-109
