### PR TITLE
Create lading 0.25.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
-## Changed
+## [0.25.8]
 ## Fixed
 - Lading will now ignore child processes when polling /proc if the children are
   forked but not exec'd.
+- Lading uses virtual CPUs when calculating both procfs and cgroup CPU data.
 
 ## [0.25.7]
 ## Changed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1565,7 +1565,7 @@ dependencies = [
 
 [[package]]
 name = "lading"
-version = "0.25.7"
+version = "0.25.8"
 dependencies = [
  "async-compression",
  "async-pidfd",

--- a/lading/Cargo.toml
+++ b/lading/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lading"
-version = "0.25.7"
+version = "0.25.8"
 authors = [
   "Brian L. Troutwine <brian.troutwine@datadoghq.com>",
   "George Hahn <george.hahn@datadoghq.com>",


### PR DESCRIPTION
### What does this PR do?

This commit contains fixes for the observer, using virtual CPU count for both procfs and cgroup CPU calculations as well as ignoring child processes if they are forked but not exec'd when performing memory sums. We will improve the detection mechanism on this later case over time.
