### PR TITLE
Fix CI formatting check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest]
+        tool: [check, fmt, clippy]
         include:
           - tool: check
             protobuf: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
             protobuf: true
             fuse: true
             components: "rustfmt"
-            command: cargo fmt --all -- --check --all-features
+            command: cargo fmt --all -- --check
           - tool: clippy
             protobuf: true
             fuse: true

--- a/integration/ducks/src/main.rs
+++ b/integration/ducks/src/main.rs
@@ -17,19 +17,18 @@ use anyhow::Context;
 use bytes::Bytes;
 use bytes::BytesMut;
 use http_body_util::Full;
-use http_body_util::{combinators::BoxBody, BodyExt};
-use hyper::{service::service_fn, Method, Request, StatusCode};
+use http_body_util::{BodyExt, combinators::BoxBody};
+use hyper::{Method, Request, StatusCode, service::service_fn};
 use hyper_util::rt::TokioExecutor;
 use hyper_util::rt::TokioIo;
 use hyper_util::server::conn::auto;
 use once_cell::sync::OnceCell;
 use shared::{
-    integration_api::{
-        self,
-        integration_target_server::{IntegrationTarget, IntegrationTargetServer},
-        Empty, HttpMetrics, ListenInfo, LogMessage, Metrics, SocketMetrics, TestConfig,
-    },
     DucksConfig,
+    integration_api::{
+        self, Empty, HttpMetrics, ListenInfo, LogMessage, Metrics, SocketMetrics, TestConfig,
+        integration_target_server::{IntegrationTarget, IntegrationTargetServer},
+    },
 };
 use sketches_ddsketch::DDSketch;
 use std::{collections::HashMap, net::SocketAddr, pin::Pin, sync::Arc, time::Duration};
@@ -37,9 +36,9 @@ use tokio::task::JoinSet;
 use tokio::{
     io::AsyncReadExt,
     net::{TcpListener, TcpStream, UdpSocket, UnixListener},
-    sync::{mpsc, Mutex},
+    sync::{Mutex, mpsc},
 };
-use tokio_stream::{wrappers::UnixListenerStream, Stream};
+use tokio_stream::{Stream, wrappers::UnixListenerStream};
 use tonic::Status;
 use tracing::error;
 use tracing::{debug, trace, warn};

