### PR TITLE
Remove explicit use of hyper in integration/ducks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -195,7 +195,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b829e4e32b91e643de6eafe82b1d90675f5874230191a4ffbc1b336dec4d6bf"
 dependencies = [
  "async-trait",
- "axum-core",
+ "axum-core 0.3.4",
  "bitflags 1.3.2",
  "bytes",
  "futures-util",
@@ -217,6 +217,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "axum"
+version = "0.7.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edca88bc138befd0323b20752846e6587272d3b03b0343c8ea28a6f819e6e71f"
+dependencies = [
+ "async-trait",
+ "axum-core 0.4.5",
+ "bytes",
+ "futures-util",
+ "http 1.2.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "hyper 1.5.1",
+ "hyper-util",
+ "itoa",
+ "matchit",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustversion",
+ "serde",
+ "sync_wrapper 1.0.2",
+ "tokio",
+ "tower 0.5.2",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
 name = "axum-core"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -230,6 +260,45 @@ dependencies = [
  "mime",
  "rustversion",
  "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09f2bd6146b97ae3359fa0cc6d6b376d9539582c7b4220f041a33ec24c226199"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "futures-util",
+ "http 1.2.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "rustversion",
+ "sync_wrapper 1.0.2",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "axum-server"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56bac90848f6a9393ac03c63c640925c4b7c8ca21654de40d53f55964667c7d8"
+dependencies = [
+ "bytes",
+ "futures-util",
+ "http 1.2.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "hyper 1.5.1",
+ "hyper-util",
+ "pin-project-lite",
+ "tokio",
+ "tower 0.4.13",
  "tower-service",
 ]
 
@@ -667,16 +736,16 @@ name = "ducks"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "axum 0.7.9",
+ "axum-server",
  "bytes",
  "entropy",
- "hyper 0.14.31",
  "once_cell",
  "shared",
  "sketches-ddsketch 0.3.0",
  "tokio",
  "tokio-stream",
  "tonic 0.9.2",
- "tower 0.5.2",
  "tracing",
  "tracing-subscriber",
 ]
@@ -1181,7 +1250,7 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "socket2 0.4.10",
+ "socket2 0.5.8",
  "tokio",
  "tower-service",
  "tracing",
@@ -3054,7 +3123,7 @@ checksum = "8f219fad3b929bef19b1f86fbc0358d35daed8f2cac972037ac0dc10bbb8d5fb"
 dependencies = [
  "async-stream",
  "async-trait",
- "axum",
+ "axum 0.6.20",
  "base64 0.13.1",
  "bytes",
  "futures-core",
@@ -3085,7 +3154,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3082666a3a6433f7f511c7192923fa1fe07c69332d3c6a2e6bb040b569199d5a"
 dependencies = [
  "async-trait",
- "axum",
+ "axum 0.6.20",
  "base64 0.21.7",
  "bytes",
  "futures-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,8 @@ members = [
 ]
 
 [workspace.dependencies]
+axum = { version = "0.7", default-features = false }
+axum-server = { version = "0.7", default-features = false }
 bytes = { version = "1.8", default-features = false, features = ["std"] }
 byte-unit = { version = "4.0", features = ["serde"] }
 metrics = { version = "0.23.0" }

--- a/integration/ducks/Cargo.toml
+++ b/integration/ducks/Cargo.toml
@@ -8,10 +8,11 @@ license = "MIT"
 publish = false
 
 [dependencies]
+axum = { workspace = true, features = ["tokio", "http1", "http2"] }
+axum-server = { workspace = true }
 anyhow = "1.0"
 bytes = { workspace = true }
 entropy = "0.4"
-hyper = { workspace = true, features = ["server", "backports", "deprecated"] }
 once_cell = { workspace = true }
 shared = { path = "../shared" }
 sketches-ddsketch = "0.3"
@@ -29,11 +30,6 @@ tokio-stream = { version = "0.1", features = ["net"] }
 tonic = { workspace = true, default-features = false, features = [
   "transport",
   "prost",
-] }
-tower = { workspace = true, features = [
-  "timeout",
-  "limit",
-  "load-shed",
 ] }
 tracing = { version = "0.1", features = ["std", "attributes"] }
 tracing-subscriber = { version = "0.3", features = ["std", "env-filter"] }

--- a/integration/ducks/src/main.rs
+++ b/integration/ducks/src/main.rs
@@ -249,7 +249,9 @@ impl DucksTarget {
         debug!("HTTP listener active");
         HTTP_COUNTERS.get_or_init(|| Arc::new(Mutex::new(HttpCounters::default())));
 
-        let app = Router::new().route("/*path", any(req_handle));
+        let app = Router::new()
+            .route("/", any(req_handle))
+            .route("/*path", any(req_handle));
 
         axum_server::bind(addr)
             .serve(app.into_make_service())


### PR DESCRIPTION
### What does this PR do?

I can't figure out how to update hyper in our project given the
set of interlinked crates that all have to update in one shot. As
a result, I'm removing explicit references to hyper and started with
ducks. This commit also removes the tower layers as it was not clear
to me that these are required for integration test purposes.
