### PR TITLE
Added support for https in expvar scraping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Added
 - Introduced the ability for users to configure lading's sample rate,
   configuration option `sample_period_milliseconds` in `lading.yaml`.
+- Users can now configure expvar scraping on https endpoints, skipping certificate validation.
 
 ## [0.25.4]
 ## Changed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -539,6 +539,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "core-foundation"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
 name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -832,6 +842,21 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "form_urlencoded"
@@ -1294,6 +1319,22 @@ dependencies = [
  "hyper-util",
  "pin-project-lite",
  "tokio",
+ "tower-service",
+]
+
+[[package]]
+name = "hyper-tls"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
+dependencies = [
+ "bytes",
+ "http-body-util",
+ "hyper 1.5.2",
+ "hyper-util",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
  "tower-service",
 ]
 
@@ -1911,6 +1952,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "defc4c55412d89136f966bbb339008b474350e5e6e78d2714439c386b3137a03"
 
 [[package]]
+name = "native-tls"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8614eb2c83d59d1c8cc974dd3f920198647674a0a035e1af1fa58707e317466"
+dependencies = [
+ "libc",
+ "log",
+ "openssl",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "security-framework",
+ "security-framework-sys",
+ "tempfile",
+]
+
+[[package]]
 name = "nibble_vec"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1986,6 +2044,50 @@ name = "oorandom"
 version = "11.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b410bbe7e14ab526a0e86877eb47c6996a2bd7746f027ba551028c925390e4e9"
+
+[[package]]
+name = "openssl"
+version = "0.10.68"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6174bc48f102d208783c2c84bf931bb75927a617866870de8a4ea85597f871f5"
+dependencies = [
+ "bitflags 2.6.0",
+ "cfg-if",
+ "foreign-types",
+ "libc",
+ "once_cell",
+ "openssl-macros",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.91",
+]
+
+[[package]]
+name = "openssl-probe"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.104"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45abf306cbf99debc8195b66b7346498d7b10c210de50418b5ccd7ceba08c741"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
 
 [[package]]
 name = "opentelemetry"
