### PR TITLE
Update lading container base image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Changed
 - The `bytes_received` metric in the HTTP blackhole now tracks wire bytes, the
   former metric is preserved with `decoded_bytes_received`.
+- Base image is now bookworm, updated from bullseye.
 
 ## [0.25.1]
 ## Removed

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Update the rust version in-sync with the version in rust-toolchain.toml
-FROM docker.io/rust:1.81.0-bullseye AS builder
+FROM docker.io/rust:1.81.0-bookworm AS builder
 
 RUN apt-get update && apt-get install -y \
     protobuf-compiler fuse3 libfuse3-dev \
@@ -9,8 +9,8 @@ WORKDIR /app
 COPY . /app
 RUN cargo build --release --locked --bin lading --features logrotate_fs
 
-FROM docker.io/debian:bullseye-20240701-slim
-RUN apt-get update && apt-get install -y libfuse3-dev=3.10.3-2 fuse3=3.10.3-2 && rm -rf /var/lib/apt/lists/*
+FROM docker.io/debian:bookworm-20241202-slim
+RUN apt-get update && apt-get install -y libfuse3-dev=3.14.0-4 fuse3=3.14.0-4 && rm -rf /var/lib/apt/lists/*
 COPY --from=builder /app/target/release/lading /usr/bin/lading
 
 # smoke test


### PR DESCRIPTION
### What does this PR do?

This commit updates the lading base OS from Debian bullseye to the
latest stable bookworm.
