### PR TITLE
Introduce pidfd use into the procfs observer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Fixed
 - Lading will now ignore child processes when polling /proc if the children are
   forked but not exec'd.
+- Lading observer will now reject processes that appear to be children of the
+  target because of PID reuse.
 
 ## [0.25.7]
 ## Changed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1588,6 +1588,7 @@ dependencies = [
  "lading-payload",
  "lading-signal",
  "lading-throttle",
+ "libc",
  "metrics",
  "metrics-exporter-prometheus",
  "metrics-util",

--- a/lading/Cargo.toml
+++ b/lading/Cargo.toml
@@ -43,6 +43,7 @@ http-serde = "2.1"
 hyper = { workspace = true, features = ["client", "http1", "http2", "server"] }
 hyper-util = { workspace = true, features = ["default", "client", "client-legacy"] }
 is_executable = "1.0.4"
+libc = { version = "0.2", features = [] }
 metrics = { workspace = true }
 metrics-exporter-prometheus = { workspace = true }
 metrics-util = { workspace = true }

--- a/lading/src/observer/linux.rs
+++ b/lading/src/observer/linux.rs
@@ -1,4 +1,5 @@
 mod cgroup;
+mod pidfd;
 mod procfs;
 
 use tracing::error;

--- a/lading/src/observer/linux/pidfd.rs
+++ b/lading/src/observer/linux/pidfd.rs
@@ -5,6 +5,10 @@ use std::mem::MaybeUninit;
 use std::os::unix::io::RawFd;
 
 fn siginfo() -> libc::siginfo_t {
+    // SAFETY: This function creates a zero-initialized siginfo_t struct which
+    // is safe because all bit patterns are valid for the struct. The struct is
+    // only used as an output parameter for waitid() which will properly
+    // initialize all fields.
     unsafe {
         // Create zero-initialized siginfo_t. The libc crate exposes siginfo_t
         // with its union fields etc as private fields, so we need to create a

--- a/lading/src/observer/linux/pidfd.rs
+++ b/lading/src/observer/linux/pidfd.rs
@@ -4,8 +4,6 @@ use nix::unistd::{Pid, close};
 use std::mem::MaybeUninit;
 use std::os::unix::io::RawFd;
 
-#[allow(dead_code)] // TODO remove before merging
-#[inline]
 fn siginfo() -> libc::siginfo_t {
     unsafe {
         // Create zero-initialized siginfo_t. The libc crate exposes siginfo_t
@@ -21,7 +19,7 @@ fn siginfo() -> libc::siginfo_t {
     }
 }
 
-#[allow(dead_code)] // TODO remove before merging
+#[derive(Debug)]
 pub(crate) struct PidFd {
     fd: RawFd,
 }
@@ -32,7 +30,6 @@ impl PidFd {
     /// # Errors
     /// Returns an error if the PID doesn't exist or if the kernel doesn't
     /// support pidfd.
-    #[allow(dead_code)] // TODO remove before merging
     pub(crate) fn open(pid: Pid) -> Result<Self, Error> {
         // Perform the syscall directly using libc, but convert errors using nix::errno::Errno.
         let res = Errno::result(unsafe {
@@ -52,7 +49,6 @@ impl PidFd {
     /// This function calls `waitid(P_PIDFD, fd, WEXITED|WNOHANG)`, so a wait
     /// without waiting. Returns true immediately if the process has exited,
     /// else false.
-    #[allow(dead_code)] // TODO remove before merging
     #[allow(clippy::cast_sign_loss)]
     pub(crate) fn is_active(&self) -> Result<bool, Error> {
         let mut info = siginfo();

--- a/lading/src/observer/linux/pidfd.rs
+++ b/lading/src/observer/linux/pidfd.rs
@@ -50,22 +50,68 @@ impl PidFd {
     /// without waiting. Returns true immediately if the process has exited,
     /// else false.
     #[allow(clippy::cast_sign_loss)]
-    pub(crate) fn is_active(&self) -> Result<bool, Error> {
+    pub(crate) fn is_exited(&self) -> Result<bool, Error> {
         let mut info = siginfo();
 
         // waitid(P_PIDFD, <fd>, &mut info, WEXITED|WNOHANG)
-        Errno::result(unsafe {
+        //
+        // WEXITED -- Wait for processes that have exited.
+        //
+        // WNOHANG -- Do not hang if no status is available; return
+        //
+        // If waitid() returns because a child process was found that satisfied
+        // the conditions indicated by the arguments idtype and options, then
+        // the structure pointed to by infop shall be filled in by the system
+        // with the status of the process; the si_signo member shall be set
+        // equal to SIGCHLD.  If waitid() returns because WNOHANG was specified
+        // and status is not available for any process specified by idtype and
+        // id, then the si_signo and si_pid members of the structure pointed to
+        // by infop shall be set to zero and the values of other members of the
+        // structure are unspecified.
+        //
+        // The waitid() function shall fail if:
+        //
+        // ECHILD -- The calling process has no existing unwaited-for child
+        // processes.
+        //
+        // EINTR -- The waitid() function was interrupted by a signal.
+        //
+        // EINVAL -- An invalid value was specified for options, or idtype and
+        // id specify an invalid set of processes.
+        //
+        // With pidfd in play ECHILD will be returned if the target process has
+        // exited, didn't exist to begin with or lading is not in the same pid
+        // namespace.
+
+        let res = Errno::result(unsafe {
             libc::waitid(
                 libc::P_PIDFD,
-                self.fd as libc::id_t, // 'pid' in waitid terms
+                self.fd as libc::id_t,
                 &raw mut info,
                 libc::WEXITED | libc::WNOHANG,
             )
-        })?;
+        });
 
-        // If `info.si_pid() != 0`, that means the process has exited.
-        let exited = unsafe { info.si_pid() } != 0;
-        Ok(exited)
+        // If WNOHANG was specified and status is not available for any process
+        // specified by idtype and id, 0 shall be returned. If waitid() returns
+        // due to the change of state of one of its children, 0 shall be
+        // returned. Otherwise, -1 shall be returned and errno set to indicate
+        // the error.
+
+        match res {
+            Ok(0) => {
+                let si_pid = unsafe { info.si_pid() };
+                // NOTE `info` lacks a si_signo and it's sufficient to check
+                // only si_pid.
+                Ok(si_pid != 0)
+            }
+            Ok(_) => unreachable!("waitid() returned a value other than 0 or -1"),
+            Err(Errno::ECHILD) => {
+                // No such process existed or remains.
+                Ok(true)
+            }
+            Err(e) => Err(e),
+        }
     }
 }
 

--- a/lading/src/observer/linux/pidfd.rs
+++ b/lading/src/observer/linux/pidfd.rs
@@ -1,0 +1,80 @@
+use nix::Error;
+use nix::errno::Errno;
+use nix::unistd::{Pid, close};
+use std::mem::MaybeUninit;
+use std::os::unix::io::RawFd;
+
+#[allow(dead_code)] // TODO remove before merging
+#[inline]
+fn siginfo() -> libc::siginfo_t {
+    unsafe {
+        // Create zero-initialized siginfo_t. The libc crate exposes siginfo_t
+        // with its union fields etc as private fields, so we need to create a
+        // zeroed out instance and then set the platform specific fields.
+        let mut siginfo = MaybeUninit::<libc::siginfo_t>::zeroed().assume_init();
+
+        siginfo.si_signo = 0;
+        siginfo.si_errno = 0;
+        siginfo.si_code = 0;
+
+        siginfo
+    }
+}
+
+#[allow(dead_code)] // TODO remove before merging
+pub(crate) struct PidFd {
+    fd: RawFd,
+}
+
+impl PidFd {
+    /// Open a pidfd for the specified PID via the `SYS_pidfd_open` syscall.
+    ///
+    /// # Errors
+    /// Returns an error if the PID doesn't exist or if the kernel doesn't
+    /// support pidfd.
+    #[allow(dead_code)] // TODO remove before merging
+    pub(crate) fn open(pid: Pid) -> Result<Self, Error> {
+        // Perform the syscall directly using libc, but convert errors using nix::errno::Errno.
+        let res = Errno::result(unsafe {
+            libc::syscall(
+                libc::SYS_pidfd_open, // numeric ID for pidfd_open
+                libc::c_long::from(pid.as_raw()),
+                0 as libc::c_long, // flags = 0
+            )
+        })?;
+
+        let fd = res as RawFd;
+        Ok(Self { fd })
+    }
+
+    /// Check if the process associated with this pidfd has exited yet.
+    ///
+    /// This function calls `waitid(P_PIDFD, fd, WEXITED|WNOHANG)`, so a wait
+    /// without waiting. Returns true immediately if the process has exited,
+    /// else false.
+    #[allow(dead_code)] // TODO remove before merging
+    #[allow(clippy::cast_sign_loss)]
+    pub(crate) fn is_active(&self) -> Result<bool, Error> {
+        let mut info = siginfo();
+
+        // waitid(P_PIDFD, <fd>, &mut info, WEXITED|WNOHANG)
+        Errno::result(unsafe {
+            libc::waitid(
+                libc::P_PIDFD,
+                self.fd as libc::id_t, // 'pid' in waitid terms
+                &raw mut info,
+                libc::WEXITED | libc::WNOHANG,
+            )
+        })?;
+
+        // If `info.si_pid() != 0`, that means the process has exited.
+        let exited = unsafe { info.si_pid() } != 0;
+        Ok(exited)
+    }
+}
+
+impl Drop for PidFd {
+    fn drop(&mut self) {
+        let _ = close(self.fd);
+    }
+}

--- a/lading/src/observer/linux/procfs.rs
+++ b/lading/src/observer/linux/procfs.rs
@@ -228,7 +228,7 @@ impl Sampler {
         let pinfo = self
             .process_info
             .get_mut(&pid)
-            .expect("catastrophic programming error");
+            .expect("[pinfo] catastrophic programming error");
 
         // Check if process is still active before polling. There's a
         // non-trivial chance that the process has died -- no big deal -- or

--- a/lading/src/observer/linux/procfs.rs
+++ b/lading/src/observer/linux/procfs.rs
@@ -234,7 +234,7 @@ impl Sampler {
         // non-trivial chance that the process has died -- no big deal -- or
         // that it has died and been replaced and the PID reused. This second
         // case is a real problem.
-        if !pinfo.pidfd.is_active()? {
+        if pinfo.pidfd.is_exited()? {
             info!("Process {pid} is no longer active");
             return Ok(false);
         }
@@ -377,7 +377,7 @@ async fn initialize_process_info(pid: i32) -> Result<Option<ProcessInfo>, Error>
     };
 
     // Check if process is still active
-    if !pidfd.is_active()? {
+    if pidfd.is_exited()? {
         warn!("Process {pid} is no longer active");
         return Ok(None);
     }


### PR DESCRIPTION
### What does this PR do?

This PR ensures our process polling in the observer is correct in
the case of a PID being reused between polling for child processes
and when we go to poll for data on that process.

