### PR TITLE
Release lading 0.25.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [0.25.9]
 ## Added
 - Introduce a `container` generator able to generate an arbitrary number
   of docker containers

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1650,7 +1650,7 @@ dependencies = [
 
 [[package]]
 name = "lading"
-version = "0.25.8"
+version = "0.25.9"
 dependencies = [
  "async-compression",
  "async-pidfd",

--- a/lading/Cargo.toml
+++ b/lading/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lading"
-version = "0.25.8"
+version = "0.25.9"
 authors = [
   "Brian L. Troutwine <brian.troutwine@datadoghq.com>",
   "George Hahn <george.hahn@datadoghq.com>",


### PR DESCRIPTION
### What does this PR do?

This release introduces a `container` generator that allows lading to spin and monitor user-provided containers as load for experiments that require scanning containers. Lading is not more strict about interpreting MiB / Mb etc in configurations. Strongly recommend to not mix and match. Lading generators will also no longer allow blocks larger than the throughput setting to pass through, a bug that impacted very low throughput use cases.
