### PR TITLE
Update clap to 4.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -445,26 +445,12 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "3.2.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ea181bf566f71cb9a5d17a59e1871af638180a18fb0035c92ae62b705207123"
-dependencies = [
- "bitflags 1.3.2",
- "clap_derive",
- "clap_lex 0.2.4",
- "indexmap 1.9.3",
- "once_cell",
- "strsim",
- "textwrap",
-]
-
-[[package]]
-name = "clap"
 version = "4.5.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69371e34337c4c984bbe322360c2547210bf632eb2814bbe78a6e87a2935bd2b"
 dependencies = [
  "clap_builder",
+ "clap_derive",
 ]
 
 [[package]]
@@ -474,29 +460,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e24c1b4099818523236a8ca881d2b45db98dadfb4625cf6608c12069fcbbde1"
 dependencies = [
  "anstyle",
- "clap_lex 0.7.3",
+ "clap_lex",
+ "strsim",
 ]
 
 [[package]]
 name = "clap_derive"
-version = "3.2.25"
+version = "4.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae6371b8bdc8b7d3959e9cf7b22d4435ef3e79e138688421ec654acf8c81b008"
+checksum = "4ac6a0c7b1a9e9a5186361f67dfa1b88213572f427fb9ab038efb2bd8c582dab"
 dependencies = [
- "heck 0.4.1",
- "proc-macro-error",
+ "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "clap_lex"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
-dependencies = [
- "os_str_bytes",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -547,7 +524,7 @@ dependencies = [
  "anes",
  "cast",
  "ciborium",
- "clap 4.5.22",
+ "clap",
  "criterion-plot",
  "is-terminal",
  "itertools",
@@ -1567,7 +1544,7 @@ dependencies = [
  "bollard",
  "byte-unit",
  "bytes",
- "clap 3.2.25",
+ "clap",
  "flate2",
  "fuser",
  "futures",
@@ -2010,12 +1987,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "os_str_bytes"
-version = "6.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2355d85b9a3786f481747ced0e0ff2ba35213a1f9bd406ed906554d7af805a1"
-
-[[package]]
 name = "overload"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2183,30 +2154,6 @@ checksum = "6c8646e95016a7a6c4adea95bafa8a16baab64b583356217f2c85db4a39d9a86"
 dependencies = [
  "proc-macro2",
  "syn 1.0.109",
-]
-
-[[package]]
-name = "proc-macro-error"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
-dependencies = [
- "proc-macro-error-attr",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
- "version_check",
-]
-
-[[package]]
-name = "proc-macro-error-attr"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
-dependencies = [
- "proc-macro2",
- "quote",
- "version_check",
 ]
 
 [[package]]
@@ -2866,9 +2813,9 @@ checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
 name = "strsim"
-version = "0.10.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "syn"
@@ -2930,12 +2877,6 @@ dependencies = [
  "rustix 0.38.41",
  "windows-sys 0.59.0",
 ]
-
-[[package]]
-name = "textwrap"
-version = "0.16.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23d434d3f8967a09480fb04132ebe0a3e088c173e6d0ee7897abbdf4eab0f8b9"
 
 [[package]]
 name = "thiserror"

--- a/lading/Cargo.toml
+++ b/lading/Cargo.toml
@@ -29,6 +29,7 @@ clap = { version = "4.5", default-features = false, features = [
   "std",
   "suggestions",
   "derive",
+  "help",
 ] }
 flate2 = { version = "1.0.34", default-features = false, features = [
   "rust_backend",

--- a/lading/Cargo.toml
+++ b/lading/Cargo.toml
@@ -25,7 +25,7 @@ average = { version = "0.15", default-features = false, features = [] }
 bollard = { version = "0.18", default-features = false, features = ["pipe", "http"] }
 byte-unit = { workspace = true }
 bytes = { workspace = true, features = ["std"] }
-clap = { version = "3.2", default-features = false, features = [
+clap = { version = "4.5", default-features = false, features = [
   "std",
   "suggestions",
   "derive",

--- a/lading/src/bin/lading.rs
+++ b/lading/src/bin/lading.rs
@@ -130,17 +130,17 @@ impl FromStr for CliKeyValues {
 #[clap(group(
     ArgGroup::new("target")
         .required(true)
-        .args(&["target-path", "target-pid", "target-container", "no-target"]),
+        .args(&["target_path", "target_pid", "target_container", "no_target"]),
 ))]
 #[clap(group(
     ArgGroup::new("telemetry")
         .required(true)
-        .args(&["capture-path", "prometheus-addr", "prometheus-path"]),
+        .args(&["capture_path", "prometheus_addr", "prometheus_path"]),
 ))]
 #[clap(group(
      ArgGroup::new("experiment-duration")
            .required(false)
-           .args(&["experiment-duration-seconds", "experiment-duration-infinite"]),
+           .args(&["experiment_duration_seconds", "experiment_duration_infinite"]),
 ))]
 struct Opts {
     /// path on disk to the configuration file


### PR DESCRIPTION
### What does this PR do?

This commit updates the clap crate in use by lading to the latest
release.
