### PR TITLE
Ignore processes that exit mid poll

### DIFF
--- a/lading/src/observer/linux/procfs.rs
+++ b/lading/src/observer/linux/procfs.rs
@@ -118,6 +118,8 @@ impl Sampler {
                     }
                 }
             }
+            // Update the process_info map to only hold processes seen by the current poll call.
+            self.process_info.retain(|pid, _| pids.contains(pid));
 
             let pid = process.pid();
 
@@ -254,7 +256,8 @@ impl Sampler {
                     // We don't want to bail out entirely if we can't read stats
                     // which will happen if we don't have permissions or, more
                     // likely, the process has exited.
-                    warn!("Couldn't process `/proc/{pid}/smaps`: {err}");
+                    warn!("Couldn't process `/proc/{pid}/smaps`, reading next process: {err}");
+                    continue;
                 }
             }
 
@@ -263,7 +266,8 @@ impl Sampler {
                 // We don't want to bail out entirely if we can't read smap rollup
                 // which will happen if we don't have permissions or, more
                 // likely, the process has exited.
-                warn!("Couldn't process `/proc/{pid}/smaps_rollup`: {err}");
+                warn!("Couldn't process `/proc/{pid}/smaps_rollup`, reading next process: {err}");
+                continue;
             }
         }
         // END pid loop


### PR DESCRIPTION
### What does this PR do?

At any point during the sampling loop, a process may no longer exist on the machine. If this is the case (assuming we dont want to calculate resource usage by these "dead processes") then we need to ensure that we "continue" and start reading from the next process we have in the list. It is vital that we continue before doing any operations on the dead process that could result in an uncaught error, crashing lading, and ruining the experiment run for the replicate.


### Motivation

Initial investigation done in https://github.com/DataDog/lading/pull/1142

### Related issues


### Additional Notes

Any drawbacks from cleaning up the process_info map like this?

TODO:


