### PR TITLE
hotfix: remove compromised changed-files action

### DIFF
--- a/.github/workflows/check-changelog.yml
+++ b/.github/workflows/check-changelog.yml
@@ -25,10 +25,12 @@ jobs:
     - name: Check if CHANGELOG.md was modified
       id: changelog-check
       if: steps.label-check.outputs.has_label == 'false'
-      uses: tj-actions/changed-files@dcc7a0cba800f454d79fff4b993e8c3555bcc0a8 # v45.0.7
-      with:
-        files: |
-          CHANGELOG.md
+      run: |
+          if git diff --quiet HEAD^ -- CHANGELOG.md; then
+              echo "any_changed=false" >> $GITHUB_OUTPUT
+          else
+              echo "any_changed=true" >> $GITHUB_OUTPUT
+          fi
 
     - name: Assert CHANGELOG.md is modified
       uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ## Changed
 - Lading now built with edition 2024
+- Removed use of compromised `tj-actions/changed-files` action from project's GitHub CI configuration
 
 ## [0.25.6]
 ## Fixed


### PR DESCRIPTION
### What does this PR do?

The `tj-actions/changed-files` GitHub action appears to have been compromised. For details, see:

- https://semgrep.dev/blog/2025/popular-github-action-tj-actionschanged-files-is-compromised/
- https://www.stepsecurity.io/blog/harden-runner-detection-tj-actions-changed-files-action-is-compromised

Apparently, using the action can leak CI secrets, so this commit removes our only use of the action and replaces it with an equivalent implementation in shell.

### Motivation

Security.

### Related issues

n/a

### Additional Notes

Will force-merge once tests pass; given the circumstances, this course of action seems appropriate.