### PR TITLE
Release 0.25.2

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -92,7 +92,8 @@ jobs:
 
       - name: Create and Push Multiarch Manifest
         run: |
+          FINAL_TAG=$(echo "${{ steps.meta.outputs.tags }}" | head -n 1)
           docker buildx imagetools create \
-            --tag ${{ steps.meta.outputs.tags }} \
-            ${{ steps.meta.outputs.tags }}-amd64 \
-            ${{ steps.meta.outputs.tags }}-arm64
+            --tag "$FINAL_TAG" \
+            "$FINAL_TAG-amd64" \
+            "$FINAL_TAG-arm64"

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -13,7 +13,10 @@ jobs:
     runs-on: ubuntu-20.04
     permissions:
       contents: read
-      packages: write
+      packages: read
+    outputs:
+      FINAL_TAG: ${{ steps.tags.outputs.FINAL_TAG }}
+      SHA_TAG: ${{ steps.tags.outputs.SHA_TAG }}
 
     steps:
       - name: Log in to Container Registry
@@ -39,6 +42,7 @@ jobs:
             type=sha,format=long
 
       - name: Determine Final Tag
+        id: tags
         run: |
           ALL_TAGS="${{ steps.meta.outputs.tags }}"
           SEMVER_TAG=$(echo "$ALL_TAGS" | grep '^ghcr.io/.*:v' || true)
@@ -50,15 +54,17 @@ jobs:
             FINAL_TAG="$SHA_TAG"
           fi
 
-          echo "SHA_TAG=$SHA_TAG" >> $GITHUB_ENV
-          echo "FINAL_TAG=$FINAL_TAG" >> $GITHUB_ENV
+          # Use output variables to pass to other jobs
+          echo "::set-output name=SHA_TAG::$SHA_TAG"
+          echo "::set-output name=FINAL_TAG::$FINAL_TAG"
 
       - name: Debug Tags
         run: |
-          echo "SHA_TAG: $SHA_TAG"
-          echo "FINAL_TAG: $FINAL_TAG"
+          echo "SHA_TAG: ${{ steps.tags.outputs.SHA_TAG }}"
+          echo "FINAL_TAG: ${{ steps.tags.outputs.FINAL_TAG }}"
 
   build:
+    needs: tagging
     runs-on: ${{ matrix.runner }}
     strategy:
       matrix:
@@ -88,19 +94,18 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Extract metadata for Docker
-        uses: docker/metadata-action@369eb591f429131d6889c46b94e711f089e6ca96 # v5.6.1
+        uses: docker/metadata-action@v5.6.1
         id: meta
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
-            # Produce a SHA tag
             type=sha,format=long
 
       - name: Build and push Docker image
         uses: docker/build-push-action@48aba3b46d1b1fec4febb7c5d0c644b249a11355 # v6.10.0
         with:
           file: Dockerfile
-          tags: ${{ steps.meta.outputs.tags }}-${{ matrix.arch }}
+          tags: ${{ needs.tagging.outputs.SHA_TAG }}-${{ matrix.arch }}
           push: true
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=registry,ref=ghcr.io/datadog/lading:cache
@@ -108,7 +113,9 @@ jobs:
 
   manifest:
     name: Create Multi-Arch Manifest
-    needs: build
+    needs: 
+      - tagging
+      - build
     runs-on: ubuntu-20.04
     permissions:
       contents: read
@@ -125,41 +132,9 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@c47758b77c9736f4b2ef4073d4d51994fabfe349 # v3.7.1
 
