### PR TITLE
Adds path to metric labels for http blackhole

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,15 +6,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ## Added
-- Parse nearly the complete field list of smaps/smaps_rollup in the Linux observer. 
+- Parse nearly the complete field list of smaps/smaps_rollup in the Linux observer.
+- Requests sent to the 'http' blackhole will now record the `path` of the HTTP
+  request as a tag of the `bytes_received` and `requests_received` metrics.
 ## Removed
-- Removed the unused target-rss-byte-limit from the command line, internal stub of. 
+- Removed the unused target-rss-byte-limit from the command line, internal stub of.
 ## Changed
 - logrotate_fs is now behind a feature flag and not enabled in the default
   build. It remains enabled in the release artifact.
 - The build now includes http1 and http2 support. Actual usage and availability may vary.
 - Metrics storage is now generational, expiring unwritten metrics every 3 seconds.
-- CPU data now sourced from cgroup v2 on Linux, memory data expanded significantly. 
+- CPU data now sourced from cgroup v2 on Linux, memory data expanded significantly.
 - CPU data now also includes kubernetes style 'millicore' calculations.
 
 ## [0.24.0]


### PR DESCRIPTION
### What does this PR do?

Adds the HTTP `path` that a request was sent to for the metrics that give insight into the blackhole-received data.

### Motivation

Datadog agent sends to many different endpoints, we observe spikes that don't have a clearly understood destination, this will help.

### Related issues



### Additional Notes

I omit the `query` parameters, which should limit the cardinality of these metrics, but this is still a technically unbounded metric tag, which isn't ideal. I wasn't able to come up with any ideas to bound the cardinality here without making this feature significantly less useful (ie, only record up to 1/2/3 path segments)
