### PR TITLE
fix(splunk_hec generator): Only require ack when acks enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+## Changed
+- The `splunk_hec` generator now only requires responses to have an `ackId` when
+  `acknowledgements` are enabled.
+
 ## [0.25.3]
 ## Changed
 - Various dependencies updated, notably `hyper` is now 1.x.

--- a/lading/src/generator/splunk_hec.rs
+++ b/lading/src/generator/splunk_hec.rs
@@ -352,7 +352,7 @@ where
                         counter!("request_ok", &status_labels).increment(1);
                         let body_bytes = body.boxed().collect().await?.to_bytes();
                         let hec_ack_response =
-                            serde_json::from_slice::<HecAckResponse>(&body_bytes).expect("unable to parse response body");
+                            serde_json::from_slice::<HecResponse>(&body_bytes).expect("unable to parse response body");
                         channel.send(ready(hec_ack_response.ack_id)).await?;
                     }
                     Err(err) => {
@@ -376,11 +376,11 @@ where
 
 #[derive(Deserialize, Serialize, Debug)]
 #[serde(deny_unknown_fields)]
-struct HecAckResponse {
+struct HecResponse {
     #[allow(dead_code)]
     text: String,
     #[allow(dead_code)]
     code: u8,
     #[serde(rename = "ackId")]
-    ack_id: u64,
+    ack_id: Option<u64>,
 }

--- a/lading/src/generator/splunk_hec/acknowledgements.rs
+++ b/lading/src/generator/splunk_hec/acknowledgements.rs
@@ -54,11 +54,13 @@ impl Channel {
 
     pub(crate) async fn send<Fut>(&self, msg: Fut) -> Result<(), Error>
     where
-        Fut: Future<Output = AckId>,
+        Fut: Future<Output = Option<AckId>>,
     {
         match self {
             Self::NoAck { .. } => Ok(()),
-            Self::Ack { tx, .. } => Ok(tx.send(msg.await).await?),
+            Self::Ack { tx, .. } => Ok(tx
+                .send(msg.await.expect("acknowledgemnts enabled, should have id"))
+                .await?),
         }
     }
 }


### PR DESCRIPTION
### What does this PR do?

Only requires ack id in Splunk HEC responses when acknowledgements are enabled.

### Motivation

`splunk_hec_to_splunk_hec_logs_noack` experiment in Vector is currently failing due to lading expecting ack responses and Vector not returning them. This error was previously hidden but exposed by https://github.com/DataDog/lading/commit/c38e915.

### Related issues



### Additional Notes

Open to thoughts on refactoring this. I took what seemed like the most straightforward path towards a fix.