### PR TITLE
Fix process-tree generator

### DIFF
--- a/lading/src/bin/lading.rs
+++ b/lading/src/bin/lading.rs
@@ -139,7 +139,7 @@ impl FromStr for CliKeyValues {
 #[clap(group(
     ArgGroup::new("telemetry")
         .required(true)
-        .args(&["capture_path", "prometheus_addr", "prometheus_path"]),
+        .args(&["capture_path", "prometheus_addr", "prometheus_path", "no_capture"]),
 ))]
 #[clap(group(
      ArgGroup::new("experiment-duration")
@@ -196,6 +196,9 @@ struct Opts {
     /// capture-path
     #[clap(long)]
     prometheus_addr: Option<String>,
+    /// disable capture
+    #[clap(long)]
+    no_capture: bool,
     /// the maximum time to wait, in seconds, for controlled shutdown
     #[clap(long, default_value_t = 30)]
     max_shutdown_delay: u16,

--- a/lading/src/bin/lading.rs
+++ b/lading/src/bin/lading.rs
@@ -227,7 +227,7 @@ enum ExtraCommands {
 #[clap(group(
     ArgGroup::new("config")
         .required(true)
-        .args(&["config-path", "config-content"]),
+        .args(&["config_path", "config_content"]),
 ))]
 struct ProcessTreeGen {
     /// path on disk to the configuration file

--- a/lading/src/generator/process_tree.rs
+++ b/lading/src/generator/process_tree.rs
@@ -320,10 +320,9 @@ impl ProcessTree {
         loop {
             tokio::select! {
                 _ = self.throttle.wait() => {
-                    // Dummy --capture-path and --target-pid just to pass laging clap constraints
                     let output = Command::new(lading_path)
-                        .args(["--capture-path", "dummy"])
-                        .args(["--target-pid", "1"])
+                        .args(["--no-capture"])
+                        .args(["--no-target"])
                         .arg("process-tree-gen")
                         .arg("--config-content")
                         .arg(&self.config_content)

--- a/lading/src/generator/process_tree.rs
+++ b/lading/src/generator/process_tree.rs
@@ -320,8 +320,9 @@ impl ProcessTree {
         loop {
             tokio::select! {
                 _ = self.throttle.wait() => {
-                    // using pid as target pid just to pass laging clap constraints
+                    // Dummy --capture-path and --target-pid just to pass laging clap constraints
                     let output = Command::new(lading_path)
+                        .args(["--capture-path", "dummy"])
                         .args(["--target-pid", "1"])
                         .arg("process-tree-gen")
                         .arg("--config-content")


### PR DESCRIPTION
### What does this PR do?

Fix the following errors which occur when using the process_tree generator (for example, with examples/lading.yaml):

 ERROR lading: Generator shut down unexpectedly: Execution error: execution failed:
 Command process-tree-gen: Argument group 'config' contains non-existent argument 'config-path'

 ERROR lading::generator::process_tree: process tree generator execution error
 ERROR lading: Generator shut down unexpectedly: Execution error:
  execution failed: error: the following required arguments were not
  provided:
   <--capture-path <CAPTURE_PATH>|...>

### Motivation

Error found while running example.

### Related issues

### Additional Notes
