### PR TITLE
feat: fix devcontainer for rust analyzer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,5 +1,6 @@
 FROM mcr.microsoft.com/devcontainers/base:1-bookworm
+
 RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
-    && apt-get -y install git build-essential protobuf-compiler \
+    && apt-get -y install git build-essential protobuf-compiler pkg-config libssl-dev \
     # Remove imagemagick due to https://security-tracker.debian.org/tracker/CVE-2019-10131
     && apt-get purge -y imagemagick imagemagick-6-common

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -15,7 +15,7 @@
 			"installDockerBuildx": "true"
 		},
 		"ghcr.io/devcontainers/features/rust:1": {
-			"version": "1.70",
+			"version": "1.85",
 			"profile": "complete"
 		},
 		"ghcr.io/devcontainers/features/git:1": {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Changed
 - Lading now built with edition 2024
 - Removed use of compromised `tj-actions/changed-files` action from project's GitHub CI configuration
+- Fixed devcontainer configuration to ensure the `rust-analyzer` can run successfully within IDEs
 
 ## [0.25.6]
 ## Fixed


### PR DESCRIPTION
### What does this PR do?

This addresses some issues with the devcontainer and working in VsCode/Cursor: the rust analyzer was running into some errors around openssl/pkg-config.

With these changes, you should be able to launch VsCode/Cursor in a devcontainer and get appropriate warnings/errors in your IDE as rust-analyzer now runs.

### Motivation

I wasn't seeing errors in my IDE that should have been obvious.

### Related issues

N/A

### Additional Notes

N/A
