### PR TITLE
Update byte-unit crate to 5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## Changed
+- Lading's byte-unit crate is now updated to 5.x. This version of the crate is
+  very strict about the difference between MiB, Mb etc.
 ## Fixed
 - Fixed throttle capacity validation to prevent requests larger than maximum
   capacity from being emitted.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,6 +19,17 @@ checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
 
 [[package]]
 name = "ahash"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "891477e0c6a8957309ee5c45a6368af3ae14bb510732d2684ffa19af310920f9"
+dependencies = [
+ "getrandom 0.2.15",
+ "once_cell",
+ "version_check",
+]
+
+[[package]]
+name = "ahash"
 version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
@@ -79,6 +90,12 @@ checksum = "dde20b3d026af13f561bdd0f15edf01fc734f0dafcedbaf42bba506a9517f223"
 dependencies = [
  "derive_arbitrary",
 ]
+
+[[package]]
+name = "arrayvec"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
 name = "async-compression"
@@ -290,6 +307,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
 
 [[package]]
+name = "bitvec"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bc2832c24239b0141d5674bb9174f9d68a8b5b3f2753311927c172ca46f7e9c"
+dependencies = [
+ "funty",
+ "radium",
+ "tap",
+ "wyz",
+]
+
+[[package]]
 name = "block-buffer"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -343,6 +372,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "borsh"
