### PR TITLE
Unifty httpd in blackholes

### DIFF
--- a/lading/src/blackhole.rs
+++ b/lading/src/blackhole.rs
@@ -7,6 +7,7 @@
 
 use serde::{Deserialize, Serialize};
 
+mod common;
 pub mod http;
 pub mod splunk_hec;
 pub mod sqs;

--- a/lading/src/blackhole/common.rs
+++ b/lading/src/blackhole/common.rs
@@ -65,12 +65,12 @@ where
                         continue;
                     }
                 };
+                debug!("Accepted connection from {addr}");
 
                 let sem = Arc::clone(&sem);
                 let service_factory = make_service.clone();
 
                 join_set.spawn(async move {
-                    debug!("Accepted connection from {addr}");
                     let permit = match sem.try_acquire() {
                         Ok(p) => p,
                         Err(TryAcquireError::Closed) => {

--- a/lading/src/blackhole/common.rs
+++ b/lading/src/blackhole/common.rs
@@ -34,7 +34,7 @@ where
     // The bounds on `S` per
     // https://docs.rs/hyper/latest/hyper/service/trait.Service.html and then
     // made concrete per
-    // https://docs.rs/hyper-util/latest/hyper_util/server/conn/auto/struct.Builder.html#method.serve_connection.
+    // https://docs.rs/hyper-util/latest/hyper_util/server/conn/auto/struct.Builder.html#method.serve_connection
     S: Service<
             hyper::Request<hyper::body::Incoming>,
             Response = hyper::Response<BoxBody<Bytes, hyper::Error>>,

--- a/lading/src/blackhole/common.rs
+++ b/lading/src/blackhole/common.rs
@@ -1,0 +1,95 @@
+use bytes::Bytes;
+use http_body_util::combinators::BoxBody;
+use hyper::service::Service;
+use hyper_util::{
+    rt::{TokioExecutor, TokioIo},
+    server::conn::auto,
+};
+use lading_signal::Watcher;
+use std::{net::SocketAddr, sync::Arc};
+use tokio::{net::TcpListener, pin, sync::Semaphore, task::JoinSet};
+use tracing::{debug, error, info};
+
+#[derive(thiserror::Error, Debug)]
+pub enum Error {
+    /// Wrapper for [`std::io::Error`].
+    #[error("IO error: {0}")]
+    Io(std::io::Error),
+}
+
+pub(crate) async fn run_httpd<SF, S>(
+    addr: SocketAddr,
+    concurrency_limit: usize,
+    shutdown: Watcher,
+    make_service: SF,
+) -> Result<(), Error>
+where
+    // "service factory"
+    SF: Send + Sync + 'static + Clone + Fn() -> S,
+    // The bounds on `S` per
+    // https://docs.rs/hyper/latest/hyper/service/trait.Service.html and then
+    // made concrete per
+    // https://docs.rs/hyper-util/latest/hyper_util/server/conn/auto/struct.Builder.html#method.serve_connection.
+    S: Service<
+            hyper::Request<hyper::body::Incoming>,
+            Response = hyper::Response<BoxBody<Bytes, hyper::Error>>,
+            Error = hyper::Error,
+        > + Send
+        + 'static,
+
+    S::Future: Send + 'static,
+{
+    let listener = TcpListener::bind(addr).await.map_err(Error::Io)?;
+    let sem = Arc::new(Semaphore::new(concurrency_limit));
+    let mut join_set = JoinSet::new();
+
+    let shutdown_fut = shutdown.recv();
+    pin!(shutdown_fut);
+    loop {
+        tokio::select! {
+            () = &mut shutdown_fut => {
+                info!("Shutdown signal received, stopping accept loop.");
+                break;
+            }
+
+            incoming = listener.accept() => {
+                let (stream, addr) = match incoming {
+                    Ok(sa) => sa,
+                    Err(e) => {
+                        error!("Error accepting connection: {e}");
+                        continue;
+                    }
+                };
+
+                let sem = Arc::clone(&sem);
+                let service_factory = make_service.clone();
+
+                join_set.spawn(async move {
+                    debug!("Accepted connection from {addr}");
+                    let permit = match sem.acquire_owned().await {
+                        Ok(p) => p,
+                        Err(e) => {
+                            error!("Semaphore closed: {e}");
+                            return;
+                        }
+                    };
+
+                    let builder = auto::Builder::new(TokioExecutor::new());
+                    let serve_future = builder.serve_connection_with_upgrades(
+                        TokioIo::new(stream),
+                        service_factory(),
+                    );
+
+                    if let Err(e) = serve_future.await {
+                        error!("Error serving {addr}: {e}");
+                    }
+                    drop(permit);
+                });
+            }
+        }
+    }
+
+    drop(listener);
+    while join_set.join_next().await.is_some() {}
+    Ok(())
+}

--- a/lading/src/blackhole/common.rs
+++ b/lading/src/blackhole/common.rs
@@ -71,6 +71,13 @@ where
                 let service_factory = make_service.clone();
 
                 join_set.spawn(async move {
+                    // NOTE we are paying the cost for allocating a socket et al
+                    // here and then immediately dropping the connection. If we
+                    // wanted to be more resource spare we should not accept the
+                    // connection before the semaphore is known to have capacity.
+                    //
+                    // Doesn't matter really for lading -- so far as we can tell
+                    // -- but it's not strictly speaking good behavior.
                     let permit = match sem.try_acquire() {
                         Ok(p) => p,
                         Err(TryAcquireError::Closed) => {


### PR DESCRIPTION
### What does this PR do?

This commit unifies the httpd bits of the blackholes, removing a duplicated loop in three places. The type logic here started out general and got gradually more concrete and there's scope to reduce duplication even further but I don't know that it's a pressing issue.