-      - name: Extract Docker Metadata
-        uses: docker/metadata-action@369eb591f429131d6889c46b94e711f089e6ca96 # v5.6.1
-        id: meta
-        with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-          tags: |
-            # Tag event (pushing a git tag that starts with v), produce a
-            # semver tag
-            type=semver,pattern={{version}},event=tag,prefix=v
-            # All other push events (no PR, no semver tag), produce a SHA tag
-            type=sha,format=long
-
-      - name: Determine Final Tag
-        run: |
-          ALL_TAGS="${{ steps.meta.outputs.tags }}"
-          SHA_TAG=$(echo "$ALL_TAGS" | grep sha-)
-          SEMVER_TAG=$(echo "$ALL_TAGS" | grep '^ghcr.io/.*:v')
-
-          if [ -n "$SEMVER_TAG" ]; then
-            FINAL_TAG="$SEMVER_TAG"
-          else
-            FINAL_TAG="$SHA_TAG"
-          fi
-
-          echo "SHA_TAG=$SHA_TAG" >> $GITHUB_ENV
-          echo "FINAL_TAG=$FINAL_TAG" >> $GITHUB_ENV
-
-      - name: Debug Tags
-        run: |
-          echo "SHA_TAG: $SHA_TAG"
-          echo "FINAL_TAG: $FINAL_TAG"
-
       - name: Create and Push Multiarch Manifest
         run: |
           docker buildx imagetools create \
-            --tag "$FINAL_TAG" \
-            "$SHA_TAG-amd64" \
-            "$SHA_TAG-arm64"
+            --tag "${{ needs.tagging.outputs.FINAL_TAG }}" \
+            "${{ needs.tagging.outputs.SHA_TAG }}-amd64" \
+            "${{ needs.tagging.outputs.SHA_TAG }}-arm64"

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -9,7 +9,7 @@ env:
 
 jobs:
   tagging:
-    name: Debug Multi-Arch Manifest
+    name: Determine Tags
     runs-on: ubuntu-20.04
     permissions:
       contents: read
@@ -54,9 +54,8 @@ jobs:
             FINAL_TAG="$SHA_TAG"
           fi
 
-          # Use output variables to pass to other jobs
-          echo "::set-output name=SHA_TAG::$SHA_TAG"
-          echo "::set-output name=FINAL_TAG::$FINAL_TAG"
+          echo "SHA_TAG=$SHA_TAG" >> $GITHUB_OUTPUT
+          echo "FINAL_TAG=$FINAL_TAG" >> $GITHUB_OUTPUT
 
       - name: Debug Tags
         run: |

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -41,13 +41,13 @@ jobs:
         uses: docker/metadata-action@369eb591f429131d6889c46b94e711f089e6ca96 # v5.6.1
         id: meta
         with:
-          tags: |
-            type=sha,format=long
-            type=ref,prefix=pr-,event=pr
-            type=semver,pattern={{version}},event=tag
-            type=semver,pattern={{major}}.{{minor}},event=tag
-            type=semver,pattern={{major}},event=tag
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=ref,event=pr,prefix=pr-
+            type=semver,pattern={{version}},event=tag,prefix=v
+            type=semver,pattern={{major}}.{{minor}},event=tag,prefix=v
+            type=semver,pattern={{major}},event=tag,prefix=v
+            type=sha,format=long
 
       - name: Build and push Docker image
         uses: docker/build-push-action@48aba3b46d1b1fec4febb7c5d0c644b249a11355 # v6.10.0
@@ -82,13 +82,13 @@ jobs:
         uses: docker/metadata-action@369eb591f429131d6889c46b94e711f089e6ca96 # v5.6.1
         id: meta
         with:
-          tags: |
-            type=sha,format=long
-            type=ref,prefix=pr-,event=pr
-            type=semver,pattern={{version}},event=tag
-            type=semver,pattern={{major}}.{{minor}},event=tag
-            type=semver,pattern={{major}},event=tag
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=ref,event=pr,prefix=pr-
+            type=semver,pattern={{version}},event=tag,prefix=v
+            type=semver,pattern={{major}}.{{minor}},event=tag,prefix=v
+            type=semver,pattern={{major}},event=tag,prefix=v
+            type=sha,format=long
 
       - name: Create and Push Multiarch Manifest
         run: |

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -10,7 +10,6 @@ env:
 jobs:
   tagging:
     name: Debug Multi-Arch Manifest