+version = "1.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad8646f98db542e39fc66e68a20b2144f6a732636df7c2354e74645faaa433ce"
+dependencies = [
+ "borsh-derive",
+ "cfg_aliases",
+]
+
+[[package]]
+name = "borsh-derive"
+version = "1.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdd1d3c0c2f5833f22386f252fe8ed005c7f59fdcddeef025c01b4c3b9fd9ac3"
+dependencies = [
+ "once_cell",
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.91",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -350,12 +402,35 @@ checksum = "79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c"
 
 [[package]]
 name = "byte-unit"
-version = "4.0.19"
+version = "5.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da78b32057b8fdfc352504708feeba7216dcd65a2c9ab02978cbd288d1279b6c"
+checksum = "e1cd29c3c585209b0cbc7309bfe3ed7efd8c84c21b7af29c8bfae908f8777174"
 dependencies = [
+ "rust_decimal",
  "serde",
  "utf8-width",
+]
+
+[[package]]
+name = "bytecheck"
+version = "0.6.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23cdc57ce23ac53c931e88a43d06d070a6fd142f2617be5855eb75efc9beb1c2"
+dependencies = [
+ "bytecheck_derive",
+ "ptr_meta",
+ "simdutf8",
+]
+
+[[package]]
+name = "bytecheck_derive"
+version = "0.6.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3db406d29fbcd95542e92559bed4d8ad92636d1ca8b3b72ede10b4bcc010e659"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -795,6 +870,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "funty"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
+
+[[package]]
 name = "fuser"
 version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1025,6 +1106,9 @@ name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+dependencies = [
+ "ahash 0.7.8",
+]
 
 [[package]]
 name = "hashbrown"
@@ -1032,7 +1116,7 @@ version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 dependencies = [
- "ahash",
+ "ahash 0.8.11",
 ]
 
 [[package]]
@@ -1758,7 +1842,7 @@ version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "884adb57038347dfbaf2d5065887b6cf4312330dc8e94bc30a1a839bd79d3261"
 dependencies = [
- "ahash",
+ "ahash 0.8.11",
  "portable-atomic",
 ]
 
@@ -2213,6 +2297,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "proc-macro-crate"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edce586971a4dfaa28950c6f18ed55e0406c1ab88bbce2c6f6293a7aaba73d35"
+dependencies = [
+ "toml_edit",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2327,6 +2420,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "ptr_meta"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0738ccf7ea06b608c10564b31debd4f5bc5e197fc8bfe088f68ae5ce81e7a4f1"
+dependencies = [
+ "ptr_meta_derive",
+]
+
+[[package]]
+name = "ptr_meta_derive"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16b845dbfca988fa33db069c0e230574d15a3088f147a87b64c7589eb662c9ac"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "quanta"
 version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2355,6 +2468,12 @@ checksum = "b5b9d34b8991d19d98081b46eacdd8eb58c6f2b201139f7c5f643cc155a633af"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "radium"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "radix_trie"
@@ -2510,6 +2629,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
+name = "rend"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71fe3824f5629716b1589be05dacd749f6aa084c87e00e016714a8cdfccc997c"
+dependencies = [
+ "bytecheck",
+]
+
+[[package]]
 name = "reqwest"
 version = "0.12.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2550,6 +2678,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "rkyv"
+version = "0.7.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9008cd6385b9e161d8229e1f6549dd23c3d022f132a2ea37ac3a10ac4935779b"
+dependencies = [
+ "bitvec",
+ "bytecheck",
+ "bytes",
+ "hashbrown 0.12.3",
+ "ptr_meta",
+ "rend",
+ "rkyv_derive",
+ "seahash",
+ "tinyvec",
+ "uuid",
+]
+
+[[package]]
+name = "rkyv_derive"
+version = "0.7.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "503d1d27590a2b0a3a4ca4c94755aa2875657196ecbf401a42eff41d7de532c0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "rmp"
 version = "0.8.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2569,6 +2726,22 @@ dependencies = [
  "byteorder",
  "rmp",
  "serde",
+]
+
+[[package]]
+name = "rust_decimal"
+version = "1.37.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "faa7de2ba56ac291bd90c6b9bece784a52ae1411f9506544b3eae36dd2356d50"
+dependencies = [
+ "arrayvec",
+ "borsh",
+ "bytes",
+ "num-traits",
+ "rand 0.8.5",
+ "rkyv",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -2685,6 +2858,12 @@ name = "scoped-tls"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294"
+
+[[package]]
+name = "seahash"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c107b6f4780854c8b126e228ea8869f4d7b71260f962fefb57b996b8959ba6b"
 
 [[package]]
 name = "security-framework"
@@ -2889,6 +3068,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
+
+[[package]]
 name = "sketches-ddsketch"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2994,6 +3179,12 @@ dependencies = [
  "quote",
  "syn 2.0.91",
 ]
+
+[[package]]
+name = "tap"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "tempfile"
@@ -3110,6 +3301,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinyvec"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09b3661f17e86524eccd4371ab0429194e0d7c008abb45f7a7495b1719463c71"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
 name = "tokio"
 version = "1.44.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3181,6 +3387,23 @@ dependencies = [
  "futures-sink",
  "pin-project-lite",
  "tokio",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0dd7358ecb8fc2f8d014bf86f6f638ce72ba252a2c3a2572f2a795f1d23efb41"
+
+[[package]]
+name = "toml_edit"
+version = "0.22.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17b4795ff5edd201c7cd6dca065ae59972ce77d1b80fa0a84d94950ece7d1474"
+dependencies = [
+ "indexmap 2.7.0",
+ "toml_datetime",
+ "winnow",
 ]
 
 [[package]]
@@ -3967,6 +4190,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
 
 [[package]]
+name = "winnow"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63d3fcd9bba44b03821e7d699eeee959f3126dcc4aa8e4ae18ec617c2a5cea10"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "wit-bindgen-rt"
 version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3986,6 +4218,15 @@ name = "writeable"
 version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e9df38ee2d2c3c5948ea468a8406ff0db0b29ae1ffde1bcf20ef305bcc95c51"
+
+[[package]]
+name = "wyz"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
+dependencies = [
+ "tap",
+]
 
 [[package]]
 name = "yoke"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ members = [
 
 [workspace.dependencies]
 bytes = { version = "1.10", default-features = false, features = ["std"] }
-byte-unit = { version = "4.0", features = ["serde"] }
+byte-unit = { version = "5.1", features = ["serde"] }
 metrics = { version = "0.23.0" }
 metrics-util = { version = "0.17.0" }
 metrics-exporter-prometheus = { version = "0.15.3", default-features = false, features = [

--- a/README.md
+++ b/README.md
@@ -47,12 +47,12 @@ generator:
   - http:
       seed: [2, 3, 5, 7, 11, 13, 19, 23, 29, 31, 37, 41, 43, 47, 53, 59, 61, 67, 71, 73, 79, 83, 89, 97, 101, 103, 107, 109, 113, 127, 131, 137]
       target_uri: "http://localhost:8282/"
-      bytes_per_second: "100 Mb"
+      bytes_per_second: "100 MiB"
       parallel_connections: 10
       method:
         post:
           variant: "fluent"
-          maximum_prebuild_cache_size_bytes: "256 Mb"
+          maximum_prebuild_cache_size_bytes: "256 MiB"
       headers: {}
 
 blackhole:
@@ -63,10 +63,10 @@ blackhole:
 In this setup `lading` is configured to run one generator and one blackhole. In
 general, at least one generator is required and zero or more blackholes are. The
 generator here, named "http", uses a fixed seed to repeatably produce [fluent's
-forward protocol][fluent] instances at 100 Mb per second into the target, with a
-pre-built size of 256 Mb. That is, `lading` will _attempt_ to push at a fixed
+forward protocol][fluent] instances at 100 MiB per second into the target, with a
+pre-built size of 256 MiB. That is, `lading` will _attempt_ to push at a fixed
 throughput, although the target might not be able to cope with that load and
-`lading` will consume 256 Mb of RAM to accommodate pre-build payloads. The
+`lading` will consume 256 MiB of RAM to accommodate pre-build payloads. The
 blackhole in this configuration responds with an empty body 200 OK.
 
 `lading` supports three types of targets, binary launch mode, PID watch mode,

--- a/examples/dogstatsd-generation.yaml
+++ b/examples/dogstatsd-generation.yaml
@@ -31,7 +31,7 @@ generator:
             set: 0
             histogram: 0
       bytes_per_second: "80 MiB"
-      maximum_prebuild_cache_size_bytes: "500 Mb"
+      maximum_prebuild_cache_size_bytes: "500 MiB"
 
 blackhole:
   - http:

--- a/examples/lading-logrotatefs.yaml
+++ b/examples/lading-logrotatefs.yaml
@@ -4,12 +4,12 @@ generator:
         seed: [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53,
                59, 61, 67, 71, 73, 79, 83, 89, 97, 101, 103, 107, 109, 113, 127, 131]
         concurrent_logs: 8
-        maximum_bytes_per_log: 100MB
+        maximum_bytes_per_log: 100MiB
         total_rotations: 4
         max_depth: 0
         variant: "ascii"
-        bytes_per_second: 1.3MB
-        maximum_prebuild_cache_size_bytes: 1GB
+        bytes_per_second: 1.3MiB
+        maximum_prebuild_cache_size_bytes: 1GiB
         mount_point: /tmp/logrotate
 
 blackhole:

--- a/examples/lading.yaml
+++ b/examples/lading.yaml
@@ -3,8 +3,8 @@ generator:
       seed: [2, 3, 5, 7, 11, 13, 19, 23, 29, 31, 37, 41, 43, 47, 53, 59, 61, 67, 71, 73, 79, 83, 89, 97, 101, 103, 107, 109, 113, 127, 131, 137]
       addr: "0.0.0.0:8282"
       variant: "syslog5424"
-      bytes_per_second: "500 Mb"
-      maximum_prebuild_cache_size_bytes: "256 Mb"
+      bytes_per_second: "500 MiB"
+      maximum_prebuild_cache_size_bytes: "256 MiB"
   - file_tree:
       seed: [2, 3, 5, 7, 11, 13, 19, 23, 29, 31, 37, 41, 43, 47, 53, 59, 61, 67, 71, 73, 79, 83, 89, 97, 101, 103, 107, 109, 113, 127, 131, 137]
       max_depth: 10

--- a/integration/sheepdog/src/lib.rs
+++ b/integration/sheepdog/src/lib.rs
@@ -351,11 +351,11 @@ generator:
           59, 61, 67, 71, 73, 79, 83, 89, 97, 101, 103, 107, 109, 113, 127, 131]
         headers: {}
         target_uri: "http://localhost:{{port_number}}/"
-        bytes_per_second: "100 Mb"
+        bytes_per_second: "100 MiB"
         parallel_connections: 5
         method:
           post:
-            maximum_prebuild_cache_size_bytes: "8 Mb"
+            maximum_prebuild_cache_size_bytes: "8 MiB"
             variant: "apache_common"
         "#,
         )?;
@@ -385,11 +385,11 @@ generator:
           59, 61, 67, 71, 73, 79, 83, 89, 97, 101, 103, 107, 109, 113, 127, 131]
         headers: {}
         target_uri: "http://localhost:{{port_number}}/"
-        bytes_per_second: "100 Mb"
+        bytes_per_second: "100 MiB"
         parallel_connections: 5
         method:
           post:
-            maximum_prebuild_cache_size_bytes: "8 Mb"
+            maximum_prebuild_cache_size_bytes: "8 MiB"
             variant: "ascii"
         "#,
         )?;