@@ -2579,19 +2681,23 @@ dependencies = [
  "http-body 1.0.1",
  "http-body-util",
  "hyper 1.5.2",
+ "hyper-tls",
  "hyper-util",
  "ipnet",
  "js-sys",
  "log",
  "mime",
+ "native-tls",
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
+ "rustls-pemfile",
  "serde",
  "serde_json",
  "serde_urlencoded",
  "sync_wrapper 1.0.2",
  "tokio",
+ "tokio-native-tls",
  "tower 0.5.2",
  "tower-service",
  "url",
@@ -2663,6 +2769,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls-pemfile"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16f1201b3c9a7ee8039bcadc17b7e605e2945b27eee7631788c1bd2b0643674b"
+
+[[package]]
 name = "rustversion"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2696,6 +2817,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "schannel"
+version = "0.1.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f29ebaa345f945cec9fbbc532eb307f0fdad8161f281b6369539c8d84876b3d"
+dependencies = [
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "scoped-tls"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2706,6 +2836,29 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "security-framework"
+version = "2.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
+dependencies = [
+ "bitflags 2.6.0",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa39c7303dc58b5543c94d22c1766b0d31f2ee58306363ea622b10bbc075eaa2"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
 
 [[package]]
 name = "serde"
@@ -3153,6 +3306,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-native-tls"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
+dependencies = [
+ "native-tls",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-stream"
 version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3503,6 +3666,12 @@ name = "valuable"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version_check"

--- a/lading/Cargo.toml
+++ b/lading/Cargo.toml
@@ -58,7 +58,7 @@ rand = { workspace = true, default-features = false, features = [
   "std_rng",
 ] }
 regex = { version = "1.11" }
-reqwest = { version = "0.12", default-features = false, features = ["json"] }
+reqwest = { version = "0.12", default-features = false, features = ["json", "default-tls"] }
 rustc-hash = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/lading/src/target_metrics/expvar.rs
+++ b/lading/src/target_metrics/expvar.rs
@@ -88,15 +88,18 @@ impl Expvar {
 
         let server = async move {
             loop {
-                tokio::time::sleep(self.sample_period).await;
-                let Ok(resp) = client
+                tokio::time::sleep(Duration::from_secs(1)).await;
+                let resp = match client
                     .get(&self.config.uri)
                     .timeout(self.sample_period)
                     .send()
                     .await
-                else {
-                    info!("failed to get expvar uri");
-                    continue;
+                {
+                    Ok(resp) => resp, // If successful, return the response
+                    Err(err) => {
+                        info!("Failed to get expvar URI: {}", err);
+                        continue; // Skip the iteration on error
+                    }
                 };
 
                 let Ok(json) = resp.json::<Value>().await else {

--- a/lading/src/target_metrics/expvar.rs
+++ b/lading/src/target_metrics/expvar.rs
@@ -102,9 +102,12 @@ impl Expvar {
                     }
                 };
 
-                let Ok(json) = resp.json::<Value>().await else {
-                    info!("failed to parse expvar json");
-                    continue;
+                let json = match resp.json::<Value>().await {
+                    Ok(json) => json, // Successfully parsed JSON
+                    Err(err) => {
+                        info!("Failed to parse expvar JSON: {}", err);
+                        continue; // Skip the iteration on error
+                    }
                 };
 
                 // Add lading labels including user defined tags for this endpoint

--- a/lading/src/target_metrics/expvar.rs
+++ b/lading/src/target_metrics/expvar.rs
@@ -1,7 +1,7 @@
 //! Expvar target metrics fetcher
 //!
 //! This module scrapes Go expvar formatted metrics from the target software.
-//! The metrics are formatted as a JSON tree that is fetched over HTTP.
+//! The metrics are formatted as a JSON tree that is fetched over HTTP or HTTPS.
 
 use std::time::Duration;
 

--- a/lading/src/target_metrics/expvar.rs
+++ b/lading/src/target_metrics/expvar.rs
@@ -80,7 +80,11 @@ impl Expvar {
             self.sample_period
         );
 
-        let client = reqwest::Client::new();
+        // Disable certificate validation
+        let client = reqwest::ClientBuilder::new()
+            .danger_accept_invalid_certs(true)
+            .build()
+            .expect("Failed to build http/https client");
 
         let server = async move {
             loop {

--- a/lading/src/target_metrics/expvar.rs
+++ b/lading/src/target_metrics/expvar.rs
@@ -88,7 +88,7 @@ impl Expvar {
 
         let server = async move {
             loop {
-                tokio::time::sleep(Duration::from_secs(1)).await;
+                tokio::time::sleep(self.sample_period).await;
                 let resp = match client
                     .get(&self.config.uri)
                     .timeout(self.sample_period)


### PR DESCRIPTION
### What does this PR do?

Adds support for https requests for scraping expvar. Currently I am allowing any certificate with no tls verification. This is most definitely a bad practice in general. For this specific use case it _may_ be fine. After testing this I should be able to pass in the pem path used for tls validation if we dont want to allow any certificate. 

### Motivation

Error seen in this [notebook](https://app.datadoghq.com/notebook/11124176/caleb-investigating-http-to-https-error?notebookType=rte)

Update as of Jan 22:
The change to set trace agents debug endpoint to https has been reverted for now so this change is not needed yet.

Update as of Jan 29:
The change has [landed](https://github.com/DataDog/datadog-agent/pull/33402). These errors will be present from now. I need to update expvar endpoint for quality gates in agent repo and finish this change and get a lading release out

Testing:
job_id:03321fcd-6cdb-45ee-b07d-0ca48e4848d0
- comparison image is nightly from jan 10 (was hitting api limit when trying to pull todays, jan 30)
- This version has the trace https change that was reapplied [here](https://github.com/DataDog/datadog-agent/pull/33402)
-`quality_gate_idle` has expvar configured for https
-`quality_gate_all_features` has expvar configured for http
-`quality_gate_logs` has no expvar configured
I expect to see the following:
- comparison + `quality_gate_idle` => no errors ([logs](https://app.datadoghq.com/logs?query=client_team%3Acm-dev%20job_id%3A03321fcd-6cdb-45ee-b07d-0ca48e4848d0%20variant%3Acomparison%20experiment%3Aquality_gate_idle&agg_m=count&agg_m_source=base&agg_t=count&cols=host%2Cservice&fromUser=true&index=single-machine-performance-target-logs&messageDisplay=inline&refresh_mode=paused&storage=hot&stream_sort=desc&viz=stream&from_ts=1738249721935&to_ts=1738251296547&live=false))
- baseline + `quality_gate_idle` => cant get expvar endpoint since we are sending request to https port and 7.58 will expose over http ([logs](https://app.datadoghq.com/logs?query=client_team%3Acm-dev%20job_id%3A03321fcd-6cdb-45ee-b07d-0ca48e4848d0%20variant%3Abaseline%20experiment%3Aquality_gate_idle&agg_m=count&agg_m_source=base&agg_t=count&cols=host%2Cservice&fromUser=true&index=single-machine-performance-target-logs&messageDisplay=inline&refresh_mode=paused&storage=hot&stream_sort=desc&viz=stream&from_ts=1738249721935&to_ts=1738251296547&live=false))
- comparison + `quality_gate_all_features` => `Http request sent to an https server` error ([logs](https://app.datadoghq.com/logs?query=client_team%3Acm-dev%20job_id%3A03321fcd-6cdb-45ee-b07d-0ca48e4848d0%20variant%3Acomparison%20experiment%3Aquality_gate_idle_all_features&agg_m=count&agg_m_source=base&agg_t=count&cols=host%2Cservice&fromUser=true&index=single-machine-performance-target-logs&messageDisplay=inline&refresh_mode=paused&storage=hot&stream_sort=desc&viz=stream&from_ts=1738249721935&to_ts=1738251296547&live=false))
- baseline + `quality_gate_all_features` => no errors ([logs](https://app.datadoghq.com/logs?query=client_team%3Acm-dev%20job_id%3A03321fcd-6cdb-45ee-b07d-0ca48e4848d0%20variant%3Abaseline%20experiment%3Aquality_gate_idle_all_features&agg_m=count&agg_m_source=base&agg_t=count&cols=host%2Cservice&fromUser=true&index=single-machine-performance-target-logs&messageDisplay=inline&refresh_mode=paused&storage=hot&stream_sort=desc&viz=stream&from_ts=1738249721935&to_ts=1738251296547&live=false))

[SMPTNG-587
](https://datadoghq.atlassian.net/browse/SMPTNG-587)