### PR TITLE
Migrate all `tower` use to workspace

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ serde = { version = "1.0", features = ["std", "derive"] }
 serde_json = { version = "1.0", features = ["std"] }
 thiserror = { version = "1.0" }
 tokio = { version = "1.41" }
+tower = { version = "0.4", default-features = false }
 tracing = { version = "0.1" }
 uuid = { version = "1.11", default-features = false, features = [
   "v4",

--- a/integration/ducks/Cargo.toml
+++ b/integration/ducks/Cargo.toml
@@ -30,7 +30,7 @@ tonic = { version = "0.9", default-features = false, features = [
   "transport",
   "prost",
 ] }
-tower = { version = "0.4", default-features = false, features = [
+tower = { workspace = true, features = [
   "timeout",
   "limit",
   "load-shed",

--- a/integration/sheepdog/Cargo.toml
+++ b/integration/sheepdog/Cargo.toml
@@ -26,7 +26,7 @@ tonic = { version = "0.9", default-features = false, features = [
   "transport",
   "prost",
 ] }
-tower = { version = "0.4", default-features = false, features = [
+tower = { workspace = true, features = [
   "timeout",
   "limit",
   "load-shed",

--- a/lading/Cargo.toml
+++ b/lading/Cargo.toml
@@ -76,7 +76,7 @@ tokio = { workspace = true, features = [
 tokio-stream = { version = "0.1", features = ["io-util"] }
 tokio-util = { version = "0.7", features = ["io"] }
 tonic = { version = "0.9" }
-tower = { version = "0.4", default-features = false, features = [
+tower = { workspace = true, features = [
   "timeout",
   "limit",
   "load-shed",


### PR DESCRIPTION
### What does this PR do?

This commit migrates all `tower` crate use to derive from the workspace.
This is intended to make updating tower easier.
