### PR TITLE
Adjust how `bytes_received` is calculated in the HTTP blackhole

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+## Changed
+- The `bytes_received` metric in the HTTP blackhole now tracks raw bytes, the
+  former metric is preserved with `decoded_bytes_received`.
+
 ## [0.25.1]
 ## Removed
 - Revert PR #1148

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ## Changed
-- The `bytes_received` metric in the HTTP blackhole now tracks raw bytes, the
+- The `bytes_received` metric in the HTTP blackhole now tracks wire bytes, the
   former metric is preserved with `decoded_bytes_received`.
 
 ## [0.25.1]

--- a/lading/src/blackhole/http.rs
+++ b/lading/src/blackhole/http.rs
@@ -138,11 +138,12 @@ async fn srv(
     let (parts, body) = req.into_parts();
 
     let bytes = body.collect().await?.to_bytes();
+    counter!("bytes_received", &metric_labels).increment(bytes.len() as u64);
 
     match crate::codec::decode(parts.headers.get(hyper::header::CONTENT_ENCODING), bytes) {
         Err(response) => Ok(response),
         Ok(body) => {
-            counter!("bytes_received", &metric_labels).increment(body.len() as u64);
+            counter!("decoded_bytes_received", &metric_labels).increment(body.len() as u64);
 
             tokio::time::sleep(response_delay).await;
 


### PR DESCRIPTION
### What does this PR do?

This commit adjusts `bytes_received` to measure the bytes received over the wire
before decoding. This allows lading to make assertions about the efficacy of
compression by targets, matching the behavior of the other lading blackholes. We
preserve the decoded metric by renaming it `decoded_bytes_received`.
