### PR TITLE
Release lading 0.25.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.25.4]
 ## Changed
 - The `splunk_hec` generator now only requires responses to have an `ackId` when
   `acknowledgements` are enabled.
-- cgroup.v2 PSI metrics are now parsed.
+- cgroup.v2 PSI metrics are now parsed. These metrics may change in future
+  versions of lading as we get more experience with them.
 
 ## [0.25.3]
 ## Changed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1606,7 +1606,7 @@ dependencies = [
 
 [[package]]
 name = "lading"
-version = "0.25.3"
+version = "0.25.4"
 dependencies = [
  "async-compression",
  "async-pidfd",

--- a/lading/Cargo.toml
+++ b/lading/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lading"
-version = "0.25.3"
+version = "0.25.4"
 authors = [
   "Brian L. Troutwine <brian.troutwine@datadoghq.com>",
   "George Hahn <george.hahn@datadoghq.com>",


### PR DESCRIPTION
### What does this PR do?

This release adds cgroup v2 PSI metrics and the splunk-hec generator now only requires ackId if acknowledgements are enabled.
