### PR TITLE
Multi-arch container takes the same tag meta

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -84,6 +84,10 @@ jobs:
         with:
           tags: |
             type=sha,format=long
+            type=ref,prefix=pr-,event=pr
+            type=semver,pattern={{version}},event=tag
+            type=semver,pattern={{major}}.{{minor}},event=tag
+            type=semver,pattern={{major}},event=tag
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
 
       - name: Create and Push Multiarch Manifest


### PR DESCRIPTION
### What does this PR do?

This commit makes sure our tag metadata is made to match across all the metadata extraction. The lack of this parity caused the release builds for 0.25.0 and 0.25.1 to fail to tag properly.

