### PR TITLE
Record smaps less often

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Fixed
 - `smaps` parsing logic correctly collects memory region pathnames that contain whitespace
 - Fixes issue when parsing `NaN` values from a prometheus endpoint
+## Changed
+- smaps data is scraped every tenth sample to reduce capture size.
 
 ## [0.25.5]
 ## Added

--- a/lading/src/observer/linux.rs
+++ b/lading/src/observer/linux.rs
@@ -16,8 +16,8 @@ pub enum Error {
 
 #[derive(Debug)]
 pub(crate) struct Sampler {
-    procfs_sampler: procfs::Sampler,
-    cgroup_sampler: cgroup::Sampler,
+    procfs: procfs::Sampler,
+    cgroup: cgroup::Sampler,
     smaps_interval: u8,
 }
 
@@ -27,8 +27,8 @@ impl Sampler {
         let cgroup_sampler = cgroup::Sampler::new(parent_pid, labels)?;
 
         Ok(Self {
-            procfs_sampler,
-            cgroup_sampler,
+            procfs: procfs_sampler,
+            cgroup: cgroup_sampler,
             smaps_interval: 10,
         })
     }
@@ -42,8 +42,8 @@ impl Sampler {
             false
         };
 
-        self.procfs_sampler.poll(sample_smaps).await?;
-        self.cgroup_sampler.poll().await?;
+        self.procfs.poll(sample_smaps).await?;
+        self.cgroup.poll().await?;
 
         Ok(())
     }


### PR DESCRIPTION
### What does this PR do?

Record smaps data every tenth sample.

### Motivation

These measurements increase capture size and processing time. They're about 1/3 of the metrics in capture files by linecount and by size.
