### PR TITLE
Don't coerce counters to floats, avoid metrics handles

### DIFF
--- a/lading/src/blackhole/tcp.rs
+++ b/lading/src/blackhole/tcp.rs
@@ -63,13 +63,11 @@ impl Tcp {
 
     async fn handle_connection(socket: TcpStream, labels: &'static [(String, String)]) {
         let mut stream = ReaderStream::new(socket);
-        let bytes_received = counter!("bytes_received", labels);
-        let message_received = counter!("message_received", labels);
 
         while let Some(msg) = stream.next().await {
-            message_received.increment(1);
+            counter!("message_received", labels).increment(1);
             if let Ok(msg) = msg {
-                bytes_received.increment(msg.len() as u64);
+                counter!("bytes_received", labels).increment(msg.len() as u64);
             }
         }
     }
@@ -91,7 +89,6 @@ impl Tcp {
             .await
             .map_err(Error::Io)?;
 
-        let connection_accepted = counter!("connection_accepted", &self.metric_labels);
         let labels: &'static _ = Box::new(self.metric_labels.clone()).leak();
 
         let shutdown_wait = self.shutdown.recv();
@@ -100,7 +97,7 @@ impl Tcp {
             tokio::select! {
                 conn = listener.accept() => {
                     let (socket, _) = conn.map_err(Error::Io)?;
-                    connection_accepted.increment(1);
+                    counter!("connection_accepted", &self.metric_labels).increment(1);
                     tokio::spawn(
                         Self::handle_connection(socket, labels)
                     );

--- a/lading/src/blackhole/unix_datagram.rs
+++ b/lading/src/blackhole/unix_datagram.rs
@@ -77,15 +77,13 @@ impl UnixDatagram {
         let socket = net::UnixDatagram::bind(&self.path).map_err(Error::Io)?;
         let mut buf = [0; 65536];
 
-        let bytes_received = counter!("bytes_received", &self.metric_labels);
-
         let shutdown_wait = self.shutdown.recv();
         tokio::pin!(shutdown_wait);
         loop {
             tokio::select! {
                 res = socket.recv(&mut buf) => {
                     let n: usize = res.map_err(Error::Io)?;
-                    bytes_received.increment(n as u64);
+                    counter!("bytes_received", &self.metric_labels).increment(n as u64);
                 }
                 () = &mut shutdown_wait => {
                     info!("shutdown signal received");

--- a/lading/src/captures.rs
+++ b/lading/src/captures.rs
@@ -152,14 +152,14 @@ impl CaptureManager {
                 // TODO we're allocating the same small strings over and over most likely
                 labels.insert(lbl.key().into(), lbl.value().into());
             }
-            let value: f64 = f64::from_bits(counter.get_inner().load(Ordering::Relaxed));
+            let value: u64 = counter.get_inner().load(Ordering::Relaxed);
             let line = json::Line {
                 run_id: self.run_id,
                 time: now_ms,
                 fetch_index: self.fetch_index,
                 metric_name: key.name().into(),
                 metric_kind: json::MetricKind::Counter,
-                value: json::LineValue::Float(value),
+                value: json::LineValue::Int(value),
                 labels,
             };
             lines.push(line);

--- a/lading/src/generator/file_gen/traditional.rs
+++ b/lading/src/generator/file_gen/traditional.rs
@@ -255,7 +255,6 @@ impl Child {
         let (snd, rcv) = mpsc::channel(1024);
         let mut rcv: PeekableReceiver<Block> = PeekableReceiver::new(rcv);
         thread::Builder::new().spawn(|| block_cache.spin(snd))?;
-        let bytes_written = counter!("bytes_written");
 
         let shutdown_wait = self.shutdown.recv();
         tokio::pin!(shutdown_wait);
@@ -270,7 +269,7 @@ impl Child {
 
                     {
                         fp.write_all(&blk.bytes).await?;
-                        bytes_written.increment(total_bytes);
+                        counter!("bytes_written").increment(total_bytes);
                         total_bytes_written += total_bytes;
                     }
 

--- a/lading/src/observer/linux/cgroup/v2/cpu.rs
+++ b/lading/src/observer/linux/cgroup/v2/cpu.rs
@@ -101,6 +101,7 @@ pub(crate) async fn poll(group_prefix: &Path, labels: &[(String, String)]) -> Re
         let user_cpu = (user_fraction / allowed_cores) * 100.0;
         let system_cpu = (system_fraction / allowed_cores) * 100.0;
         gauge!("total_cpu_percentage", labels).set(total_cpu);
+        gauge!("cpu_percentage", labels).set(total_cpu); // backward compatibility
         gauge!("user_cpu_percentage", labels).set(user_cpu);
         gauge!("kernel_cpu_percentage", labels).set(system_cpu); // kernel is a misnomer, keeping for compatibility
         gauge!("system_cpu_percentage", labels).set(system_cpu);

--- a/lading/src/target_metrics/expvar.rs
+++ b/lading/src/target_metrics/expvar.rs
@@ -107,11 +107,11 @@ impl Expvar {
                     let val = json.pointer(var_name).and_then(serde_json::Value::as_f64);
                     if let Some(val) = val {
                         trace!("expvar: {} = {}", var_name, val);
-                        let handle = gauge!(
+                        gauge!(
                             format!("target/{name}", name = var_name.trim_start_matches('/'),),
                             &all_labels
-                        );
-                        handle.set(val);
+                        )
+                        .set(val);
                     }
                 }
             }

--- a/lading/src/target_metrics/prometheus.rs
+++ b/lading/src/target_metrics/prometheus.rs
@@ -270,8 +270,7 @@ pub(crate) async fn scrape_metrics(
                     }
                 };
 
-                let handle = gauge!(format!("target/{name}"), &all_labels.unwrap_or_default());
-                handle.set(value);
+                gauge!(format!("target/{name}"), &all_labels.unwrap_or_default()).set(value);
             }
             Some(MetricType::Counter) => {
                 let value: f64 = match value.parse() {
@@ -296,8 +295,7 @@ pub(crate) async fn scrape_metrics(
                 };
 
                 trace!("counter: {name} = {value}");
-                let handle = counter!(format!("target/{name}"), &all_labels.unwrap_or_default());
-                handle.absolute(value);
+                counter!(format!("target/{name}"), &all_labels.unwrap_or_default()).absolute(value);
             }
             Some(_) => {
                 trace!("unsupported metric type: {name} = {value}");


### PR DESCRIPTION
### What does this PR do?

This commit corrects a bug where counter values -- integer -- were
converted to floats leading to odd capture data. I have also adjusted
our use of metrics to always use the macro, avoiding metric handles
that might cause a metric to not expire when it should.

