### PR TITLE
Instrument connection limit and current count for http blackholes

### DIFF
--- a/lading/src/blackhole/common.rs
+++ b/lading/src/blackhole/common.rs
@@ -55,7 +55,9 @@ where
     let shutdown_fut = shutdown.recv();
     pin!(shutdown_fut);
     loop {
-        gauge!("connection.current", &labels).set(sem.available_permits() as f64);
+        let claimed_permits = concurrency_limit - sem.available_permits();
+
+        gauge!("connection.current", &labels).set(claimed_permits as f64);
         tokio::select! {
             () = &mut shutdown_fut => {
                 info!("Shutdown signal received, stopping accept loop.");

--- a/lading/src/blackhole/http.rs
+++ b/lading/src/blackhole/http.rs
@@ -13,7 +13,7 @@ use hyper::{header, Request, Response, StatusCode};
 use metrics::counter;
 use serde::{Deserialize, Serialize};
 use std::{net::SocketAddr, time::Duration};
-use tracing::{debug, error};
+use tracing::error;
 
 use super::General;
 
@@ -238,6 +238,7 @@ impl Http {
             self.httpd_addr,
             self.concurrency_limit,
             self.shutdown,
+            self.metric_labels.clone(),
             move || {
                 let metric_labels = self.metric_labels.clone();
                 let body_bytes = self.body_bytes.clone();
@@ -246,7 +247,6 @@ impl Http {
                 let response_delay = self.response_delay;
 
                 hyper::service::service_fn(move |req| {
-                    debug!("REQUEST: {:?}", req);
                     srv(
                         status,
                         metric_labels.clone(),

--- a/lading/src/blackhole/sqs.rs
+++ b/lading/src/blackhole/sqs.rs
@@ -101,13 +101,10 @@ impl Sqs {
             self.httpd_addr,
             self.concurrency_limit,
             self.shutdown,
+            self.metric_labels.clone(),
             move || {
                 let metric_labels = self.metric_labels.clone();
-
-                hyper::service::service_fn(move |req| {
-                    debug!("REQUEST: {:?}", req);
-                    srv(req, metric_labels.clone())
-                })
+                hyper::service::service_fn(move |req| srv(req, metric_labels.clone()))
             },
         )
         .await?;


### PR DESCRIPTION
### What does this PR do?

This commit introduces telemetry keeping track of the connection
limit for http blackholes and the current connection count. This is
desirable information for targets that wish to trade total connections
for other resources.
