### PR TITLE
procfs: Assume all cores for max

### DIFF
--- a/lading/src/observer/linux/procfs/stat.rs
+++ b/lading/src/observer/linux/procfs/stat.rs
@@ -63,9 +63,9 @@ impl Sampler {
         let parts: Vec<&str> = cpu_max.split_whitespace().collect();
         let (max_str, period_str) = (parts[0], parts[1]);
         let allowed_cores = if max_str == "max" {
-            // If the target cgroup has no CPU limit we assume it has access to all
-            // physical cores.
-            num_cpus::get_physical() as f64
+            // If the target cgroup has no CPU limit we assume it has access to
+            // all cores.
+            num_cpus::get() as f64
         } else {
             let max_val = max_str.parse::<f64>()?;
             let period_val = period_str.parse::<f64>()?;


### PR DESCRIPTION


### What does this PR do?

If there are no limits in `cpu.max`, assume all cores instead of just physical cores.  This results in values that match other tools like top (with Irix mode off).

### Motivation

Noticed while evaluating lading.

### Related issues



### Additional Notes