@@ -418,11 +418,11 @@ generator:
         seed: [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53,
           59, 61, 67, 71, 73, 79, 83, 89, 97, 101, 103, 107, 109, 113, 127, 131]
         target_uri: "http://localhost:{{port_number}}/v1/logs"
-        bytes_per_second: "100 Mb"
+        bytes_per_second: "100 MiB"
         parallel_connections: 5
         method:
           post:
-            maximum_prebuild_cache_size_bytes: "8 Mb"
+            maximum_prebuild_cache_size_bytes: "8 MiB"
             variant: "opentelemetry_logs"
         headers:
             Content-Type: "application/x-protobuf"
@@ -453,11 +453,11 @@ generator:
         seed: [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53,
           59, 61, 67, 71, 73, 79, 83, 89, 97, 101, 103, 107, 109, 113, 127, 131]
         target_uri: "http://localhost:{{port_number}}/v1/traces"
-        bytes_per_second: "100 Mb"
+        bytes_per_second: "100 MiB"
         parallel_connections: 5
         method:
           post:
-            maximum_prebuild_cache_size_bytes: "8 Mb"
+            maximum_prebuild_cache_size_bytes: "8 MiB"
             variant: "opentelemetry_traces"
         headers:
             Content-Type: "application/x-protobuf"
