### PR TITLE
Revert "Bump taiki-e/create-gh-release-action from 1.8.3 to 1.9.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Create GitHub release
-        uses: taiki-e/create-gh-release-action@ceeaaf73c0f3f0cadd7bfd9b4d27de4076891fc2 # v1.9.0
+        uses: taiki-e/create-gh-release-action@d33396ec937b3c8de323c14ec623aa6bfb93d9a1 # v1.8.3
         with:
           changelog: CHANGELOG.md
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This reverts commit 58b098c392f99e663a0354e153e0682b4cf51d99.

### What does this PR do?

Reverts - Bump [taiki-e/create-gh-release-action](https://github.com/taiki-e/create-gh-release-action) from 1.8.3 to 1.9.0.
### Motivation

1.9.0 has a bug where the github release fails to be created
