### PR TITLE
Isolate tower to single use site

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1652,7 +1652,6 @@ dependencies = [
  "tokio-stream",
  "tokio-util",
  "tonic 0.12.3",
- "tower 0.5.2",
  "tracing",
  "tracing-subscriber",
  "uuid",
@@ -3308,10 +3307,8 @@ dependencies = [
  "pin-project-lite",
  "sync_wrapper 1.0.2",
  "tokio",
- "tokio-util",
  "tower-layer",
  "tower-service",
- "tracing",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,6 @@ tokio = { version = "1.41" }
 # If you update tonic, search for tonic-build in sub-crates and update their
 # version.
 tonic = { version = "0.12", default-features = false, features = [] }
-tower = { version = "0.5", default-features = false }
 tracing = { version = "0.1" }
 uuid = { version = "1.11", default-features = false, features = [
   "v4",

--- a/integration/sheepdog/Cargo.toml
+++ b/integration/sheepdog/Cargo.toml
@@ -27,11 +27,6 @@ tonic = { workspace = true, default-features = false, features = [
   "prost",
 ] }
 hyper-util = { workspace = true }
-tower = { workspace = true, features = [
-  "timeout",
-  "limit",
-  "load-shed",
-  "util"
-] }
+tower = { version = "0.5", default-features = false, features = ["util"] }
 tracing = { version = "0.1", features = ["std", "attributes"] }
 tracing-subscriber = { version = "0.3", features = ["std", "env-filter"] }

--- a/lading/Cargo.toml
+++ b/lading/Cargo.toml
@@ -78,12 +78,7 @@ tokio = { workspace = true, features = [
 ] }
 tokio-stream = { version = "0.1", features = ["io-util"] }
 tokio-util = { version = "0.7", features = ["io"] }
-tonic = { version = "0.12" }
-tower = { workspace = true, features = [
-  "timeout",
-  "limit",
-  "load-shed",
-] }
+tonic = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { version = "0.3", features = ["std", "env-filter"] }
 uuid = { workspace = true }


### PR DESCRIPTION
### What does this PR do?

This commit removes the `tower` crate down into sheepdog where it
has its last remaining use. We do require it here as it's Service
is part of the type definition for our UDS connection function.