@@ -488,11 +488,11 @@ generator:
         seed: [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53,
           59, 61, 67, 71, 73, 79, 83, 89, 97, 101, 103, 107, 109, 113, 127, 131]
         target_uri: "http://localhost:{{port_number}}/v1/metrics"
-        bytes_per_second: "100 Mb"
+        bytes_per_second: "100 MiB"
         parallel_connections: 5
         method:
           post:
-            maximum_prebuild_cache_size_bytes: "8 Mb"
+            maximum_prebuild_cache_size_bytes: "8 MiB"
             variant: "opentelemetry_metrics"
         headers:
             Content-Type: "application/x-protobuf"
@@ -524,9 +524,9 @@ generator:
         seed: [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53,
           59, 61, 67, 71, 73, 79, 83, 89, 97, 101, 103, 107, 109, 113, 127, 131]
         addr: "127.0.0.1:{{port_number}}"
-        bytes_per_second: "100 Mb"
+        bytes_per_second: "100 MiB"
         variant: fluent
-        maximum_prebuild_cache_size_bytes: "8 Mb"
+        maximum_prebuild_cache_size_bytes: "8 MiB"
         "#,
         )?;
 
@@ -553,9 +553,9 @@ generator:
         seed: [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53,
           59, 61, 67, 71, 73, 79, 83, 89, 97, 101, 103, 107, 109, 113, 127, 131]
         addr: "127.0.0.1:{{port_number}}"
