### PR TITLE
Support gauge/counter distinction in Linux observer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Fixed
 - `smaps` parsing logic correctly collects memory region pathnames that contain whitespace
 - Fixes issue when parsing `NaN` values from a prometheus endpoint
+- Linux cgroup v2 observer now correctly sets known-counter values as counters in telemetry.
 ## Changed
 - smaps data is scraped every tenth sample to reduce capture size.
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1686,6 +1686,7 @@ dependencies = [
  "metrics-exporter-prometheus",
  "metrics-util",
  "nix",
+ "num-traits",
  "num_cpus",
  "once_cell",
  "procfs",

--- a/lading/Cargo.toml
+++ b/lading/Cargo.toml
@@ -51,6 +51,7 @@ nix = { version = "0.29", default-features = false, features = [
   "signal",
 ] }
 num_cpus = { version = "1.16" }
+num-traits = { version = "0.2", default-features = false }
 once_cell = { workspace = true }
 rand = { workspace = true, default-features = false, features = [
   "small_rng",

--- a/lading/src/observer/linux/cgroup/v2.rs
+++ b/lading/src/observer/linux/cgroup/v2.rs
@@ -190,7 +190,7 @@ pub(crate) async fn poll(file_path: &Path, labels: &[(String, String)]) -> Resul
 
 #[inline]
 pub(crate) fn single_value(content: &str, metric_prefix: String, labels: &[(String, String)]) {
-    // Content is a single-vaue file with an integer value.
+    // Content is a single-value file with an integer value.
     if content == "max" {
         gauge!(metric_prefix, labels).set(f64::MAX);
     } else if let Ok(value) = content.parse::<f64>() {

--- a/lading/src/observer/linux/cgroup/v2.rs
+++ b/lading/src/observer/linux/cgroup/v2.rs
@@ -100,7 +100,11 @@ pub(crate) async fn poll(file_path: &Path, labels: &[(String, String)]) -> Resul
                                                     | "memory.oom.group"
                                                     | "memory.peak",
                                                 ) => {
-                                                    single_value(content, metric_prefix, labels);
+                                                    single_value_gauge(
+                                                        content,
+                                                        metric_prefix,
+                                                        labels,
+                                                    );
                                                 }
                                                 Some(
                                                     "cpu.pressure" | "io.pressure"
@@ -189,7 +193,11 @@ pub(crate) async fn poll(file_path: &Path, labels: &[(String, String)]) -> Resul
 }
 
 #[inline]
-pub(crate) fn single_value(content: &str, metric_prefix: String, labels: &[(String, String)]) {
+pub(crate) fn single_value_gauge(
+    content: &str,
+    metric_prefix: String,
+    labels: &[(String, String)],
+) {
     // Content is a single-value file with an integer value.
     if content == "max" {
         gauge!(metric_prefix, labels).set(f64::MAX);

--- a/lading/src/observer/linux/cgroup/v2.rs
+++ b/lading/src/observer/linux/cgroup/v2.rs
@@ -143,7 +143,7 @@ pub(crate) async fn poll(file_path: &Path, labels: &[(String, String)]) -> Resul
                                                     io::stat(content, &metric_prefix, labels);
                                                 }
                                                 Some(unknown) => {
-                                                    warn!("Heuristicly parsing of unknown cgroup v2 file: {unknown}");
+                                                    debug!("Heuristicly parsing of unknown cgroup v2 file: {unknown}");
                                                     if content == "max" {
                                                         gauge!(metric_prefix, labels).set(f64::MAX);
                                                     } else if let Ok(value) = content.parse::<f64>()
@@ -238,13 +238,13 @@ where
                 } else if let Ok(value) = value_str.parse::<T>() {
                     f(metric_name, labels, value);
                 } else {
-                    warn!("[{metric_prefix}] Failed to parse {key}: {content}");
+                    debug!("[{metric_prefix}] Failed to parse {key}: {content}");
                 }
             } else {
-                warn!("[{metric_prefix}] missing value in key/value pair, skipping");
+                debug!("[{metric_prefix}] missing value in key/value pair, skipping");
             }
         } else {
-            warn!("[{metric_prefix}] missing value in key/value pair, skipping");
+            debug!("[{metric_prefix}] missing value in key/value pair, skipping");
         }
     }
 }

--- a/lading/src/observer/linux/cgroup/v2.rs
+++ b/lading/src/observer/linux/cgroup/v2.rs
@@ -83,33 +83,31 @@ pub(crate) async fn poll(file_path: &Path, labels: &[(String, String)]) -> Resul
                                                         "Failed to parse file name: {file_name:?}"
                                                     );
                                                 }
