### PR TITLE
Migrate `tonic` to workspace

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,9 @@ serde = { version = "1.0", features = ["std", "derive"] }
 serde_json = { version = "1.0", features = ["std"] }
 thiserror = { version = "1.0" }
 tokio = { version = "1.41" }
+# If you update tonic, search for tonic-build in sub-crates and update their
+# version.
+tonic = { version = "0.9", default-features = false, features = [] }
 tower = { version = "0.5", default-features = false }
 tracing = { version = "0.1" }
 uuid = { version = "1.11", default-features = false, features = [
@@ -33,6 +36,7 @@ uuid = { version = "1.11", default-features = false, features = [
 ] }
 once_cell = { version = "1.20" }
 hyper = { version = "0.14", default-features = false }
+
 
 [profile.release]
 lto = true        # Optimize our binary at link stage.

--- a/integration/ducks/Cargo.toml
+++ b/integration/ducks/Cargo.toml
@@ -26,7 +26,7 @@ tokio = { workspace = true, features = [
   "net",
 ] }
 tokio-stream = { version = "0.1", features = ["net"] }
-tonic = { version = "0.9", default-features = false, features = [
+tonic = { workspace = true, default-features = false, features = [
   "transport",
   "prost",
 ] }

--- a/integration/shared/Cargo.toml
+++ b/integration/shared/Cargo.toml
@@ -9,7 +9,7 @@ publish = false
 
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
-tonic = { version = "0.9", default-features = false, features = [
+tonic = { workspace = true, default-features = false, features = [
   "codegen",
   "prost",
   "transport",
@@ -18,4 +18,4 @@ prost = "0.11"
 serde_json = "1.0"
 
 [build-dependencies]
-tonic-build = "0.9"
+tonic-build = { version = "0.9" }

--- a/integration/sheepdog/Cargo.toml
+++ b/integration/sheepdog/Cargo.toml
@@ -22,7 +22,7 @@ tokio = { version = "1.41", features = [
   "time",
   "net",
 ] }
-tonic = { version = "0.9", default-features = false, features = [
+tonic = { workspace = true, default-features = false, features = [
   "transport",
   "prost",
 ] }


### PR DESCRIPTION
### What does this PR do?

This commit migrates the `tonic` dependency to the workspace. Unfortunately
this leaves tonic-build still in shared/Cargo.toml but it's a start. Goal
here is to make upgrading tonic more achievable.
