### PR TITLE
Allow observer sample rate to be configured

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+## Added
+- Introduced the ability for users to configure observer sample rate,
+  configuration option `sample_period_milliseconds`. 
+
 ## [0.25.4]
 ## Changed
 - The `splunk_hec` generator now only requires responses to have an `ackId` when

--- a/lading/src/bin/lading.rs
+++ b/lading/src/bin/lading.rs
@@ -485,7 +485,7 @@ async fn inner_main(
     if let Some(target) = config.target {
         let obs_rcv = tgt_snd.subscribe();
         let observer_server = observer::Server::new(config.observer, shutdown_watcher.clone())?;
-        osrv_joinset.spawn(observer_server.run(obs_rcv));
+        osrv_joinset.spawn(observer_server.run(obs_rcv, config.sample_period_milliseconds));
 
         //
         // TARGET

--- a/lading/src/bin/lading.rs
+++ b/lading/src/bin/lading.rs
@@ -485,7 +485,8 @@ async fn inner_main(
     if let Some(target) = config.target {
         let obs_rcv = tgt_snd.subscribe();
         let observer_server = observer::Server::new(config.observer, shutdown_watcher.clone())?;
-        osrv_joinset.spawn(observer_server.run(obs_rcv, config.sample_period_milliseconds));
+        let sample_period = Duration::from_millis(config.sample_period_milliseconds);
+        osrv_joinset.spawn(observer_server.run(obs_rcv, sample_period));
 
         //
         // TARGET

--- a/lading/src/config.rs
+++ b/lading/src/config.rs
@@ -22,6 +22,10 @@ pub enum Error {
     SocketAddr(#[from] std::net::AddrParseError),
 }
 
+fn default_sample_period() -> Duration {
+    Duration::from_millis(1_000)
+}
+
 /// Main configuration struct for this program
 #[derive(Debug, Default, Deserialize, PartialEq)]
 #[serde(deny_unknown_fields)]
@@ -36,6 +40,9 @@ pub struct Config {
     /// The observer that watches the target
     #[serde(skip_deserializing)]
     pub observer: observer::Config,
+    /// The period on which target observations -- if any -- are made.
+    #[serde(default = "default_sample_period")]
+    pub sample_period_milliseconds: Duration,
     /// The program being targetted by this rig
     #[serde(skip_deserializing)]
     pub target: Option<target::Config>,
@@ -187,6 +194,7 @@ blackhole:
                 observer: observer::Config::default(),
                 inspector: Option::default(),
                 target_metrics: Option::default(),
+                sample_period_milliseconds: Duration::from_millis(1_000),
             },
         );
         Ok(())

--- a/lading/src/config.rs
+++ b/lading/src/config.rs
@@ -22,8 +22,8 @@ pub enum Error {
     SocketAddr(#[from] std::net::AddrParseError),
 }
 
-fn default_sample_period() -> Duration {
-    Duration::from_millis(1_000)
+fn default_sample_period() -> u64 {
+    1_000
 }
 
 /// Main configuration struct for this program
@@ -42,7 +42,7 @@ pub struct Config {
     pub observer: observer::Config,
     /// The period on which target observations -- if any -- are made.
     #[serde(default = "default_sample_period")]
-    pub sample_period_milliseconds: Duration,
+    pub sample_period_milliseconds: u64,
     /// The program being targetted by this rig
     #[serde(skip_deserializing)]
     pub target: Option<target::Config>,

--- a/lading/src/config.rs
+++ b/lading/src/config.rs
@@ -194,7 +194,7 @@ blackhole:
                 observer: observer::Config::default(),
                 inspector: Option::default(),
                 target_metrics: Option::default(),
-                sample_period_milliseconds: Duration::from_millis(1_000),
+                sample_period_milliseconds: 1_000,
             },
         );
         Ok(())

--- a/lading/src/observer.rs
+++ b/lading/src/observer.rs
@@ -140,7 +140,11 @@ impl Server {
     /// None are known.
     #[allow(clippy::unused_async)]
     #[cfg(not(target_os = "linux"))]
-    pub async fn run(self, _pid_snd: TargetPidReceiver) -> Result<(), Error> {
+    pub async fn run(
+        self,
+        _pid_snd: TargetPidReceiver,
+        _sample_period: std::time::Duration,
+    ) -> Result<(), Error> {
         tracing::warn!("observer unavailable on non-Linux system");
         Ok(())
     }

--- a/lading/src/observer.rs
+++ b/lading/src/observer.rs
@@ -90,9 +90,11 @@ impl Server {
         clippy::cast_sign_loss
     )]
     #[cfg(target_os = "linux")]
-    pub async fn run(self, mut pid_snd: TargetPidReceiver) -> Result<(), Error> {
-        use std::time::Duration;
-
+    pub async fn run(
+        self,
+        mut pid_snd: TargetPidReceiver,
+        sample_period: std::time::Duration,
+    ) -> Result<(), Error> {
         use crate::observer::linux::Sampler;
 
         let target_pid = pid_snd
@@ -103,7 +105,7 @@ impl Server {
 
         let target_pid = target_pid.expect("observer cannot be used in no-target mode");
 
-        let mut sample_delay = tokio::time::interval(Duration::from_secs(1));
+        let mut sample_delay = tokio::time::interval(sample_period);
         let mut sampler = Sampler::new(
             target_pid,
             vec![(String::from("focus"), String::from("target"))],


### PR DESCRIPTION
### What does this PR do?

Historically the observer has been sampling at 1hz, although the
only place this was explicit was in lading bin. We now expose
`sample_period_milliseconds` to configure this rate. The default
remains one second.

