### PR TITLE
Release lading 0.25.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.25.3]
+## Changed
+- Various dependencies updated, notably `hyper` is now 1.x.
+- Error handling in observer made more forgiving of PID death.
+
 ## [0.25.2]
 ## Changed
 - The `bytes_received` metric in the HTTP and splunk_heck blackholes now tracks

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1606,7 +1606,7 @@ dependencies = [
 
 [[package]]
 name = "lading"
-version = "0.25.2"
+version = "0.25.3"
 dependencies = [
  "async-compression",
  "async-pidfd",

--- a/lading/Cargo.toml
+++ b/lading/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lading"
-version = "0.25.2"
+version = "0.25.3"
 authors = [
   "Brian L. Troutwine <brian.troutwine@datadoghq.com>",
   "George Hahn <george.hahn@datadoghq.com>",


### PR DESCRIPTION
### What does this PR do?

This commit is a very minor update, including some dependency updates -- notably hyper to 1.x -- and updates to the error handling in our procfs reads to allow more for PID death.