-        bytes_per_second: "100 Mb"
+        bytes_per_second: "100 MiB"
         variant: ascii
-        maximum_prebuild_cache_size_bytes: "8 Mb"
+        maximum_prebuild_cache_size_bytes: "8 MiB"
         "#,
         )?;
 

--- a/lading/src/bin/payloadtool.rs
+++ b/lading/src/bin/payloadtool.rs
@@ -10,7 +10,8 @@ use rand::{SeedableRng, rngs::StdRng};
 use tracing::{debug, error, info, warn};
 use tracing_subscriber::{fmt::format::FmtSpan, util::SubscriberInitExt};
 
-const UDP_PACKET_LIMIT_BYTES: u64 = 65_507;
+const UDP_PACKET_LIMIT_BYTES: byte_unit::Byte =
+    byte_unit::Byte::from_u64_with_unit(65_507, Unit::B).expect("valid bytes");
 
 #[derive(Parser, Debug)]
 #[clap(author, version, about, long_about = None)]
@@ -79,9 +80,7 @@ fn check_generator(config: &lading::generator::Config) -> Result<(), Error> {
     match &config.inner {
         lading::generator::Inner::FileGen(_) => unimplemented!("FileGen not supported"),
         lading::generator::Inner::UnixDatagram(g) => {
-            let max_block_size =
-                byte_unit::Byte::from_u64_with_unit(UDP_PACKET_LIMIT_BYTES, Unit::B)
-                    .expect("valid bytes");
+            let max_block_size = UDP_PACKET_LIMIT_BYTES;
             let total_bytes = NonZeroU32::new(g.maximum_prebuild_cache_size_bytes.as_u128() as u32)
                 .expect("Non-zero max prebuild cache size");
             generate_and_check(&g.variant, g.seed, total_bytes, max_block_size)?;
@@ -94,9 +93,7 @@ fn check_generator(config: &lading::generator::Config) -> Result<(), Error> {
         lading::generator::Inner::Udp(g) => {
             let total_bytes = NonZeroU32::new(g.maximum_prebuild_cache_size_bytes.as_u128() as u32)
                 .expect("Non-zero max prebuild cache size");
-            let max_block_size =
-                byte_unit::Byte::from_u64_with_unit(UDP_PACKET_LIMIT_BYTES, Unit::B)
-                    .expect("valid bytes");
+            let max_block_size = UDP_PACKET_LIMIT_BYTES;
             generate_and_check(&g.variant, g.seed, total_bytes, max_block_size)?;
         }
         lading::generator::Inner::Http(g) => {

--- a/lading/src/config.rs
+++ b/lading/src/config.rs
@@ -154,17 +154,19 @@ blackhole:
                             .expect("Failed to convert to to valid URI"),
                         method: generator::http::Method::Post {
                             variant: lading_payload::Config::Fluent,
-                            maximum_prebuild_cache_size_bytes: byte_unit::Byte::from_unit(
-                                8_f64,
-                                byte_unit::ByteUnit::MB
-                            )?,
+                            maximum_prebuild_cache_size_bytes: byte_unit::Byte::from_u64_with_unit(
+                                8,
+                                byte_unit::Unit::MB
+                            )
+                            .expect("valid bytes"),
                             block_cache_method: block::CacheMethod::Fixed,
                         },
                         headers: HeaderMap::default(),
-                        bytes_per_second: byte_unit::Byte::from_unit(
-                            100_f64,
-                            byte_unit::ByteUnit::MB
-                        )?,
+                        bytes_per_second: byte_unit::Byte::from_u64_with_unit(
+                            100,
+                            byte_unit::Unit::MB
+                        )
+                        .expect("valid bytes"),
                         maximum_block_size: lading_payload::block::default_maximum_block_size(),
                         parallel_connections: 5,
                         throttle: lading_throttle::Config::default(),

--- a/lading/src/config.rs
+++ b/lading/src/config.rs
@@ -14,9 +14,6 @@ pub enum Error {
     /// Error for a serde [`serde_yaml`].
     #[error("Failed to deserialize yaml: {0}")]
     SerdeYaml(#[from] serde_yaml::Error),
-    /// Error for a byte unit [`byte_unit`].
-    #[error("Value provided is negative: {0}")]
-    ByteUnit(#[from] byte_unit::ByteError),
     /// Error for a socket address [`std::net::SocketAddr`].
     #[error("Failed to convert to valid SocketAddr: {0}")]
     SocketAddr(#[from] std::net::AddrParseError),

--- a/lading/src/config.rs
+++ b/lading/src/config.rs
@@ -126,11 +126,11 @@ generator:
       seed: [0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0]
       headers: {}
       target_uri: "http://localhost:1000/"
-      bytes_per_second: "100 Mb"
+      bytes_per_second: "100 MiB"
       parallel_connections: 5
       method:
         post:
-          maximum_prebuild_cache_size_bytes: "8 Mb"
+          maximum_prebuild_cache_size_bytes: "8 MiB"
           variant: "fluent"
 blackhole:
   - id: "Data in"
@@ -156,7 +156,7 @@ blackhole:
                             variant: lading_payload::Config::Fluent,
                             maximum_prebuild_cache_size_bytes: byte_unit::Byte::from_u64_with_unit(
                                 8,
-                                byte_unit::Unit::MB
+                                byte_unit::Unit::MiB
                             )
                             .expect("valid bytes"),
                             block_cache_method: block::CacheMethod::Fixed,
@@ -164,7 +164,7 @@ blackhole:
                         headers: HeaderMap::default(),
                         bytes_per_second: byte_unit::Byte::from_u64_with_unit(
                             100,
-                            byte_unit::Unit::MB
+                            byte_unit::Unit::MiB
                         )
                         .expect("valid bytes"),
                         maximum_block_size: lading_payload::block::default_maximum_block_size(),

--- a/lading/src/generator/file_gen/logrotate.rs
+++ b/lading/src/generator/file_gen/logrotate.rs
@@ -20,7 +20,7 @@ use std::{
     thread,
 };
 
-use byte_unit::{Byte, ByteError};
+use byte_unit::Byte;
 use futures::future::join_all;
 use lading_throttle::Throttle;
 use metrics::{counter, gauge};
@@ -102,7 +102,7 @@ pub enum Error {
     Child(#[from] JoinError),
     /// Byte error
     #[error("Bytes must not be negative: {0}")]
-    Byte(#[from] ByteError),
+    Byte(#[from] byte_unit::ParseError),
     /// Failed to convert, value is 0
     #[error("Value provided must not be zero")]
     Zero,
@@ -183,26 +183,30 @@ impl Server {
             labels.push(("id".to_string(), id));
         }
 
-        let bytes_per_second = NonZeroU32::new(config.bytes_per_second.get_bytes() as u32)
-            .expect("Expect: config bytes per second must be non-zero");
+        let bytes_per_second = NonZeroU32::new(config.bytes_per_second.as_u128() as u32)
+            .expect("bytes_per_second must be non-zero");
         gauge!("bytes_per_second", &labels).set(f64::from(bytes_per_second.get()));
 
-        let maximum_bytes_per_file =
-            NonZeroU32::new(config.maximum_bytes_per_log.get_bytes() as u32).ok_or(Error::Zero)?;
+        let maximum_bytes_per_log =
+            NonZeroU32::new(config.maximum_bytes_per_log.as_u128() as u32).ok_or(Error::Zero)?;
+
+        let maximum_prebuild_cache_size_bytes =
+            NonZeroU32::new(config.maximum_prebuild_cache_size_bytes.as_u128() as u32)
+                .ok_or(Error::Zero)?;
+
+        let maximum_block_size =
+            NonZeroU32::new(config.maximum_block_size.as_u128() as u32).ok_or(Error::Zero)?;
 
         let mut handles = Vec::new();
 
         for idx in 0..config.concurrent_logs {
             let throttle = Throttle::new_with_config(config.throttle, bytes_per_second);
 
-            let total_bytes =
-                NonZeroU32::new(config.maximum_prebuild_cache_size_bytes.get_bytes() as u32)
-                    .ok_or(Error::Zero)?;
             let block_cache = match config.block_cache_method {
                 block::CacheMethod::Fixed => block::Cache::fixed(
                     &mut rng,
-                    total_bytes,
-                    config.maximum_block_size.get_bytes(),
+                    maximum_prebuild_cache_size_bytes,
+                    u128::from(maximum_block_size.get()),
                     &config.variant,
                 )?,
             };
@@ -224,7 +228,7 @@ impl Server {
                 &basename,
                 config.total_rotations,
                 bytes_per_second,
-                maximum_bytes_per_file,
+                maximum_bytes_per_log,
                 block_cache,
                 throttle,
                 shutdown.clone(),

--- a/lading/src/generator/file_gen/logrotate_fs.rs
+++ b/lading/src/generator/file_gen/logrotate_fs.rs
@@ -78,13 +78,13 @@ impl LoadProfile {
     fn to_model(self) -> model::LoadProfile {
         // For now, one tick is one second.
         match self {
-            LoadProfile::Constant(bpt) => model::LoadProfile::Constant(bpt.get_bytes() as u64),
+            LoadProfile::Constant(bpt) => model::LoadProfile::Constant(bpt.as_u128() as u64),
             LoadProfile::Linear {
                 initial_bytes_per_second,
                 rate,
             } => model::LoadProfile::Linear {
-                start: initial_bytes_per_second.get_bytes() as u64,
-                rate: rate.get_bytes() as u64,
+                start: initial_bytes_per_second.as_u128() as u64,
+                rate: rate.as_u128() as u64,
             },
         }
     }
@@ -137,12 +137,12 @@ impl Server {
         let mut rng = SmallRng::from_seed(config.seed);
 
         let total_bytes =
-            NonZeroU32::new(config.maximum_prebuild_cache_size_bytes.get_bytes() as u32)
+            NonZeroU32::new(config.maximum_prebuild_cache_size_bytes.as_u128() as u32)
                 .ok_or(Error::Zero)?;
         let block_cache = block::Cache::fixed(
             &mut rng,
             total_bytes,
-            config.maximum_block_size.get_bytes(),
+            config.maximum_block_size.as_u128(),
             &config.variant,
         )?;
 
@@ -153,7 +153,7 @@ impl Server {
             &mut rng,
             start_time.elapsed().as_secs(),
             config.total_rotations,
-            config.maximum_bytes_per_log.get_bytes() as u64,
+            config.maximum_bytes_per_log.as_u128() as u64,
             block_cache,
             config.max_depth,
             config.concurrent_logs,

--- a/lading/src/generator/unix_datagram.rs
+++ b/lading/src/generator/unix_datagram.rs
@@ -12,7 +12,7 @@
 //!
 
 use crate::common::PeekableReceiver;
-use byte_unit::{Byte, ByteError, ByteUnit};
+use byte_unit::{Byte, Unit};
 use futures::future::join_all;
 use lading_payload::block::{self, Block};
 use lading_throttle::Throttle;
@@ -36,7 +36,7 @@ fn default_parallel_connections() -> u16 {
 // Mimic the belief of Datadog Agent, although correctly we should be reading
 // sysctl values on Linux.
 fn maximum_block_size() -> Byte {
-    Byte::from_unit(8_192f64, ByteUnit::B).expect("catastrophic programming bug")
+    Byte::from_u64_with_unit(8_192, Unit::B).expect("catastrophic programming bug")
 }
 
 #[derive(Debug, Deserialize, Serialize, PartialEq)]
@@ -95,7 +95,7 @@ pub enum Error {
     Zero,
     /// Byte error
     #[error("Bytes must not be negative: {0}")]
-    Byte(#[from] ByteError),
+    Byte(#[from] byte_unit::ParseError),
 }
 
 #[derive(Debug)]
@@ -136,7 +136,7 @@ impl UnixDatagram {
         }
 
         let bytes_per_second =
-            NonZeroU32::new(config.bytes_per_second.get_bytes() as u32).ok_or(Error::Zero)?;
+            NonZeroU32::new(config.bytes_per_second.as_u128() as u32).ok_or(Error::Zero)?;
         gauge!("bytes_per_second", &labels).set(f64::from(bytes_per_second.get()));
 
         let (startup, _startup_rx) = tokio::sync::broadcast::channel(1);
@@ -144,13 +144,13 @@ impl UnixDatagram {
         let mut handles = Vec::new();
         for _ in 0..config.parallel_connections {
             let total_bytes =
-                NonZeroU32::new(config.maximum_prebuild_cache_size_bytes.get_bytes() as u32)
+                NonZeroU32::new(config.maximum_prebuild_cache_size_bytes.as_u128() as u32)
                     .ok_or(Error::Zero)?;
             let block_cache = match config.block_cache_method {
                 block::CacheMethod::Fixed => block::Cache::fixed(
                     &mut rng,
                     total_bytes,
-                    config.maximum_block_size.get_bytes(),
+                    config.maximum_block_size.as_u128(),
                     &config.variant,
                 )?,
             };

--- a/lading/src/generator/unix_stream.rs
+++ b/lading/src/generator/unix_stream.rs
@@ -12,7 +12,6 @@
 //!
 
 use crate::common::PeekableReceiver;
-use byte_unit::ByteError;
 use lading_payload::block::{self, Block};
 use lading_throttle::Throttle;
 use metrics::{counter, gauge};
@@ -63,7 +62,7 @@ pub enum Error {
     Subtask(#[from] JoinError),
     /// Byte error
     #[error("Bytes must not be negative: {0}")]
-    Byte(#[from] ByteError),
+    Byte(#[from] byte_unit::ParseError),
     /// Failed to convert, value is 0
     #[error("Value provided must not be zero")]
     Zero,
@@ -109,17 +108,17 @@ impl UnixStream {
         }
 
         let bytes_per_second =
-            NonZeroU32::new(config.bytes_per_second.get_bytes() as u32).ok_or(Error::Zero)?;
+            NonZeroU32::new(config.bytes_per_second.as_u128() as u32).ok_or(Error::Zero)?;
         gauge!("bytes_per_second", &labels).set(f64::from(bytes_per_second.get()));
 
         let total_bytes =
-            NonZeroU32::new(config.maximum_prebuild_cache_size_bytes.get_bytes() as u32)
+            NonZeroU32::new(config.maximum_prebuild_cache_size_bytes.as_u128() as u32)
                 .ok_or(Error::Zero)?;
         let block_cache = match config.block_cache_method {
             block::CacheMethod::Fixed => block::Cache::fixed(
                 &mut rng,
                 total_bytes,
-                config.maximum_block_size.get_bytes(),
+                config.maximum_block_size.as_u128(),
                 &config.variant,
             )?,
         };


### PR DESCRIPTION
### What does this PR do?

This commit updates the byte-unit crate to the latest. There are many
API changes here but the newest version of the crate support math
operations directly on the type without coercion back and forth to
integer values.