--- a/integration/sheepdog/src/lib.rs
+++ b/integration/sheepdog/src/lib.rs
@@ -29,8 +29,8 @@ use std::{
 use anyhow::Context;
 use hyper_util::rt::TokioIo;
 use shared::{
-    integration_api::{self, integration_target_client::IntegrationTargetClient},
     DucksConfig,
+    integration_api::{self, integration_target_client::IntegrationTargetClient},
 };
 use tempfile::TempDir;
 use tokio::{net::UnixStream, process::Command};

--- a/lading/src/bin/captool.rs
+++ b/lading/src/bin/captool.rs
@@ -1,16 +1,16 @@
-use std::collections::{hash_map::RandomState, BTreeSet, HashMap};
+use std::collections::{BTreeSet, HashMap, hash_map::RandomState};
 use std::ffi::OsStr;
 use std::hash::BuildHasher;
 use std::hash::Hasher;
 
 use async_compression::tokio::bufread::ZstdDecoder;
-use average::{concatenate, Estimate, Max, Min, Variance};
+use average::{Estimate, Max, Min, Variance, concatenate};
 use clap::Parser;
 use futures::io;
 use lading_capture::json::{Line, MetricKind};
 use tokio::io::{AsyncBufReadExt, BufReader};
-use tokio_stream::wrappers::LinesStream;
 use tokio_stream::StreamExt;
+use tokio_stream::wrappers::LinesStream;
 use tracing::{error, info};
 use tracing_subscriber::{fmt::format::FmtSpan, util::SubscriberInitExt};
 

--- a/lading/src/bin/lading.rs
+++ b/lading/src/bin/lading.rs
@@ -20,17 +20,17 @@ use lading::{
 use metrics::gauge;
 use metrics_exporter_prometheus::PrometheusBuilder;
 use once_cell::sync::Lazy;
-use rand::{rngs::StdRng, SeedableRng};
+use rand::{SeedableRng, rngs::StdRng};
 use regex::Regex;
 use rustc_hash::FxHashMap;
 use tokio::{
     runtime::Builder,
     signal,
     sync::broadcast,
-    time::{self, sleep, Duration},
+    time::{self, Duration, sleep},
 };
-use tracing::{debug, error, info, info_span, warn, Instrument};
-use tracing_subscriber::{util::SubscriberInitExt, EnvFilter};
+use tracing::{Instrument, debug, error, info, info_span, warn};
+use tracing_subscriber::{EnvFilter, util::SubscriberInitExt};
 
 #[derive(thiserror::Error, Debug)]
 enum Error {

--- a/lading/src/bin/payloadtool.rs
+++ b/lading/src/bin/payloadtool.rs
@@ -5,7 +5,7 @@ use std::{io, num::NonZeroU32};
 use clap::Parser;
 use lading::generator::http::Method;
 use lading_payload::block;
-use rand::{rngs::StdRng, SeedableRng};
+use rand::{SeedableRng, rngs::StdRng};
 use tracing::{debug, error, info, warn};
 use tracing_subscriber::{fmt::format::FmtSpan, util::SubscriberInitExt};
 
@@ -64,7 +64,9 @@ fn generate_and_check(
         let total_generated_bytes_str = total_generated_bytes
             .get_appropriate_unit(false)
             .to_string();
-        warn!("Generator failed to generate {total_requested_bytes_str}, instead only found {total_generated_bytes_str} of data")
+        warn!(
+            "Generator failed to generate {total_requested_bytes_str}, instead only found {total_generated_bytes_str} of data"
+        )
     }
 
     Ok(())

--- a/lading/src/blackhole/common.rs
+++ b/lading/src/blackhole/common.rs
@@ -43,7 +43,6 @@ where
             Error = hyper::Error,
         > + Send
         + 'static,
-
     S::Future: Send + 'static,
 {
     let listener = TcpListener::bind(addr).await.map_err(Error::Io)?;

--- a/lading/src/blackhole/http.rs
+++ b/lading/src/blackhole/http.rs
@@ -7,9 +7,9 @@
 //!
 
 use bytes::Bytes;
-use http::{header::InvalidHeaderValue, status::InvalidStatusCode, HeaderMap};
-use http_body_util::{combinators::BoxBody, BodyExt};
-use hyper::{header, Request, Response, StatusCode};
+use http::{HeaderMap, header::InvalidHeaderValue, status::InvalidStatusCode};
+use http_body_util::{BodyExt, combinators::BoxBody};
+use hyper::{Request, Response, StatusCode, header};
 use metrics::counter;
 use serde::{Deserialize, Serialize};
 use std::{net::SocketAddr, time::Duration};

--- a/lading/src/blackhole/splunk_hec.rs
+++ b/lading/src/blackhole/splunk_hec.rs
@@ -12,8 +12,8 @@ use std::{
 };
 
 use bytes::Bytes;
-use http_body_util::{combinators::BoxBody, BodyExt};
-use hyper::{header, Method, Request, Response, StatusCode};
+use http_body_util::{BodyExt, combinators::BoxBody};
+use hyper::{Method, Request, Response, StatusCode, header};
 use metrics::counter;
 use rustc_hash::FxHashMap;
 use serde::{Deserialize, Serialize};

--- a/lading/src/codec.rs
+++ b/lading/src/codec.rs
@@ -65,7 +65,7 @@ pub(crate) fn decode(
                         .body(crate::full(format!(
                             "Unsupported encoding type: {encoding}"
                         )))
-                        .expect("failed to build response"))
+                        .expect("failed to build response"));
                 }
             }
         }

