### PR TITLE
Ignore metrics read over prometheus with NaN value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Introduced the ability for users to configure lading's sample rate,
   configuration option `sample_period_milliseconds` in `lading.yaml`.
 - Users can now configure expvar scraping on https endpoints, skipping certificate validation.
+- Fixes issue when parsing `NaN` values from a prometheus endpoint
 
 ## [0.25.4]
 ## Changed

--- a/lading/src/target_metrics/prometheus.rs
+++ b/lading/src/target_metrics/prometheus.rs
@@ -276,6 +276,11 @@ pub(crate) async fn scrape_metrics(
                     }
                 };
 
+                if value.is_nan() {
+                    warn!("Skipping NaN guage value");
+                    continue;
+                }
+
                 gauge!(format!("target/{name}"), &all_labels.unwrap_or_default()).set(value);
             }
             Some(MetricType::Counter) => {
@@ -286,6 +291,11 @@ pub(crate) async fn scrape_metrics(
                         continue;
                     }
                 };
+
+                if value.is_nan() {
+                    warn!("Skipping NaN counter value");
+                    continue;
+                }
 
                 let value = if value < 0.0 {
                     warn!("Negative counter value unhandled");

--- a/lading/src/target_metrics/prometheus.rs
+++ b/lading/src/target_metrics/prometheus.rs
@@ -277,7 +277,7 @@ pub(crate) async fn scrape_metrics(
                 };
 
                 if value.is_nan() {
-                    warn!("Skipping NaN guage value");
+                    warn!("Skipping NaN gauge value");
                     continue;
                 }
 


### PR DESCRIPTION
### What does this PR do?

Ignores counters and guages scraped over prometheus that have a NaN value.

### Motivation

Turns out NaN is a valid [constant](https://doc.rust-lang.org/std/f64/constant.NAN.html) of f64 so when we scrape prometheus endpoint and read a NaN value we try to set it as a gauge or counter. This is then translated to null in the capture file. null in the capture file causes `rouster-series-sender` to fail when submitting metrics

### Related issues

I am not 100% confident that this is all we need to handle all edges regarding NaN


