### PR TITLE
release v0.25.7

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Create GitHub release
-        uses: taiki-e/create-gh-release-action@ceeaaf73c0f3f0cadd7bfd9b4d27de4076891fc2 # v1.9.0
+        uses: taiki-e/create-gh-release-action@b7abb0cf5e72cb5500307b577f9ca3fd4c5be9d2 # v1.8.4
         with:
           changelog: CHANGELOG.md
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ## Changed
+
+## [0.25.7]
+## Changed
 - Lading now built with edition 2024
 - Removed use of compromised `tj-actions/changed-files` action from project's GitHub CI configuration
 - Fixed devcontainer configuration to ensure the `rust-analyzer` can run successfully within IDEs

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1565,7 +1565,7 @@ dependencies = [
 
 [[package]]
 name = "lading"
-version = "0.25.6"
+version = "0.25.7"
 dependencies = [
  "async-compression",
  "async-pidfd",

--- a/lading/Cargo.toml
+++ b/lading/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lading"
-version = "0.25.6"
+version = "0.25.7"
 authors = [
   "Brian L. Troutwine <brian.troutwine@datadoghq.com>",
   "George Hahn <george.hahn@datadoghq.com>",


### PR DESCRIPTION
### What does this PR do?

This cuts a new release for lading, marking it as version `0.25.7`.

_This also reverts `taiki-e/create-gh-release-action` to a working version._

### Motivation

Wanted a new release so that we could start capturing the new logs/metrics emitted.

### Related issues

https://datadoghq.atlassian.net/browse/SMPTNG-644

### Additional Notes

N/A
