### PR TITLE
'sample_period_milliseconds' changes target metric collection interval

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ## Added
-- Introduced the ability for users to configure observer sample rate,
-  configuration option `sample_period_milliseconds`. 
+- Introduced the ability for users to configure lading's sample rate,
+  configuration option `sample_period_milliseconds` in `lading.yaml`.
 
 ## [0.25.4]
 ## Changed

--- a/lading/src/bin/lading.rs
+++ b/lading/src/bin/lading.rs
@@ -461,11 +461,14 @@ async fn inner_main(
     // TARGET METRICS
     //
     if let Some(cfgs) = config.target_metrics {
+        let sample_period = Duration::from_millis(config.sample_period_milliseconds);
+
         for cfg in cfgs {
             let metrics_server = target_metrics::Server::new(
                 cfg,
                 shutdown_watcher.clone(),
                 experiment_started_watcher.clone(),
+                sample_period,
             );
             tokio::spawn(async {
                 match metrics_server.run().await {

--- a/lading/src/target_metrics.rs
+++ b/lading/src/target_metrics.rs
@@ -5,6 +5,7 @@
 //!
 
 use serde::Deserialize;
+use tokio::time::Duration;
 
 pub mod expvar;
 pub mod prometheus;
@@ -49,15 +50,20 @@ impl Server {
         config: Config,
         shutdown: lading_signal::Watcher,
         experiment_started: lading_signal::Watcher,
+        sample_period: Duration,
     ) -> Self {
         match config {
-            Config::Expvar(conf) => {
-                Self::Expvar(expvar::Expvar::new(conf, shutdown, experiment_started))
-            }
+            Config::Expvar(conf) => Self::Expvar(expvar::Expvar::new(
+                conf,
+                shutdown,
+                experiment_started,
+                sample_period,
+            )),
             Config::Prometheus(conf) => Self::Prometheus(prometheus::Prometheus::new(
                 conf,
                 shutdown,
                 experiment_started,
+                sample_period,
             )),
         }
     }

--- a/lading/src/target_metrics/prometheus.rs
+++ b/lading/src/target_metrics/prometheus.rs
@@ -383,6 +383,7 @@ mod tests {
 
         let (shutdown_watcher, _) = lading_signal::signal();
         let (experiment_started_watcher, experiment_started_broadcaster) = lading_signal::signal();
+        let sample_period = Duration::from_secs(1);
         let p = Prometheus::new(
             Config {
                 uri: server_uri,
@@ -391,6 +392,7 @@ mod tests {
             },
             shutdown_watcher,
             experiment_started_watcher,
+            sample_period,
         );
 
         let dr = metrics_util::debugging::DebuggingRecorder::new();

--- a/lading/src/target_metrics/prometheus.rs
+++ b/lading/src/target_metrics/prometheus.rs
@@ -66,6 +66,7 @@ pub struct Prometheus {
     client: reqwest::Client,
     shutdown: lading_signal::Watcher,
     experiment_started: lading_signal::Watcher,
+    sample_period: Duration,
 }
 
 impl Prometheus {
@@ -78,6 +79,7 @@ impl Prometheus {
         config: Config,
         shutdown: lading_signal::Watcher,
         experiment_started: lading_signal::Watcher,
+        sample_period: Duration,
     ) -> Self {
         let client = reqwest::Client::new();
         Self {
@@ -85,6 +87,7 @@ impl Prometheus {
             client,
             shutdown,
             experiment_started,
+            sample_period,
         }
     }
 
@@ -105,7 +108,10 @@ impl Prometheus {
     pub(crate) async fn run(self) -> Result<(), Error> {
         info!("Prometheus target metrics scraper running, but waiting for warmup to complete");
         self.experiment_started.recv().await;
-        info!("Prometheus target metrics scraper starting collection");
+        info!(
+            "Prometheus target metrics scraper starting collection at {:?} interval",
+            self.sample_period
+        );
 
         let client = self.client;
         let uri = self.config.uri;
@@ -115,7 +121,7 @@ impl Prometheus {
         let shutdown_wait = self.shutdown.recv();
         tokio::pin!(shutdown_wait);
 
-        let mut poll = tokio::time::interval(Duration::from_secs(1));
+        let mut poll = tokio::time::interval(self.sample_period);
 
         loop {
             tokio::select! {


### PR DESCRIPTION
### What does this PR do?

The existing `sample_period_milliseconds` config option is now used for the target metric scraping interval.

### Motivation

Oversight from #1217 , the observer metric collection should occur at the same rate as the target metrics are scraped.

### Related issues


### Additional Notes