-    needs: build
     runs-on: ubuntu-20.04
     permissions:
       contents: read

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -43,10 +43,7 @@ jobs:
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
-            # Tag event (pushing a git tag that starts with v), produce a
-            # semver tag
-            type=semver,pattern={{version}},event=tag,prefix=v
-            # All other push events (no PR, no semver tag), produce a SHA tag
+            # Produce a SHA tag
             type=sha,format=long
 
       - name: Build and push Docker image
@@ -90,10 +87,29 @@ jobs:
             # All other push events (no PR, no semver tag), produce a SHA tag
             type=sha,format=long
 
+      - name: Determine Final Tag
+        run: |
+          ALL_TAGS="${{ steps.meta.outputs.tags }}"
+          SHA_TAG=$(echo "$ALL_TAGS" | grep sha-)
+          SEMVER_TAG=$(echo "$ALL_TAGS" | grep '^ghcr.io/.*:v')
+
+          if [ -n "$SEMVER_TAG" ]; then
+            FINAL_TAG="$SEMVER_TAG"
+          else
+            FINAL_TAG="$SHA_TAG"
+          fi
+
+          echo "SHA_TAG=$SHA_TAG" >> $GITHUB_ENV
+          echo "FINAL_TAG=$FINAL_TAG" >> $GITHUB_ENV
+
+      - name: Debug Tags
+        run: |
+          echo "SHA_TAG: $SHA_TAG"
+          echo "FINAL_TAG: $FINAL_TAG"
+
       - name: Create and Push Multiarch Manifest
         run: |
-          FINAL_TAG=$(echo "${{ steps.meta.outputs.tags }}" | head -n 1)
           docker buildx imagetools create \
             --tag "$FINAL_TAG" \
-            "$FINAL_TAG-amd64" \
-            "$FINAL_TAG-arm64"
+            "$SHA_TAG-amd64" \
+            "$SHA_TAG-arm64"

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -45,7 +45,7 @@ jobs:
         id: tags
         run: |
           ALL_TAGS="${{ steps.meta.outputs.tags }}"
-          SEMVER_TAG=$(echo "$ALL_TAGS" | grep -E '^ghcr.io/.+:[0-9]+\.[0-9]+\.[0-9]+' || true)
+          SEMVER_TAG=$(echo "$ALL_TAGS" | grep -E '^ghcr.io/.+:[0-9]+\.[0-9]+\.[0-9]+(-rc[0-9]+)?' || true)
           SHA_TAG=$(echo "$ALL_TAGS" | grep sha- || true)
 
           if [ -n "$SEMVER_TAG" ]; then

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -45,7 +45,7 @@ jobs:
         id: tags
         run: |
           ALL_TAGS="${{ steps.meta.outputs.tags }}"
-          SEMVER_TAG=$(echo "$ALL_TAGS" | grep '^ghcr.io/.*:v' || true)
+          SEMVER_TAG=$(echo "$ALL_TAGS" | grep -E '^ghcr.io/.+:[0-9]+\.[0-9]+\.[0-9]+' || true)
           SHA_TAG=$(echo "$ALL_TAGS" | grep sha- || true)
 
           if [ -n "$SEMVER_TAG" ]; then

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -8,6 +8,57 @@ env:
   IMAGE_NAME: ${{ github.repository }}
 
 jobs:
+  tagging:
+    name: Debug Multi-Arch Manifest
+    needs: build
+    runs-on: ubuntu-20.04
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Log in to Container Registry
+        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3.3.0
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@c47758b77c9736f4b2ef4073d4d51994fabfe349 # v3.7.1
+
+      - name: Extract Docker Metadata
+        uses: docker/metadata-action@369eb591f429131d6889c46b94e711f089e6ca96 # v5.6.1
+        id: meta
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            # Tag event (pushing a git tag that starts with v), produce a
+            # semver tag
+            type=semver,pattern={{version}},event=tag,prefix=v
+            # All other push events (no PR, no semver tag), produce a SHA tag
+            type=sha,format=long
+
+      - name: Determine Final Tag
+        run: |
+          ALL_TAGS="${{ steps.meta.outputs.tags }}"
+          SHA_TAG=$(echo "$ALL_TAGS" | grep sha-)
+          SEMVER_TAG=$(echo "$ALL_TAGS" | grep '^ghcr.io/.*:v')
+
+          if [ -n "$SEMVER_TAG" ]; then
+            FINAL_TAG="$SEMVER_TAG"
+          else
+            FINAL_TAG="$SHA_TAG"
+          fi
+
+          echo "SHA_TAG=$SHA_TAG" >> $GITHUB_ENV
+          echo "FINAL_TAG=$FINAL_TAG" >> $GITHUB_ENV
+
+      - name: Debug Tags
+        run: |
+          echo "SHA_TAG: $SHA_TAG"
+          echo "FINAL_TAG: $FINAL_TAG"
+
   build:
     runs-on: ${{ matrix.runner }}
     strategy:

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -41,8 +41,8 @@ jobs:
       - name: Determine Final Tag
         run: |
           ALL_TAGS="${{ steps.meta.outputs.tags }}"
