### PR TITLE
Remove labels from `bytes_received` and `bytes_written`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ## Fixed
-- Component name labels have been removed from the `bytes_received` metric to
-  fix egress throughput optimization goal analysis.
+- Labels have been removed from the `bytes_received` and `bytes_written` metrics
+   to fix some scenarios where they could break optimization goal analysis.
 ## Changed
 - Lading now built with edition 2024
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## Fixed
+- Component name labels have been removed from the `bytes_received` metric to
+  fix egress throughput optimization goal analysis.
 ## Changed
 - Lading now built with edition 2024
 

--- a/lading/src/blackhole/http.rs
+++ b/lading/src/blackhole/http.rs
@@ -138,7 +138,9 @@ async fn srv(
     // Convert the `Body` into `Bytes`
     let body: Bytes = body.boxed().collect().await?.to_bytes();
 
-    counter!("bytes_received", &metric_labels).increment(body.len() as u64);
+    // This metric must be written with a single context or it will crash
+    // analysis. The simple way to accomplish that is to attach no labels to it.
+    counter!("bytes_received").increment(body.len() as u64);
 
     match crate::codec::decode(parts.headers.get(hyper::header::CONTENT_ENCODING), body) {
         Err(response) => Ok(response),

--- a/lading/src/blackhole/splunk_hec.rs
+++ b/lading/src/blackhole/splunk_hec.rs
@@ -92,7 +92,10 @@ async fn srv(
 
     let (parts, body) = req.into_parts();
     let bytes = body.boxed().collect().await?.to_bytes();
-    counter!("bytes_received", &*labels).increment(bytes.len() as u64);
+
+    // This metric must be written with a single context or it will crash
+    // analysis. The simple way to accomplish that is to attach no labels to it.
+    counter!("bytes_received").increment(bytes.len() as u64);
 
     match crate::codec::decode(parts.headers.get(hyper::header::CONTENT_ENCODING), bytes) {
         Err(response) => Ok(response),

--- a/lading/src/blackhole/sqs.rs
+++ b/lading/src/blackhole/sqs.rs
@@ -225,7 +225,10 @@ async fn srv(
 
     let (_, body) = req.into_parts();
     let bytes = body.boxed().collect().await?.to_bytes();
-    counter!("bytes_received", &metric_labels).increment(bytes.len() as u64);
+
+    // This metric must be written with a single context or it will crash
+    // analysis. The simple way to accomplish that is to attach no labels to it.
+    counter!("bytes_received").increment(bytes.len() as u64);
 
     let action = match serde_qs::from_bytes::<Action>(&bytes) {
         Ok(a) => a,

--- a/lading/src/blackhole/tcp.rs
+++ b/lading/src/blackhole/tcp.rs
@@ -67,7 +67,10 @@ impl Tcp {
         while let Some(msg) = stream.next().await {
             counter!("message_received", labels).increment(1);
             if let Ok(msg) = msg {
-                counter!("bytes_received", labels).increment(msg.len() as u64);
+                // This metric must be written with a single context or it will
+                // crash analysis. The simple way to accomplish that is to
+                // attach no labels to it.
+                counter!("bytes_received").increment(msg.len() as u64);
             }
         }
     }

--- a/lading/src/blackhole/udp.rs
+++ b/lading/src/blackhole/udp.rs
@@ -84,7 +84,11 @@ impl Udp {
                 packet = socket.recv_from(&mut buf) => {
                     let (bytes, _) = packet.map_err(Error::Io)?;
                     counter!("packet_received", &self.metric_labels).increment(1);
-                    counter!("bytes_received", &self.metric_labels).increment(bytes as u64);
+
+                    // This metric must be written with a single context or it
+                    // will crash analysis. The simple way to accomplish that is
+                    // to attach no labels to it.
+                    counter!("bytes_received").increment(bytes as u64);
                 }
                 () = &mut shutdown_wait => {
                     info!("shutdown signal received");

--- a/lading/src/blackhole/unix_datagram.rs
+++ b/lading/src/blackhole/unix_datagram.rs
@@ -83,7 +83,10 @@ impl UnixDatagram {
             tokio::select! {
                 res = socket.recv(&mut buf) => {
                     let n: usize = res.map_err(Error::Io)?;
-                    counter!("bytes_received", &self.metric_labels).increment(n as u64);
+                    // This metric must be written with a single context or it
+                    // will crash analysis. The simple way to accomplish that is
+                    // to attach no labels to it.
+                    counter!("bytes_received").increment(n as u64);
                 }
                 () = &mut shutdown_wait => {
                     info!("shutdown signal received");

--- a/lading/src/blackhole/unix_datagram.rs
+++ b/lading/src/blackhole/unix_datagram.rs
@@ -36,7 +36,7 @@ pub struct Config {
 pub struct UnixDatagram {
     path: PathBuf,
     shutdown: lading_signal::Watcher,
-    metric_labels: Vec<(String, String)>,
+    _metric_labels: Vec<(String, String)>,
 }
 
 impl UnixDatagram {
@@ -54,7 +54,7 @@ impl UnixDatagram {
         Self {
             path: config.path,
             shutdown,
-            metric_labels,
+            _metric_labels: metric_labels,
         }
     }
 

--- a/lading/src/blackhole/unix_stream.rs
+++ b/lading/src/blackhole/unix_stream.rs
@@ -103,7 +103,10 @@ impl UnixStream {
         while let Some(msg) = stream.next().await {
             counter!("message_received", labels).increment(1);
             if let Ok(msg) = msg {
-                counter!("bytes_received", labels).increment(msg.len() as u64);
+                // This metric must be written with a single context or it will
+                // crash analysis. The simple way to accomplish that is to
+                // attach no labels to it.
+                counter!("bytes_received").increment(msg.len() as u64);
             }
         }
     }

--- a/lading/src/generator/file_gen/logrotate.rs
+++ b/lading/src/generator/file_gen/logrotate.rs
@@ -403,7 +403,7 @@ async fn write_bytes(
     maximum_bytes_per_log: u64,
     names: &[PathBuf],
     last_name: &Path,
-    labels: &[(String, String)],
+    _labels: &[(String, String)],
 ) -> Result<(), Error> {
     let total_bytes = u64::from(blk.total_bytes.get());
 

--- a/lading/src/generator/file_gen/logrotate.rs
+++ b/lading/src/generator/file_gen/logrotate.rs
@@ -411,7 +411,11 @@ async fn write_bytes(
         fp.write_all(&blk.bytes)
             .await
             .map_err(|err| Error::IoWriteAll { err })?;
-        counter!("bytes_written", labels).increment(total_bytes);
+
+        // This metric must be written with a single context or it will crash
+        // analysis. The simple way to accomplish that is to attach no labels to
+        // it.
+        counter!("bytes_written").increment(total_bytes);
         *total_bytes_written += total_bytes;
     }
 

--- a/lading/src/generator/file_gen/logrotate_fs/model.rs
+++ b/lading/src/generator/file_gen/logrotate_fs/model.rs
@@ -198,7 +198,11 @@ impl File {
         let diff = now.saturating_sub(self.modified_tick);
         let bytes_accum = diff.saturating_mul(self.bytes_per_tick);
 
+        // This metric must be written with a single context or it will crash
+        // analysis. The simple way to accomplish that is to attach no labels to
+        // it.
         counter!("bytes_written").increment(bytes_accum);
+
         self.bytes_written = self.bytes_written.saturating_add(bytes_accum);
         self.modified_tick = now;
         self.status_tick = now;

--- a/lading/src/generator/file_gen/traditional.rs
+++ b/lading/src/generator/file_gen/traditional.rs
@@ -269,6 +269,10 @@ impl Child {
 
                     {
                         fp.write_all(&blk.bytes).await?;
+
+                        // This metric must be written with a single context or
+                        // it will crash analysis. The simple way to accomplish
+                        // that is to attach no labels to it.
                         counter!("bytes_written").increment(total_bytes);
                         total_bytes_written += total_bytes;
                     }

--- a/lading/src/generator/grpc.rs
+++ b/lading/src/generator/grpc.rs
@@ -289,7 +289,11 @@ impl Grpc {
 
                     match res {
                         Ok(res) => {
-                            counter!("bytes_written", &self.metric_labels).increment(block_length as u64);
+                            // This metric must be written with a single context
+                            // or it will crash analysis. The simple way to
+                            // accomplish that is to attach no labels to it.
+                            counter!("bytes_written").increment(block_length as u64);
+
                             counter!("request_ok", &self.metric_labels).increment(1);
                             counter!("response_bytes", &self.metric_labels).increment(res.into_inner() as u64);
                         }

--- a/lading/src/generator/http.rs
+++ b/lading/src/generator/http.rs
@@ -236,7 +236,11 @@ impl Http {
                         counter!("requests_sent", &labels).increment(1);
                         match client.request(request).await {
                             Ok(response) => {
-                                counter!("bytes_written", &labels).increment(block_length as u64);
+                                // This metric must be written with a single
+                                // context or it will crash analysis. The simple
+                                // way to accomplish that is to attach no labels
+                                // to it.
+                                counter!("bytes_written").increment(block_length as u64);
                                 let status = response.status();
                                 let mut status_labels = labels.clone();
                                 status_labels

--- a/lading/src/generator/passthru_file.rs
+++ b/lading/src/generator/passthru_file.rs
@@ -178,7 +178,10 @@ impl PassthruFile {
                     let blk = rcv.next().await.expect("failed to advance through the blocks"); // actually advance through the blocks
                     match current_file.write_all(&blk.bytes).await {
                         Ok(()) => {
-                            counter!("bytes_written", &self.metric_labels).increment(u64::from(blk.total_bytes.get()));
+                            // This metric must be written with a single context
+                            // or it will crash analysis. The simple way to
+                            // accomplish that is to attach no labels to it.
+                            counter!("bytes_written").increment(u64::from(blk.total_bytes.get()));
                         }
                         Err(err) => {
                             warn!("write failed: {}", err);

--- a/lading/src/generator/splunk_hec.rs
+++ b/lading/src/generator/splunk_hec.rs
@@ -344,7 +344,11 @@ where
             match tm {
                 Ok(tm) => match tm {
                     Ok(response) => {
-                        counter!("bytes_written", &labels).increment(block_length as u64);
+                        // This metric must be written with a single context or
+                        // it will crash analysis. The simple way to accomplish
+                        // that is to attach no labels to it.
+                        counter!("bytes_written").increment(block_length as u64);
+
                         let (parts, body) = response.into_parts();
                         let status = parts.status;
                         let mut status_labels = labels.clone();

--- a/lading/src/generator/tcp.rs
+++ b/lading/src/generator/tcp.rs
@@ -181,7 +181,11 @@ impl Tcp {
                     let blk = rcv.next().await.expect("failed to advance through the blocks"); // actually advance through the blocks
                     match connection.write_all(&blk.bytes).await {
                         Ok(()) => {
-                            counter!("bytes_written", &self.metric_labels).increment(u64::from(blk.total_bytes.get()));
+                            // This metric must be written with a single context
+                            // or it will crash analysis. The simple way to
+                            // accomplish that is to attach no labels to it.
+                            counter!("bytes_written").increment(u64::from(blk.total_bytes.get()));
+
                             counter!("packets_sent", &self.metric_labels).increment(1);
                         }
                         Err(err) => {

--- a/lading/src/generator/udp.rs
+++ b/lading/src/generator/udp.rs
@@ -189,7 +189,11 @@ impl Udp {
                     let blk = rcv.next().await.expect("failed to advance through the blocks"); // actually advance through the blocks
                     match sock.send_to(&blk.bytes, self.addr).await {
                         Ok(bytes) => {
-                            counter!("bytes_written", &self.metric_labels).increment(bytes as u64);
+                            // This metric must be written with a single context
+                            // or it will crash analysis. The simple way to
+                            // accomplish that is to attach no labels to it.
+                            counter!("bytes_written").increment(bytes as u64);
+
                             counter!("packets_sent", &self.metric_labels).increment(1);
                             connection = Some(sock);
                         }

--- a/lading/src/generator/unix_datagram.rs
+++ b/lading/src/generator/unix_datagram.rs
@@ -256,7 +256,11 @@ impl Child {
                     let blk = rcv.next().await.expect("failed to advance through blocks"); // actually advance through the blocks
                     match socket.send(&blk.bytes).await {
                         Ok(bytes) => {
-                            counter!("bytes_written", &self.metric_labels).increment(bytes as u64);
+                            // This metric must be written with a single context
+                            // or it will crash analysis. The simple way to
+                            // accomplish that is to attach no labels to it.
+                            counter!("bytes_written").increment(bytes as u64);
+
                             counter!("packets_sent", &self.metric_labels).increment(1);
                         }
                         Err(err) => {

--- a/lading/src/generator/unix_stream.rs
+++ b/lading/src/generator/unix_stream.rs
@@ -203,7 +203,12 @@ impl UnixStream {
                             // if the readiness event is a false positive.
                             match stream.try_write(&blk.bytes[blk_offset..]) {
                                 Ok(bytes) => {
-                                    counter!("bytes_written", &self.metric_labels).increment(bytes as u64);
+                                    // This metric must be written with a single
+                                    // context or it will crash analysis. The
+                                    // simple way to accomplish that is to
+                                    // attach no labels to it.
+                                    counter!("bytes_written").increment(bytes as u64);
+
                                     counter!("packets_sent", &self.metric_labels).increment(1);
                                     blk_offset += bytes;
                                 }


### PR DESCRIPTION
### What does this PR do?

This PR removes labels from the `bytes_received` and `bytes_written` metrics. This ensures that only one context exists for each of these metrics.

### Motivation

Optimization goal analysis does not support metrics with multiple contexts.

### Related issues

SMPTNG-646

### Additional Notes

We _could_ publish another set of metrics with labels attached. I've chosen not to do that here. I would prefer to view this as a workaround pending future custom metric & filtering support in analysis.