--- a/lading/src/generator.rs
+++ b/lading/src/generator.rs
@@ -180,7 +180,9 @@ impl Server {
             Inner::UnixStream(conf) => {
                 if let lading_payload::Config::DogStatsD(variant) = conf.variant {
                     if !variant.length_prefix_framed {
-                        warn!("Dogstatsd stream requires length prefix framing. You likely want to add `length_prefix_framed: true` to your payload config.");
+                        warn!(
+                            "Dogstatsd stream requires length prefix framing. You likely want to add `length_prefix_framed: true` to your payload config."
+                        );
                     }
                 }
 

--- a/lading/src/generator/file_gen/logrotate_fs.rs
+++ b/lading/src/generator/file_gen/logrotate_fs.rs
@@ -6,13 +6,13 @@
 
 use crate::generator;
 use fuser::{
-    spawn_mount2, BackgroundSession, FileAttr, Filesystem, MountOption, ReplyAttr, ReplyData,
-    ReplyDirectory, ReplyEntry, Request,
+    BackgroundSession, FileAttr, Filesystem, MountOption, ReplyAttr, ReplyData, ReplyDirectory,
+    ReplyEntry, Request, spawn_mount2,
 };
 use lading_payload::block;
 use metrics::counter;
 use nix::libc::{self, ENOENT};
-use rand::{rngs::SmallRng, SeedableRng};
+use rand::{SeedableRng, rngs::SmallRng};
 use serde::{Deserialize, Serialize};
 use std::{
     collections::HashMap,

--- a/lading/src/generator/file_gen/traditional.rs
+++ b/lading/src/generator/file_gen/traditional.rs
@@ -17,8 +17,8 @@ use std::{
     num::NonZeroU32,
     path::PathBuf,
     sync::{
-        atomic::{AtomicU32, Ordering},
         Arc,
+        atomic::{AtomicU32, Ordering},
     },
     thread,
 };
@@ -27,7 +27,7 @@ use byte_unit::{Byte, ByteError};
 use futures::future::join_all;
 use lading_throttle::Throttle;
 use metrics::{counter, gauge};
-use rand::{prelude::StdRng, SeedableRng};
+use rand::{SeedableRng, prelude::StdRng};
 use serde::{Deserialize, Serialize};
 use tokio::{
     fs,

--- a/lading/src/generator/grpc.rs
+++ b/lading/src/generator/grpc.rs
@@ -16,16 +16,16 @@ use std::{convert::TryFrom, num::NonZeroU32, thread, time::Duration};
 
 use byte_unit::ByteError;
 use bytes::{Buf, BufMut, Bytes};
-use http::{uri::PathAndQuery, Uri};
+use http::{Uri, uri::PathAndQuery};
 use lading_throttle::Throttle;
 use metrics::{counter, gauge};
-use rand::rngs::StdRng;
 use rand::SeedableRng;
+use rand::rngs::StdRng;
 use serde::{Deserialize, Serialize};
 use tokio::sync::mpsc;
 use tonic::{
-    codec::{DecodeBuf, Decoder, EncodeBuf, Encoder},
     Request, Response, Status,
+    codec::{DecodeBuf, Decoder, EncodeBuf, Encoder},
 };
 use tracing::{debug, info};
 

--- a/lading/src/generator/http.rs
+++ b/lading/src/generator/http.rs
@@ -14,14 +14,14 @@
 use std::{num::NonZeroU32, thread};
 
 use byte_unit::ByteError;
-use hyper::{header::CONTENT_LENGTH, HeaderMap, Request, Uri};
+use hyper::{HeaderMap, Request, Uri, header::CONTENT_LENGTH};
 use hyper_util::{client::legacy::Client, rt::TokioExecutor};
 use lading_throttle::Throttle;
 use metrics::{counter, gauge};
 use once_cell::sync::OnceCell;
-use rand::{prelude::StdRng, SeedableRng};
+use rand::{SeedableRng, prelude::StdRng};
 use serde::{Deserialize, Serialize};
-use tokio::sync::{mpsc, Semaphore};
+use tokio::sync::{Semaphore, mpsc};
 use tracing::info;
 
 use crate::common::PeekableReceiver;

--- a/lading/src/generator/passthru_file.rs
+++ b/lading/src/generator/passthru_file.rs
@@ -16,7 +16,7 @@ use tokio::io::AsyncWriteExt;
 use byte_unit::ByteError;
 use lading_throttle::Throttle;
 use metrics::{counter, gauge};
-use rand::{rngs::StdRng, SeedableRng};
+use rand::{SeedableRng, rngs::StdRng};
 use serde::{Deserialize, Serialize};
 use tokio::sync::mpsc;
 use tracing::{info, warn};

--- a/lading/src/generator/process_tree.rs
+++ b/lading/src/generator/process_tree.rs
@@ -483,7 +483,8 @@ fn try_wait_pid(pids: &mut FxHashSet<Pid>) {
     let mut exited: Option<Pid> = None;
 
     for pid in pids.iter() {
-        if let Ok(WaitStatus::StillAlive) = waitpid(*pid, Some(WaitPidFlag::WNOHANG)) {} else {
+        if let Ok(WaitStatus::StillAlive) = waitpid(*pid, Some(WaitPidFlag::WNOHANG)) {
+        } else {
             exited = Some(*pid);
             break;
         }

--- a/lading/src/generator/procfs.rs
+++ b/lading/src/generator/procfs.rs
@@ -13,8 +13,8 @@ use std::str::FromStr;
 use std::{fs::File, io::Write, num::NonZeroU32, path::PathBuf};
 
 use lading_payload::procfs;
-use rand::rngs::StdRng;
 use rand::SeedableRng;
+use rand::rngs::StdRng;
 use serde::{Deserialize, Serialize};
 
 #[derive(::thiserror::Error, Debug)]

--- a/lading/src/generator/splunk_hec.rs
+++ b/lading/src/generator/splunk_hec.rs
@@ -21,22 +21,22 @@ use std::{future::ready, num::NonZeroU32, thread, time::Duration};
 use acknowledgements::Channels;
 use byte_unit::ByteError;
 use http::{
-    header::{AUTHORIZATION, CONTENT_LENGTH},
     Method, Request, Uri,
+    header::{AUTHORIZATION, CONTENT_LENGTH},
 };
 use http_body_util::BodyExt;
 use hyper::body::Body;
 use hyper_util::{
-    client::legacy::{connect::HttpConnector, Client},
+    client::legacy::{Client, connect::HttpConnector},
     rt::TokioExecutor,
 };
 use lading_throttle::Throttle;
 use metrics::{counter, gauge};
 use once_cell::sync::OnceCell;
-use rand::{prelude::StdRng, SeedableRng};
+use rand::{SeedableRng, prelude::StdRng};
 use serde::{Deserialize, Serialize};
 use tokio::{
-    sync::{mpsc, Semaphore, SemaphorePermit},
+    sync::{Semaphore, SemaphorePermit, mpsc},
     time::timeout,
 };
 use tracing::info;

--- a/lading/src/generator/tcp.rs
+++ b/lading/src/generator/tcp.rs
@@ -20,7 +20,7 @@ use std::{
 use byte_unit::ByteError;
 use lading_throttle::Throttle;
 use metrics::{counter, gauge};
-use rand::{rngs::StdRng, SeedableRng};
+use rand::{SeedableRng, rngs::StdRng};
 use serde::{Deserialize, Serialize};
 use tokio::{io::AsyncWriteExt, net::TcpStream, sync::mpsc};
 use tracing::{info, trace};

--- a/lading/src/generator/udp.rs
+++ b/lading/src/generator/udp.rs
@@ -21,7 +21,7 @@ use std::{
 use byte_unit::{Byte, ByteError, ByteUnit};
 use lading_throttle::Throttle;
 use metrics::{counter, gauge};
-use rand::{rngs::StdRng, SeedableRng};
+use rand::{SeedableRng, rngs::StdRng};
 use serde::{Deserialize, Serialize};
 use tokio::{net::UdpSocket, sync::mpsc};
 use tracing::{debug, info, trace};

--- a/lading/src/generator/unix_datagram.rs
+++ b/lading/src/generator/unix_datagram.rs
@@ -17,7 +17,7 @@ use futures::future::join_all;
 use lading_payload::block::{self, Block};
 use lading_throttle::Throttle;
 use metrics::{counter, gauge};
-use rand::{rngs::StdRng, SeedableRng};
+use rand::{SeedableRng, rngs::StdRng};
 use serde::{Deserialize, Serialize};
 use std::{num::NonZeroU32, path::PathBuf, thread};
 use tokio::{

--- a/lading/src/generator/unix_stream.rs
+++ b/lading/src/generator/unix_stream.rs
@@ -16,7 +16,7 @@ use byte_unit::ByteError;
 use lading_payload::block::{self, Block};
 use lading_throttle::Throttle;
 use metrics::{counter, gauge};
-use rand::{rngs::StdRng, SeedableRng};
+use rand::{SeedableRng, rngs::StdRng};
 use serde::{Deserialize, Serialize};
 use std::{num::NonZeroU32, path::PathBuf, thread};
 use tokio::{net, sync::mpsc, task::JoinError};

--- a/lading/src/inspector.rs
+++ b/lading/src/inspector.rs
@@ -16,7 +16,7 @@ use std::{
 
 use nix::{
     errno::Errno,
-    sys::signal::{kill, SIGTERM},
+    sys::signal::{SIGTERM, kill},
     unistd::Pid,
 };
 use rustc_hash::FxHashMap;
@@ -25,7 +25,7 @@ use tokio::process::Command;
 use tracing::{error, info};
 
 use crate::{
-    common::{stdio, Output},
+    common::{Output, stdio},
     target::TargetPidReceiver,
 };
 

--- a/lading/src/observer/linux/cgroup/v2/io.rs
+++ b/lading/src/observer/linux/cgroup/v2/io.rs
@@ -23,36 +23,36 @@ pub(crate) fn max(content: &str, metric_prefix: &str, labels: &[(String, String)
 
         let read_limit = match parts.next() {
             Some("max") => f64::MAX,
-            Some(value) => if let Ok(value) = value.parse::<f64>() { value } else {
-                warn!(
-                    "[{metric_prefix}] Failed to parse read limit for device {device}: {value}",
-                
-                );
-                continue;
-            },
+            Some(value) => {
+                if let Ok(value) = value.parse::<f64>() {
+                    value
+                } else {
+                    warn!(
+                        "[{metric_prefix}] Failed to parse read limit for device {device}: {value}",
+                    );
+                    continue;
+                }
+            }
             None => {
-                warn!(
-                    "[{metric_prefix}] Missing read limit for device {device}",
-                
-                );
+                warn!("[{metric_prefix}] Missing read limit for device {device}",);
                 continue;
             }
         };
 
         let write_limit = match parts.next() {
             Some("max") => f64::MAX,
-            Some(value) => if let Ok(value) = value.parse::<f64>() { value } else {
-                warn!(
-                    "[{metric_prefix}] Failed to parse write limit for device {device}: {value}",
-                    
-                );
-                continue;
-            },
+            Some(value) => {
+                if let Ok(value) = value.parse::<f64>() {
+                    value
+                } else {
+                    warn!(
+                        "[{metric_prefix}] Failed to parse write limit for device {device}: {value}",
+                    );
+                    continue;
+                }
+            }
             None => {
-                warn!(
-                    "[{metric_prefix}] Missing write limit for device {device}",
-                    
-                );
+                warn!("[{metric_prefix}] Missing write limit for device {device}",);
                 continue;
             }
         };
@@ -65,7 +65,6 @@ pub(crate) fn max(content: &str, metric_prefix: &str, labels: &[(String, String)
 
         gauge!(format!("{metric_prefix}.read_limit"), &tags).set(read_limit);
         gauge!(format!("{metric_prefix}.write_limit"), &tags).set(write_limit);
-
     }
 }
 
@@ -96,15 +95,11 @@ pub(crate) fn stat(content: &str, metric_prefix: &str, labels: &[(String, String
         for pair in parts {
             let mut kv = pair.split('=');
             let Some(key) = kv.next() else {
-                warn!(
-                    "[{metric_prefix}] Missing key in pair '{pair}' on device {device}",
-                );
+                warn!("[{metric_prefix}] Missing key in pair '{pair}' on device {device}",);
                 continue;
             };
             let Some(value_str) = kv.next() else {
-                warn!(
-                    "[{metric_prefix}] Missing value in pair '{pair}' on device {device}",
-                );
+                warn!("[{metric_prefix}] Missing value in pair '{pair}' on device {device}",);
                 continue;
             };
 
@@ -114,8 +109,8 @@ pub(crate) fn stat(content: &str, metric_prefix: &str, labels: &[(String, String
                 );
                 continue;
             };
-        
-            counter!(format!("{metric_prefix}.{key}"),  &tags).absolute(value);
+
+            counter!(format!("{metric_prefix}.{key}"), &tags).absolute(value);
         }
     }
 }

--- a/lading/src/observer/linux/procfs.rs
+++ b/lading/src/observer/linux/procfs.rs
@@ -4,7 +4,7 @@ mod stat;
 mod uptime;
 
 use std::{
-    collections::{hash_map::Entry, VecDeque},
+    collections::{VecDeque, hash_map::Entry},
     io,
 };
 

--- a/lading/src/observer/linux/procfs/memory/smaps.rs
+++ b/lading/src/observer/linux/procfs/memory/smaps.rs
@@ -641,9 +641,9 @@ VmFlags:               rd wr mr mw me ac";
 
         let region = Region::from_str(region).expect("Parsing failed");
         assert_eq!(
-        region.pathname,
-        "/opt/datadog-agent/embedded/lib/python3.9/site-packages/pydantic_core/_pydantic_core.cpython-39-aarch64-linux-gnu.so"
-    );
+            region.pathname,
+            "/opt/datadog-agent/embedded/lib/python3.9/site-packages/pydantic_core/_pydantic_core.cpython-39-aarch64-linux-gnu.so"
+        );
         assert_eq!(region.size, 20 * BYTES_PER_KIBIBYTE);
         assert_eq!(region.private_dirty.unwrap(), 20 * BYTES_PER_KIBIBYTE);
     }

--- a/lading/src/observer/linux/procfs/memory/smaps_rollup.rs
+++ b/lading/src/observer/linux/procfs/memory/smaps_rollup.rs
@@ -2,7 +2,7 @@ use heck::ToSnakeCase;
 use metrics::gauge;
 use tokio::fs;
 
-use super::{next_token, BYTES_PER_KIBIBYTE};
+use super::{BYTES_PER_KIBIBYTE, next_token};
 
 #[derive(thiserror::Error, Debug)]
 /// Errors produced by functions in this module
@@ -35,8 +35,8 @@ pub(crate) async fn poll(
     let mut lines = contents.lines();
 
     lines.next(); // skip header, doesn't have any useful information
-                  // looks like this:
-                  // 00400000-7fff03d61000 ---p 00000000 00:00 0                              [rollup]
+    // looks like this:
+    // 00400000-7fff03d61000 ---p 00000000 00:00 0                              [rollup]
 
     for line in lines {
         let mut chars = line.char_indices().peekable();

--- a/lading/src/target.rs
+++ b/lading/src/target.rs
@@ -28,7 +28,7 @@ use lading_signal::Broadcaster;
 use metrics::gauge;
 use nix::{
     errno::Errno,
-    sys::signal::{kill, SIGTERM},
+    sys::signal::{SIGTERM, kill},
     unistd::Pid,
 };
 use rustc_hash::FxHashMap;

--- a/lading_payload/benches/apache_common.rs
+++ b/lading_payload/benches/apache_common.rs
@@ -1,7 +1,7 @@
-use criterion::{criterion_group, BenchmarkId, Criterion, Throughput};
+use criterion::{BenchmarkId, Criterion, Throughput, criterion_group};
 
-use lading_payload::{apache_common, Serialize};
-use rand::{rngs::SmallRng, SeedableRng};
+use lading_payload::{Serialize, apache_common};
+use rand::{SeedableRng, rngs::SmallRng};
 use std::time::Duration;
 
 fn apache_common_setup(c: &mut Criterion) {

--- a/lading_payload/benches/ascii.rs
+++ b/lading_payload/benches/ascii.rs
@@ -1,7 +1,7 @@
-use criterion::{criterion_group, BenchmarkId, Criterion, Throughput};
+use criterion::{BenchmarkId, Criterion, Throughput, criterion_group};
 
-use lading_payload::{ascii, Serialize};
-use rand::{rngs::SmallRng, SeedableRng};
+use lading_payload::{Serialize, ascii};
+use rand::{SeedableRng, rngs::SmallRng};
 use std::time::Duration;
 
 fn ascii_setup(c: &mut Criterion) {

--- a/lading_payload/benches/dogstatsd.rs
+++ b/lading_payload/benches/dogstatsd.rs
@@ -1,7 +1,7 @@
-use criterion::{criterion_group, BenchmarkId, Criterion, Throughput};
+use criterion::{BenchmarkId, Criterion, Throughput, criterion_group};
 
-use lading_payload::{dogstatsd, Serialize};
-use rand::{rngs::SmallRng, SeedableRng};
+use lading_payload::{Serialize, dogstatsd};
+use rand::{SeedableRng, rngs::SmallRng};
 use std::time::Duration;
 
 fn dogstatsd_setup(c: &mut Criterion) {

--- a/lading_payload/benches/fluent.rs
+++ b/lading_payload/benches/fluent.rs
@@ -1,7 +1,7 @@
-use criterion::{criterion_group, BenchmarkId, Criterion, Throughput};
+use criterion::{BenchmarkId, Criterion, Throughput, criterion_group};
 
 use lading_payload::{Fluent, Serialize};
-use rand::{rngs::SmallRng, SeedableRng};
+use rand::{SeedableRng, rngs::SmallRng};
 use std::time::Duration;
 
 fn fluent_setup(c: &mut Criterion) {

--- a/lading_payload/benches/opentelemetry_log.rs
+++ b/lading_payload/benches/opentelemetry_log.rs
@@ -1,7 +1,7 @@
-use criterion::{criterion_group, BenchmarkId, Criterion, Throughput};
+use criterion::{BenchmarkId, Criterion, Throughput, criterion_group};
 
 use lading_payload::{OpentelemetryLogs, Serialize};
-use rand::{rngs::SmallRng, SeedableRng};
+use rand::{SeedableRng, rngs::SmallRng};
 use std::time::Duration;
 
 fn opentelemetry_log_setup(c: &mut Criterion) {

--- a/lading_payload/benches/opentelemetry_metric.rs
+++ b/lading_payload/benches/opentelemetry_metric.rs
@@ -1,7 +1,7 @@
-use criterion::{criterion_group, BenchmarkId, Criterion, Throughput};
+use criterion::{BenchmarkId, Criterion, Throughput, criterion_group};
 
 use lading_payload::{OpentelemetryMetrics, Serialize};
-use rand::{rngs::SmallRng, SeedableRng};
+use rand::{SeedableRng, rngs::SmallRng};
 use std::time::Duration;
 
 fn opentelemetry_metric_setup(c: &mut Criterion) {

--- a/lading_payload/benches/opentelemetry_traces.rs
+++ b/lading_payload/benches/opentelemetry_traces.rs
@@ -1,7 +1,7 @@
-use criterion::{criterion_group, BenchmarkId, Criterion, Throughput};
+use criterion::{BenchmarkId, Criterion, Throughput, criterion_group};
 
 use lading_payload::{OpentelemetryTraces, Serialize};
-use rand::{rngs::SmallRng, SeedableRng};
+use rand::{SeedableRng, rngs::SmallRng};
 use std::time::Duration;
 
 fn opentelemetry_traces_setup(c: &mut Criterion) {

--- a/lading_payload/benches/trace_agent.rs
+++ b/lading_payload/benches/trace_agent.rs
@@ -1,7 +1,7 @@
-use criterion::{criterion_group, BenchmarkId, Criterion, Throughput};
+use criterion::{BenchmarkId, Criterion, Throughput, criterion_group};
 
-use lading_payload::{trace_agent, Serialize};
-use rand::{rngs::SmallRng, SeedableRng};
+use lading_payload::{Serialize, trace_agent};
+use rand::{SeedableRng, rngs::SmallRng};
 use std::time::Duration;
 
 fn trace_agent_setup(c: &mut Criterion) {

--- a/lading_payload/src/opentelemetry_log.rs
+++ b/lading_payload/src/opentelemetry_log.rs
@@ -7,9 +7,9 @@
 //! experimental JSON OTLP/HTTP format can also be supported but is not
 //! currently implemented.
 
-use crate::{common::strings, Error};
+use crate::{Error, common::strings};
 use opentelemetry_proto::tonic::{
-    common::v1::{any_value, AnyValue},
+    common::v1::{AnyValue, any_value},
     logs::v1,
 };
 use prost::Message;
@@ -134,7 +134,7 @@ mod test {
     use crate::Serialize;
     use proptest::prelude::*;
     use prost::Message;
-    use rand::{rngs::SmallRng, SeedableRng};
+    use rand::{SeedableRng, rngs::SmallRng};
 
     // We want to be sure that the serialized size of the payload does not
     // exceed `max_bytes`.

--- a/lading_payload/src/statik.rs
+++ b/lading_payload/src/statik.rs
@@ -6,7 +6,7 @@ use std::{
     path::{Path, PathBuf},
 };
 
-use rand::{prelude::IteratorRandom, Rng};
+use rand::{Rng, prelude::IteratorRandom};
 use tracing::debug;
 
 #[derive(Debug)]

--- a/lading_signal/src/lib.rs
+++ b/lading_signal/src/lib.rs
@@ -15,17 +15,17 @@
 
 #[cfg(not(loom))]
 use std::sync::{
-    atomic::{AtomicU32, Ordering},
     Arc,
+    atomic::{AtomicU32, Ordering},
 };
 
 #[cfg(loom)]
 use loom::sync::{
-    atomic::{AtomicU32, Ordering},
     Arc,
+    atomic::{AtomicU32, Ordering},
 };
 
-use tokio::sync::{broadcast, Notify};
+use tokio::sync::{Notify, broadcast};
 use tracing::info;
 
 /// Construct a `Watcher` and `Broadcaster` pair.

--- a/lading_throttle/src/stable.rs
+++ b/lading_throttle/src/stable.rs
@@ -140,7 +140,7 @@ impl Valve {
 
 #[cfg(kani)]
 mod verification {
-    use crate::stable::{Valve, INTERVAL_TICKS};
+    use crate::stable::{INTERVAL_TICKS, Valve};
     use std::num::NonZeroU32;
 
     /// Capacity requests that are too large always error.


### PR DESCRIPTION
### What does this PR do?

The `cargo fmt` check doesn't run in CI and a lot of the files are not formatted correctly.  The PR makes the check run and does an automatic format of all files to make the check pass.

### Motivation
### Related issues
### Additional Notes

The branch protection rules need to be changed since the name of the job has changed.
