### PR TITLE
Make failed lookups WARN not ERROR

### DIFF
--- a/lading/src/generator/file_gen/logrotate_fs.rs
+++ b/lading/src/generator/file_gen/logrotate_fs.rs
@@ -294,7 +294,7 @@ impl Filesystem for LogrotateFS {
             }
             error!("lookup: getattr_helper returned None for inode {}", ino);
         } else {
-            error!("lookup: state.lookup returned None for name {}", name_str);
+            warn!("lookup: state.lookup returned None for name {}", name_str);
         }
         reply.error(ENOENT);
     }

--- a/lading/src/generator/file_gen/logrotate_fs.rs
+++ b/lading/src/generator/file_gen/logrotate_fs.rs
@@ -24,7 +24,7 @@ use std::{
     time::Duration,
 };
 use tokio::task::{self, JoinError};
-use tracing::{debug, error, info};
+use tracing::{debug, error, info, warn};
 
 mod model;
 


### PR DESCRIPTION
### What does this PR do?

We have some targets that look up wildcard files in the event they
exist on-disk. This causes a lot of ERROR spew in lading logs that
could otherwise be avoided.