-          SHA_TAG=$(echo "$ALL_TAGS" | grep sha-)
-          SEMVER_TAG=$(echo "$ALL_TAGS" | grep '^ghcr.io/.*:v')
+          SEMVER_TAG=$(echo "$ALL_TAGS" | grep '^ghcr.io/.*:v' || true)
+          SHA_TAG=$(echo "$ALL_TAGS" | grep sha- || true)
 
           if [ -n "$SEMVER_TAG" ]; then
             FINAL_TAG="$SEMVER_TAG"

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -93,7 +93,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Extract metadata for Docker
-        uses: docker/metadata-action@v5.6.1
+        uses: docker/metadata-action@369eb591f429131d6889c46b94e711f089e6ca96 # v5.6.1
         id: meta
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -43,10 +43,10 @@ jobs:
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
-            type=ref,event=pr,prefix=pr-
+            # Tag event (pushing a git tag that starts with v), produce a
+            # semver tag
             type=semver,pattern={{version}},event=tag,prefix=v
-            type=semver,pattern={{major}}.{{minor}},event=tag,prefix=v
-            type=semver,pattern={{major}},event=tag,prefix=v
+            # All other push events (no PR, no semver tag), produce a SHA tag
             type=sha,format=long
 
       - name: Build and push Docker image
@@ -84,10 +84,10 @@ jobs:
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
-            type=ref,event=pr,prefix=pr-
+            # Tag event (pushing a git tag that starts with v), produce a
+            # semver tag
             type=semver,pattern={{version}},event=tag,prefix=v
-            type=semver,pattern={{major}}.{{minor}},event=tag,prefix=v
-            type=semver,pattern={{major}},event=tag,prefix=v
+            # All other push events (no PR, no semver tag), produce a SHA tag
             type=sha,format=long
 
       - name: Create and Push Multiarch Manifest

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -35,9 +35,9 @@ jobs:
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
-            # Tag event (pushing a git tag that starts with v), produce a
-            # semver tag
-            type=semver,pattern={{version}},event=tag,prefix=v
+            # Tag event produce a semver tag. This will capture tags that begin
+            # vX.Y.Z and X.Y.Z.
+            type=semver,pattern={{version}},event=tag
             # All other push events (no PR, no semver tag), produce a SHA tag
             type=sha,format=long
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.25.2-rc6]
+## [0.25.2]
 ## Changed
 - The `bytes_received` metric in the HTTP and splunk_heck blackholes now tracks
   wire bytes, the former metric is preserved with `decoded_bytes_received`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.25.2-rc3]
+## [0.25.2-rc4]
 ## Changed
 - The `bytes_received` metric in the HTTP and splunk_heck blackholes now tracks
   wire bytes, the former metric is preserved with `decoded_bytes_received`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
-- The `bytes_received` metric in the HTTP and splunk_hec blackholes now tracks
+## [0.25.2-rc2]
+## Changed
+- The `bytes_received` metric in the HTTP and splunk_heck blackholes now tracks
   wire bytes, the former metric is preserved with `decoded_bytes_received`.
 - Base image is now bookworm, updated from bullseye.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.25.2-rc4]
