### PR TITLE
Re-unify crates at workspace

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ thiserror = { version = "2.0" }
 tokio = { version = "1.41" }
 # If you update tonic, search for tonic-build in sub-crates and update their
 # version.
-tonic = { version = "0.9", default-features = false, features = [] }
+tonic = { version = "0.12", default-features = false, features = [] }
 tower = { version = "0.5", default-features = false }
 tracing = { version = "0.1" }
 uuid = { version = "1.11", default-features = false, features = [
@@ -35,8 +35,12 @@ uuid = { version = "1.11", default-features = false, features = [
   "serde",
 ] }
 once_cell = { version = "1.20" }
-hyper = { version = "0.14", default-features = false }
 
+http = { version = "1.2" }
+http-body-util = { version = "0.1" }
+http-serde = { version = "2.1" }
+hyper = { version = "1.5", default-features = false }
+hyper-util = { version = "0.1", default-features = false }
 
 [profile.release]
 lto = true        # Optimize our binary at link stage.

--- a/integration/ducks/Cargo.toml
+++ b/integration/ducks/Cargo.toml
@@ -11,9 +11,9 @@ publish = false
 anyhow = "1.0"
 bytes = { workspace = true }
 entropy = "0.4"
-http-body-util = "0.1"
-hyper = { version = "1.5", features = ["server"] }
-hyper-util = "0.1"
+http-body-util = { workspace = true }
+hyper = { workspace = true, features = ["server"] }
+hyper-util = { workspace = true }
 once_cell = { workspace = true }
 shared = { path = "../shared" }
 sketches-ddsketch = "0.3"
@@ -28,7 +28,7 @@ tokio = { workspace = true, features = [
   "net",
 ] }
 tokio-stream = { version = "0.1", features = ["net"] }
-tonic = { version = "0.12", default-features = false, features = [
+tonic = { workspace = true, default-features = false, features = [
   "transport",
   "prost",
 ] }

--- a/integration/shared/Cargo.toml
+++ b/integration/shared/Cargo.toml
@@ -9,7 +9,7 @@ publish = false
 
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
-tonic = { version = "0.12", default-features = false, features = [
+tonic = { workspace = true, default-features = false, features = [
   "codegen",
   "prost",
   "transport",

--- a/integration/sheepdog/Cargo.toml
+++ b/integration/sheepdog/Cargo.toml
@@ -22,12 +22,12 @@ tokio = { version = "1.41", features = [
   "time",
   "net",
 ] }
-tonic = { version = "0.12", default-features = false, features = [
+tonic = { workspace = true, default-features = false, features = [
   "transport",
   "prost",
 ] }
-hyper-util = "0.1"
-tower = { version = "0.5", features = [
+hyper-util = { workspace = true }
+tower = { workspace = true, features = [
   "timeout",
   "limit",
   "load-shed",

--- a/lading/Cargo.toml
+++ b/lading/Cargo.toml
@@ -37,11 +37,11 @@ flate2 = { version = "1.0.34", default-features = false, features = [
 futures = "0.3.31"
 fuser = { version = "0.15", optional = true }
 heck  = { version = "0.5", default-features = false }
-http = "1.2"
+http = { workspace = true }
+http-body-util = { workspace = true }
 http-serde = "2.1"
-hyper = { version = "1.5", features = ["client", "http1", "http2", "server"] }
-http-body-util = "0.1"
-hyper-util = { version = "0.1", features = ["default", "client", "client-legacy"] }
+hyper = { workspace = true, features = ["client", "http1", "http2", "server"] }
+hyper-util = { workspace = true, features = ["default", "client", "client-legacy"] }
 is_executable = "1.0.4"
 metrics = { workspace = true }
 metrics-exporter-prometheus = { workspace = true }


### PR DESCRIPTION
### What does this PR do?

This commit re-unifies our crates at the workspace level, reversing a process begun
in #1181 in order to upgrade hyper et al in a feasible way.