-                                                Some("memory.current") => {
+                                                Some(
+                                                    "memory.current"
+                                                    | "memory.high"
+                                                    | "memory.low"
+                                                    | "memory.max"
+                                                    | "memory.min"
+                                                    | "memory.swap.current"
+                                                    | "memory.swap.high"
+                                                    | "memory.swap.max"
+                                                    | "memory.swap.peak"
+                                                    | "memory.zswap.current"
+                                                    | "memory.zswap.max"
+                                                    | "memory.zswap.writeback"
+                                                    | "cpu.idle"
+                                                    | "memory.oom.group"
+                                                    | "memory.peak",
+                                                ) => {
                                                     single_value(content, metric_prefix, labels);
                                                 }
-                                                Some("memory.events" | "memory.events.local") => {
-                                                    kv_counter(content, &metric_prefix, labels);
-                                                }
-                                                Some("memory.high") => {
-                                                    single_value(&content, metric_prefix, labels);
-                                                }
-                                                Some("memory.low") => {
-                                                    single_value(&content, metric_prefix, labels);
-                                                }
-                                                Some("memory.max") => {
-                                                    single_value(&content, metric_prefix, labels);
-                                                }
-                                                Some("memory.min") => {
-                                                    single_value(&content, metric_prefix, labels);
-                                                }
-                                                Some("memory.oom.group") => {
-                                                    single_value(&content, metric_prefix, labels);
-                                                }
-                                                Some("memory.peak") => {
-                                                    single_value(&content, metric_prefix, labels);
-                                                }
-                                                Some("memory.pressure") => {
+                                                Some(
+                                                    "cpu.pressure" | "io.pressure"
+                                                    | "memory.pressure",
+                                                ) => {
                                                     if let Err(err) = parse_pressure(
-                                                        &content,
+                                                        content,
                                                         &metric_prefix,
                                                         labels,
                                                     ) {
@@ -117,61 +115,18 @@ pub(crate) async fn poll(file_path: &Path, labels: &[(String, String)]) -> Resul
                                                     );
                                                     }
                                                 }
+                                                Some(
+                                                    "memory.events"
+                                                    | "memory.events.local"
+                                                    | "memory.swap.events",
+                                                ) => {
+                                                    kv_counter(content, &metric_prefix, labels);
+                                                }
                                                 Some("memory.stat") => {
-                                                    memory::stat(&content, metric_prefix, labels);
-                                                }
-                                                Some("memory.swap.current") => {
-                                                    single_value(&content, metric_prefix, labels);
-                                                }
-                                                Some("memory.swap.events") => {
-                                                    kv_counter(&content, &metric_prefix, labels);
-                                                }
-                                                Some("memory.swap.high") => {
-                                                    single_value(&content, metric_prefix, labels);
-                                                }
-                                                Some("memory.swap.max") => {
-                                                    single_value(&content, metric_prefix, labels);
-                                                }
-                                                Some("memory.swap.peak") => {
-                                                    single_value(&content, metric_prefix, labels);
-                                                }
-                                                Some("memory.zswap.current") => {
-                                                    single_value(&content, metric_prefix, labels);
-                                                }
-                                                Some("memory.zswap.max") => {
-                                                    single_value(&content, metric_prefix, labels);
-                                                }
-                                                Some("memory.zswap.writeback") => {
-                                                    single_value(&content, metric_prefix, labels);
-                                                }
-                                                Some("cpu.idle") => {
-                                                    single_value(&content, metric_prefix, labels);
+                                                    memory::stat(content, &metric_prefix, labels);
                                                 }
                                                 Some("cpu.max" | "cpu.stat") => {
                                                     // cpu.max and cpu.stat are handled specially in v2/cpu
-                                                }
-                                                Some("cpu.pressure") => {
-                                                    if let Err(err) = parse_pressure(
-                                                        &content,
-                                                        &metric_prefix,
-                                                        labels,
-                                                    ) {
-                                                        warn!("[{metric_prefix}] Failed to parse PSI contents: {err:?}",
-                                                    );
-                                                    }
-                                                }
-                                                Some("cpu.weight") => {
-                                                    single_value(&content, metric_prefix, labels);
-                                                }
-                                                Some("io.pressure") => {
-                                                    if let Err(err) = parse_pressure(
-                                                        &content,
-                                                        &metric_prefix,
-                                                        labels,
-                                                    ) {
-                                                        warn!("[{metric_prefix}] Failed to parse PSI contents: {err:?}",
-                                                    );
-                                                    }
                                                 }
                                                 Some(unknown) => {
                                                     warn!("Heuristicly parsing of unknown cgroup v2 file: {unknown}");

--- a/lading/src/observer/linux/cgroup/v2/io.rs
+++ b/lading/src/observer/linux/cgroup/v2/io.rs
@@ -1,0 +1,121 @@
+//! IO controller for cgroup v2.
+
+use metrics::{counter, gauge};
+use tracing::warn;
+
+pub(crate) fn max(content: &str, metric_prefix: &str, labels: &[(String, String)]) {
+    // Lines of the form
+    //
+    // <major>:<minor> <read_limit> <write_limit>
+    //
+    // Where limit is u64|max. All values are counters. We add a label called
+    // "device" that is "<major>:<minor>".
+    for line in content.lines() {
+        let line = line.trim();
+        if line.is_empty() {
+            continue;
+        }
+
+        let mut parts = line.split_whitespace();
+        let Some(device) = parts.next() else {
+            continue; // skip invalid line
+        };
+
+        let read_limit = match parts.next() {
+            Some("max") => f64::MAX,
+            Some(value) => if let Ok(value) = value.parse::<f64>() { value } else {
+                warn!(
+                    "[{metric_prefix}] Failed to parse read limit for device {device}: {value}",
+                
+                );
+                continue;
+            },
+            None => {
+                warn!(
+                    "[{metric_prefix}] Missing read limit for device {device}",
+                
+                );
+                continue;
+            }
+        };
+
+        let write_limit = match parts.next() {
+            Some("max") => f64::MAX,
+            Some(value) => if let Ok(value) = value.parse::<f64>() { value } else {
+                warn!(
+                    "[{metric_prefix}] Failed to parse write limit for device {device}: {value}",
+                    
+                );
+                continue;
+            },
+            None => {
+                warn!(
+                    "[{metric_prefix}] Missing write limit for device {device}",
+                    
+                );
+                continue;
+            }
+        };
+
+        let tags = labels
+            .iter()
+            .cloned()
+            .chain(std::iter::once(("device".to_string(), device.to_string())))
+            .collect::<Vec<_>>();
+
+        gauge!(format!("{metric_prefix}.read_limit"), &tags).set(read_limit);
+        gauge!(format!("{metric_prefix}.write_limit"), &tags).set(write_limit);
+
+    }
+}
+
+pub(crate) fn stat(content: &str, metric_prefix: &str, labels: &[(String, String)]) {
+    // Lines of the form
+    //
+    // <major>:<minor> key1=value1 key2=value2 ...
+    //
+    // All values are counters, u64. We add a label called "device" that is
+    // "<major>:<minor>".
+    for line in content.lines() {
+        let line = line.trim();
+        if line.is_empty() {
+            continue;
+        }
+
+        let mut parts = line.split_whitespace();
+        let Some(device) = parts.next() else {
+            continue; // skip invalid line
+        };
+
+        let tags = labels
+            .iter()
+            .cloned()
+            .chain(std::iter::once(("device".to_string(), device.to_string())))
+            .collect::<Vec<_>>();
+
+        for pair in parts {
+            let mut kv = pair.split('=');
+            let Some(key) = kv.next() else {
+                warn!(
+                    "[{metric_prefix}] Missing key in pair '{pair}' on device {device}",
+                );
+                continue;
+            };
+            let Some(value_str) = kv.next() else {
+                warn!(
+                    "[{metric_prefix}] Missing value in pair '{pair}' on device {device}",
+                );
+                continue;
+            };
+
+            let Ok(value) = value_str.parse::<u64>() else {
+                warn!(
+                    "[{metric_prefix}] Failed to parse value for key {key} on device {device}: {value_str}",
+                );
+                continue;
+            };
+        
+            counter!(format!("{metric_prefix}.{key}"),  &tags).absolute(value);
+        }
+    }
+}

--- a/lading/src/observer/linux/cgroup/v2/memory.rs
+++ b/lading/src/observer/linux/cgroup/v2/memory.rs
@@ -2,29 +2,8 @@
 //!
 //! Functions map to [Linux docs](https://www.kernel.org/doc/Documentation/cgroup-v2.txt).
 
-use std::str::FromStr;
-
 use metrics::{counter, gauge};
 use tracing::warn;
-
-/// Memory events
-///
-/// Metrics produced:
-///
-/// * <counter> `memory.events.low`: The number of times the cgroup is reclaimed
-///   due to high memory pressure even though its usage is under the low
-///   boundary.
-/// * <counter> `memory.events.high`: The number of times processes of the
-///   cgroup are throttled and routed to perform direct memory reclaim because
-///   the high memory boundary was exceeded.
-/// * <counter> `memory.events.max`: The number of times the cgroup's memory
-///   usage was about to go over the max boundary.
-/// * <counter> `memory.events.oom`: The number of time the cgroup's memory
-///   usage was reached the limit and allocation was about to fail.
-#[tracing::instrument(skip_all)]
-pub(crate) fn events(content: &str, metric_prefix: String, labels: &[(String, String)]) {
-    kv_counter(content, &metric_prefix, labels);
-}
 
 /// Memory stats
 ///
@@ -84,57 +63,6 @@ pub(crate) fn stat(content: &str, metric_prefix: &str, labels: &[(String, String
                 continue;
             };
             gauge!(format!("{metric_prefix}.{key}"), labels).set(value);
-        }
-    }
-}
-
-#[inline]
-#[tracing::instrument(skip_all)]
-pub(crate) fn single_value(content: &str, metric_prefix: String, labels: &[(String, String)]) {
-    // Content is a single-vaue file with an integer value.
-    if content == "max" {
-        gauge!(metric_prefix, labels).set(f64::MAX);
-    } else if let Ok(value) = content.parse::<f64>() {
-        gauge!(metric_prefix, labels).set(value);
-    } else {
-        warn!("[{metric_prefix}] Failed to parse: {content}");
-    }
-}
-
-pub(crate) fn kv_gauge(content: &str, metric_prefix: &str, labels: &[(String, String)]) {
-    kv::<_, f64>(content, metric_prefix, labels, |metric, labels, value| {
-        gauge!(metric, labels).set(value);
-    });
-}
-
-pub(crate) fn kv_counter(content: &str, metric_prefix: &str, labels: &[(String, String)]) {
-    kv::<_, u64>(content, metric_prefix, labels, |metric, labels, value| {
-        counter!(metric, labels).absolute(value);
-    });
-}
-
-fn kv<F, T>(content: &str, metric_prefix: &str, labels: &[(String, String)], f: F)
-where
-    F: Fn(String, &[(String, String)], T),
-    T: FromStr + num_traits::bounds::Bounded,
-{
-    for line in content.lines() {
-        let mut parts = line.split_whitespace();
-        if let Some(key) = parts.next() {
-            if let Some(value_str) = parts.next() {
-                let metric_name = format!("{metric_prefix}.{key}");
-                if content == "max" {
-                    f(metric_name, labels, T::max_value());
-                } else if let Ok(value) = value_str.parse::<T>() {
-                    f(metric_name, labels, value);
-                } else {
-                    warn!("[{metric_prefix}] Failed to parse {key}: {content}");
-                }
-            } else {
-                warn!("[{metric_prefix}] missing value in key/value pair, skipping");
-            }
-        } else {
-            warn!("[{metric_prefix}] missing value in key/value pair, skipping");
         }
     }
 }

--- a/lading/src/observer/linux/cgroup/v2/memory.rs
+++ b/lading/src/observer/linux/cgroup/v2/memory.rs
@@ -1,0 +1,148 @@
+//! Parser functions for memory cgroup v2.
+//!
+//! Functions map to https://www.kernel.org/doc/Documentation/cgroup-v2.txt.
+
+use std::str::FromStr;
+
+use metrics::{counter, gauge};
+use tracing::warn;
+
+use crate::observer::linux::cgroup::v2::parse_pressure;
+
+/// Memory events
+///
+/// Metrics produced:
+///
+/// * <counter> `memory.events.low`: The number of times the cgroup is reclaimed
+///   due to high memory pressure even though its usage is under the low
+///   boundary.
+/// * <counter> `memory.events.high`: The number of times processes of the
+///   cgroup are throttled and routed to perform direct memory reclaim because
+///   the high memory boundary was exceeded.
+/// * <counter> `memory.events.max`: The number of times the cgroup's memory
+///   usage was about to go over the max boundary.
+/// * <counter> `memory.events.oom`: The number of time the cgroup's memory
+///   usage was reached the limit and allocation was about to fail.
+#[tracing::instrument(skip_all)]
+pub(crate) fn events(content: &str, metric_prefix: String, labels: &[(String, String)]) {
+    kv_counter(content, &metric_prefix, labels);
+}
+
+/// Memory stats
+///
+/// Metrics produced vary by Linux kernel version.
+///
+/// All keys except the following are produced as gauges. What follows are
+/// counters:
+///
+/// * `pgfault`
+/// * `pgmajfault`
+/// * `workingset_refault`
+/// * `workingset_activate`
+/// * `workingset_nodereclaim`
+/// * `pgrefill`
+/// * `pgscan`
+/// * `pgsteal`
+/// * `pgactivate`
+/// * `pgdeactivate`
+/// * `pglazyfree`
+/// * `pglazyfreed`
+pub(crate) fn stat(content: &str, metric_prefix: String, labels: &[(String, String)]) {
+    let counter_keys = [
+        "pgfault",
+        "pgmajfault",
+        "workingset_refault",
+        "workingset_activate",
+        "workingset_nodereclaim",
+        "pgrefill",
+        "pgscan",
+        "pgsteal",
+        "pgactivate",
+        "pgdeactivate",
+        "pglazyfree",
+        "pglazyfreed",
+    ];
+
+    for line in content.lines() {
+        let mut parts = line.split_whitespace();
+        let key = match parts.next() {
+            Some(k) => k,
+            None => {
+                // empty line, skip it
+                continue;
+            }
+        };
+        let value_str = match parts.next() {
+            Some(v) => v,
+            None => {
+                warn!("[{metric_prefix}] missing value in key/value pair, skipping");
+                continue;
+            }
+        };
+
+        if counter_keys.contains(&key) {
+            let Ok(value) = value_str.parse::<u64>() else {
+                warn!("[{metric_prefix}] Failed to parse {key}: {content}");
+                continue;
+            };
+            counter!(format!("{metric_prefix}.{key}"), labels).absolute(value);
+        } else {
+            let Ok(value) = value_str.parse::<f64>() else {
+                warn!("[{metric_prefix}] Failed to parse {key}: {content}");
+                continue;
+            };
+            gauge!(format!("{metric_prefix}.{key}"), labels).set(value);
+        }
+    }
+}
+
+#[inline]
+#[tracing::instrument(skip_all)]
+pub(crate) fn single_value(content: &str, metric_prefix: String, labels: &[(String, String)]) {
+    // Content is a single-vaue file with an integer value.
+    if content == "max" {
+        gauge!(metric_prefix, labels).set(f64::MAX);
+    } else if let Ok(value) = content.parse::<f64>() {
+        gauge!(metric_prefix, labels).set(value);
+    } else {
+        warn!("[{metric_prefix}] Failed to parse: {content}");
+    }
+}
+
+pub(crate) fn kv_gauge(content: &str, metric_prefix: &str, labels: &[(String, String)]) {
+    kv::<_, f64>(content, metric_prefix, labels, |metric, labels, value| {
+        gauge!(metric, labels).set(value);
+    })
+}
+
+pub(crate) fn kv_counter(content: &str, metric_prefix: &str, labels: &[(String, String)]) {
+    kv::<_, u64>(content, metric_prefix, labels, |metric, labels, value| {
+        counter!(metric, labels).absolute(value);
+    })
+}
+
+fn kv<F, T>(content: &str, metric_prefix: &str, labels: &[(String, String)], f: F)
+where
+    F: Fn(String, &[(String, String)], T),
+    T: FromStr + num_traits::bounds::Bounded,
+{
+    for line in content.lines() {
+        let mut parts = line.split_whitespace();
+        if let Some(key) = parts.next() {
+            if let Some(value_str) = parts.next() {
+                let metric_name = format!("{metric_prefix}.{key}");
+                if content == "max" {
+                    f(metric_name, labels, T::max_value());
+                } else if let Ok(value) = value_str.parse::<T>() {
+                    f(metric_name, labels, value);
+                } else {
+                    warn!("[{metric_prefix}] Failed to parse {key}: {content}");
+                }
+            } else {
+                warn!("[{metric_prefix}] missing value in key/value pair, skipping");
+            }
+        } else {
+            warn!("[{metric_prefix}] missing value in key/value pair, skipping");
+        }
+    }
+}

--- a/lading/src/observer/linux/cgroup/v2/memory.rs
+++ b/lading/src/observer/linux/cgroup/v2/memory.rs
@@ -63,16 +63,11 @@ pub(crate) fn stat(content: &str, metric_prefix: &str, labels: &[(String, String
 
     for line in content.lines() {
         let mut parts = line.split_whitespace();
-        let key = match parts.next() {
-            Some(k) => k,
-            None => {
-                // empty line, skip it
-                continue;
-            }
+        let Some(key) = parts.next() else {
+            // empty line, skip it
+            continue;
         };
-        let value_str = if let Some(v) = parts.next() {
-            v
-        } else {
+        let Some(value_str) = parts.next() else {
             warn!("[{metric_prefix}] missing value in key/value pair, skipping");
             continue;
         };

--- a/lading/src/observer/linux/procfs/memory/smaps.rs
+++ b/lading/src/observer/linux/procfs/memory/smaps.rs
@@ -433,7 +433,7 @@ VmFlags:               rd ex mr mw me de sd";
         assert_eq!(region_one.file_pmd_mapped, Some(0));
         assert_eq!(region_one.shared_hugetlb, Some(0));
         assert_eq!(region_one.private_hugetlb, Some(0));
-        assert_eq!(region_one.swap_pss, Some(1 * BYTES_PER_KIBIBYTE));
+        assert_eq!(region_one.swap_pss, Some(BYTES_PER_KIBIBYTE));
         assert_eq!(region_one.locked, Some(0));
 
         let region_two = &regions.0[1];
@@ -492,9 +492,9 @@ VmFlags:               rd ex mr mw me de sd";
         let region_one = &regions.0[0];
 
         assert_eq!(region_one.pathname, "");
-        assert_eq!(region_one.size, 80000000 * BYTES_PER_KIBIBYTE);
-        assert_eq!(region_one.pss, 1 * BYTES_PER_KIBIBYTE);
-        assert_eq!(region_one.swap, 100000000000 * BYTES_PER_KIBIBYTE);
+        assert_eq!(region_one.size, 80_000_000 * BYTES_PER_KIBIBYTE);
+        assert_eq!(region_one.pss, BYTES_PER_KIBIBYTE);
+        assert_eq!(region_one.swap, 100_000_000_000 * BYTES_PER_KIBIBYTE);
         assert_eq!(region_one.rss, 0);
         assert_eq!(region_one.pss_dirty, Some(2 * BYTES_PER_KIBIBYTE));
         assert_eq!(region_one.shared_clean, Some(3 * BYTES_PER_KIBIBYTE));
@@ -510,13 +510,13 @@ VmFlags:               rd ex mr mw me de sd";
         assert_eq!(region_one.shared_hugetlb, Some(130 * BYTES_PER_KIBIBYTE));
         assert_eq!(
             region_one.private_hugetlb,
-            Some(140140140140 * BYTES_PER_KIBIBYTE)
+            Some(140_140_140_140 * BYTES_PER_KIBIBYTE)
         );
         assert_eq!(
             region_one.swap_pss,
-            Some(10000000000000000 * BYTES_PER_KIBIBYTE)
+            Some(10_000_000_000_000_000 * BYTES_PER_KIBIBYTE)
         );
-        assert_eq!(region_one.locked, Some(1000000000 * BYTES_PER_KIBIBYTE));
+        assert_eq!(region_one.locked, Some(1_000_000_000 * BYTES_PER_KIBIBYTE));
     }
 
     #[test]
@@ -553,9 +553,9 @@ VmFlags:               rd ex mr mw me de sd";
         let region_one = &regions.0[0];
 
         assert_eq!(region_one.pathname, "[stack]");
-        assert_eq!(region_one.size, 80000000 * BYTES_PER_KIBIBYTE);
-        assert_eq!(region_one.pss, 1 * BYTES_PER_KIBIBYTE);
-        assert_eq!(region_one.swap, 100000000000 * BYTES_PER_KIBIBYTE);
+        assert_eq!(region_one.size, 80_000_000 * BYTES_PER_KIBIBYTE);
+        assert_eq!(region_one.pss, BYTES_PER_KIBIBYTE);
+        assert_eq!(region_one.swap, 100_000_000_000 * BYTES_PER_KIBIBYTE);
         assert_eq!(region_one.rss, 0);
         assert_eq!(region_one.pss_dirty, None); // Still optional and missing
         assert_eq!(region_one.shared_clean, Some(3 * BYTES_PER_KIBIBYTE));
@@ -571,13 +571,13 @@ VmFlags:               rd ex mr mw me de sd";
         assert_eq!(region_one.shared_hugetlb, Some(130 * BYTES_PER_KIBIBYTE));
         assert_eq!(
             region_one.private_hugetlb,
-            Some(140140140140 * BYTES_PER_KIBIBYTE)
+            Some(140_140_140_140 * BYTES_PER_KIBIBYTE)
         );
         assert_eq!(
             region_one.swap_pss,
-            Some(10000000000000000 * BYTES_PER_KIBIBYTE)
+            Some(10_000_000_000_000_000 * BYTES_PER_KIBIBYTE)
         );
-        assert_eq!(region_one.locked, Some(1000000000 * BYTES_PER_KIBIBYTE));
+        assert_eq!(region_one.locked, Some(1_000_000_000 * BYTES_PER_KIBIBYTE));
     }
 
     #[test]

--- a/lading/src/target_metrics/prometheus.rs
+++ b/lading/src/target_metrics/prometheus.rs
@@ -541,7 +541,7 @@ mod tests {
         let snapshot = run_scrape_and_parse_metrics(GAUGE_LABEL_WITH_SPACES, tags).await;
 
         assert_eq!(snapshot.len(), 1);
-        dbg!(&snapshot);
+        &snapshot;
 
         let metric = snapshot
             .get(&CompositeKey::new(

--- a/lading/src/target_metrics/prometheus.rs
+++ b/lading/src/target_metrics/prometheus.rs
@@ -541,7 +541,6 @@ mod tests {
         let snapshot = run_scrape_and_parse_metrics(GAUGE_LABEL_WITH_SPACES, tags).await;
 
         assert_eq!(snapshot.len(), 1);
-        &snapshot;
 
         let metric = snapshot
             .get(&CompositeKey::new(


### PR DESCRIPTION
### What does this PR do?

This commit adjusts our Linux observer to record counter data from cgroup v2 as counters. We have found that some of our CPU data does not chart properly because it is recorded in lading as gauges. 

REF SMPTNG-608

