### PR TITLE
Adjust splunk_hec to distinguish decoded and raw bytes received

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-## Changed
-- The `bytes_received` metric in the HTTP blackhole now tracks wire bytes, the
-  former metric is preserved with `decoded_bytes_received`.
+- The `bytes_received` metric in the HTTP and splunk_heck blackholes now tracks
+  wire bytes, the former metric is preserved with `decoded_bytes_received`.
 - Base image is now bookworm, updated from bullseye.
 
 ## [0.25.1]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-- The `bytes_received` metric in the HTTP and splunk_heck blackholes now tracks
+- The `bytes_received` metric in the HTTP and splunk_hec blackholes now tracks
   wire bytes, the former metric is preserved with `decoded_bytes_received`.
 - Base image is now bookworm, updated from bullseye.
 

--- a/lading/src/blackhole/splunk_hec.rs
+++ b/lading/src/blackhole/splunk_hec.rs
@@ -96,11 +96,12 @@ async fn srv(
 
     let (parts, body) = req.into_parts();
     let bytes = body.collect().await?.to_bytes();
+    counter!("bytes_received", &metric_labels).increment(bytes.len() as u64);
 
     match crate::codec::decode(parts.headers.get(hyper::header::CONTENT_ENCODING), bytes) {
         Err(response) => Ok(response),
         Ok(body) => {
-            counter!("bytes_received", &*labels).increment(body.len() as u64);
+            counter!("decoded_bytes_received", &metric_labels).increment(body.len() as u64);
 
             let mut okay = Response::default();
             *okay.status_mut() = StatusCode::OK;

--- a/lading/src/blackhole/splunk_hec.rs
+++ b/lading/src/blackhole/splunk_hec.rs
@@ -96,12 +96,12 @@ async fn srv(
 
     let (parts, body) = req.into_parts();
     let bytes = body.collect().await?.to_bytes();
-    counter!("bytes_received", &metric_labels).increment(bytes.len() as u64);
+    counter!("bytes_received", &*labels).increment(bytes.len() as u64);
 
     match crate::codec::decode(parts.headers.get(hyper::header::CONTENT_ENCODING), bytes) {
         Err(response) => Ok(response),
         Ok(body) => {
-            counter!("decoded_bytes_received", &metric_labels).increment(body.len() as u64);
+            counter!("decoded_bytes_received", &*labels).increment(body.len() as u64);
 
             let mut okay = Response::default();
             *okay.status_mut() = StatusCode::OK;


### PR DESCRIPTION
### What does this PR do?

Similar to #1166 this commit adds a `decoded_bytes_received` so that the telemetry
from this blackhole matches the others in the project, measuring the raw/wire bytes
in `bytes_received`.