+## [0.25.2-rc5]
 ## Changed
 - The `bytes_received` metric in the HTTP and splunk_heck blackholes now tracks
   wire bytes, the former metric is preserved with `decoded_bytes_received`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.25.2-rc5]
+## [0.25.2-rc6]
 ## Changed
 - The `bytes_received` metric in the HTTP and splunk_heck blackholes now tracks
   wire bytes, the former metric is preserved with `decoded_bytes_received`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.25.2-rc2]
+## [0.25.2-rc3]
 ## Changed
 - The `bytes_received` metric in the HTTP and splunk_heck blackholes now tracks
   wire bytes, the former metric is preserved with `decoded_bytes_received`.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1536,7 +1536,7 @@ dependencies = [
 
 [[package]]
 name = "lading"
-version = "0.25.2-rc5"
+version = "0.25.2-rc6"
 dependencies = [
  "async-compression",
  "async-pidfd",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1536,7 +1536,7 @@ dependencies = [
 
 [[package]]
 name = "lading"
-version = "0.25.2-rc3"
+version = "0.25.2-rc4"
 dependencies = [
  "async-compression",
  "async-pidfd",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1536,7 +1536,7 @@ dependencies = [
 
 [[package]]
 name = "lading"
-version = "0.25.1"
+version = "0.25.2-rc2"
 dependencies = [
  "async-compression",
  "async-pidfd",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1536,7 +1536,7 @@ dependencies = [
 
 [[package]]
 name = "lading"
-version = "0.25.2-rc4"
+version = "0.25.2-rc5"
 dependencies = [
  "async-compression",
  "async-pidfd",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1536,7 +1536,7 @@ dependencies = [
 
 [[package]]
 name = "lading"
-version = "0.25.2-rc6"
+version = "0.25.2"
 dependencies = [
  "async-compression",
  "async-pidfd",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1536,7 +1536,7 @@ dependencies = [
 
 [[package]]
 name = "lading"
-version = "0.25.2-rc2"
+version = "0.25.2-rc3"
 dependencies = [
  "async-compression",
  "async-pidfd",

--- a/lading/Cargo.toml
+++ b/lading/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lading"
-version = "0.25.2-rc3"
+version = "0.25.2-rc4"
 authors = [
   "Brian L. Troutwine <brian.troutwine@datadoghq.com>",
   "George Hahn <george.hahn@datadoghq.com>",

--- a/lading/Cargo.toml
+++ b/lading/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lading"
-version = "0.25.2-rc2"
+version = "0.25.2-rc3"
 authors = [
   "Brian L. Troutwine <brian.troutwine@datadoghq.com>",
   "George Hahn <george.hahn@datadoghq.com>",

--- a/lading/Cargo.toml
+++ b/lading/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lading"
-version = "0.25.2-rc5"
+version = "0.25.2-rc6"
 authors = [
   "Brian L. Troutwine <brian.troutwine@datadoghq.com>",
   "George Hahn <george.hahn@datadoghq.com>",

--- a/lading/Cargo.toml
+++ b/lading/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lading"
-version = "0.25.1"
+version = "0.25.2-rc2"
 authors = [
   "Brian L. Troutwine <brian.troutwine@datadoghq.com>",
   "George Hahn <george.hahn@datadoghq.com>",

--- a/lading/Cargo.toml
+++ b/lading/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lading"
-version = "0.25.2-rc6"
+version = "0.25.2"
 authors = [
   "Brian L. Troutwine <brian.troutwine@datadoghq.com>",
   "George Hahn <george.hahn@datadoghq.com>",

--- a/lading/Cargo.toml
+++ b/lading/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lading"
-version = "0.25.2-rc4"
+version = "0.25.2-rc5"
 authors = [
   "Brian L. Troutwine <brian.troutwine@datadoghq.com>",
   "George Hahn <george.hahn@datadoghq.com>",


### PR DESCRIPTION
### What does this PR do?

This commit cuts  0.25.2. Minor changes are present here -- some telemetry changes, base OS image is updated -- and we believe now that the container images will be published properly.
