### PR TITLE
[CONTINT-4562] Add WSS measurement (Working Set Size)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1680,6 +1680,7 @@ dependencies = [
  "num-traits",
  "num_cpus",
  "once_cell",
+ "page_size",
  "procfs",
  "proptest",
  "quanta",

--- a/lading/Cargo.toml
+++ b/lading/Cargo.toml
@@ -36,6 +36,7 @@ flate2 = { version = "1.1.1", default-features = false, features = [
 ] }
 futures = "0.3.31"
 fuser = { version = "0.15", optional = true }
+page_size = { version = "0.6.0" }
 heck  = { version = "0.5", default-features = false }
 http = { workspace = true }
 http-body-util = { workspace = true }

--- a/lading/src/observer/linux/wss.rs
+++ b/lading/src/observer/linux/wss.rs
@@ -1,0 +1,214 @@
+use metrics::gauge;
+use procfs::process::{MemoryMap, MemoryPageFlags, PageInfo, Pfn, Process};
+use std::collections::HashMap;
+use std::io::{Read, Seek, SeekFrom, Write};
+use tracing::debug;
+
+const PAGE_OFFSET: u64 = 0xffff_8800_0000_0000;
+
+#[derive(thiserror::Error, Debug)]
+pub enum Error {
+    /// Wrapper for [`std::io::Error`]
+    #[error("IO error: {0}")]
+    Io(#[from] std::io::Error),
+    /// Wrapper for [`procfs::ProcError`]
+    #[error("Unable to read procfs: {0}")]
+    Proc(#[from] procfs::ProcError),
+}
+
+#[derive(Debug)]
+pub(crate) struct Sampler {
+    parent_pid: i32,
+}
+
+impl Sampler {
+    pub(crate) fn new(parent_pid: i32) -> Result<Self, Error> {
+        Ok(Self { parent_pid })
+    }
+
+    pub(crate) async fn poll(&mut self) -> Result<(), Error> {
+        let page_size = page_size::get();
+        let mut pfn_set = PfnSet::new();
+
+        for process in ProcessDescendentsIterator::new(self.parent_pid) {
+            debug!("Process PID: {}", process.pid());
+            let mut pagemap = process.pagemap()?;
+            for MemoryMap {
+                address: (begin, end),
+                ..
+            } in process.maps()?
+            {
+                if begin > PAGE_OFFSET {
+                    continue; // page idle tracking is user mem only
+                }
+                debug!("Memory region: {:#x} — {:#x}", begin, end);
+                let begin = begin as usize / page_size;
+                let end = end as usize / page_size;
+                for page in pagemap.get_range_info(begin..end)? {
+                    if let PageInfo::MemoryPage(memory_page_flags) = page {
+                        if memory_page_flags.contains(MemoryPageFlags::PRESENT) {
+                            pfn_set.insert(memory_page_flags.get_page_frame_number());
+                        }
+                    }
+                }
+            }
+        }
+
+        let mut nb_pages = 0;
+
+        // See https://www.kernel.org/doc/html/latest/admin-guide/mm/idle_page_tracking.html
+        let mut page_idle_bitmap = std::fs::OpenOptions::new()
+            .read(true)
+            .write(true)
+            .open("/sys/kernel/mm/page_idle/bitmap")?;
+
+        for (pfn_block, pfn_bitset) in pfn_set {
+            page_idle_bitmap.seek(SeekFrom::Start(pfn_block * 8))?;
+
+            let mut buffer = [0; 8];
+            page_idle_bitmap.read_exact(&mut buffer)?;
+            let bitset = u64::from_ne_bytes(buffer);
+
+            nb_pages += (!bitset & pfn_bitset).count_ones() as usize;
+
+            page_idle_bitmap.seek(SeekFrom::Start(pfn_block * 8))?;
+            page_idle_bitmap.write_all(&pfn_bitset.to_ne_bytes())?;
+        }
+
+        gauge!("total_wss_bytes").set((nb_pages * page_size) as f64);
+
+        Ok(())
+    }
+}
+
+struct ProcessDescendentsIterator {
+    stack: Vec<Process>,
+}
+
+impl ProcessDescendentsIterator {
+    fn new(parent_pid: i32) -> Self {
+        Self {
+            stack: vec![
+                Process::new(parent_pid).expect(format!("process {parent_pid} not found").as_str()),
+            ],
+        }
+    }
+}
+
+impl Iterator for ProcessDescendentsIterator {
+    type Item = Process;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        while let Some(process) = self.stack.pop() {
+            if let Ok(tasks) = process.tasks() {
+                for task in tasks.flatten() {
+                    if let Ok(children) = task.children() {
+                        for child in children {
+                            if let Ok(c) = Process::new(child as i32) {
+                                self.stack.push(c);
+                            }
+                        }
+                    }
+                }
+            }
+            return Some(process);
+        }
+        None
+    }
+}
+
+#[derive(Debug)]
+struct PfnSet(HashMap<u64, u64>);
+
+impl PfnSet {
+    fn new() -> Self {
+        Self(HashMap::with_capacity(1024))
+    }
+
+    fn insert(&mut self, pfn: Pfn) {
+        *self.0.entry(pfn.0 / 64).or_default() |= 1 << (pfn.0 % 64);
+    }
+}
+
+impl IntoIterator for PfnSet {
+    type Item = (u64, u64);
+    type IntoIter = std::collections::hash_map::IntoIter<u64, u64>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.0.into_iter()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashSet;
+    use std::io::BufRead;
+    use std::io::BufReader;
+    use std::process::{Command, Stdio};
+
+    #[test]
+    fn process_descendants_iterator() {
+        const NB_PROCESSES_PER_LEVEL: usize = 3;
+        const NB_LEVELS: u32 = 3;
+        // The total number of processes is the sum of the NB_LEVELS first terms
+        // of the geometric progression with common ratio of NB_PROCESSES_PER_LEVEL.
+        const NB_PROCESSES: usize =
+            (NB_PROCESSES_PER_LEVEL.pow(NB_LEVELS + 1) - 1) / (NB_PROCESSES_PER_LEVEL - 1);
+
+        let mut child = Command::new("src/observer/linux/wss/tests/create_process_tree.py")
+            .arg(NB_PROCESSES_PER_LEVEL.to_string())
+            .arg(NB_LEVELS.to_string())
+            .stdout(Stdio::piped())
+            .spawn()
+            .expect("Failed to create process tree");
+
+        let mut children_pids = HashSet::with_capacity(NB_PROCESSES);
+        children_pids.insert(child.id() as i32);
+
+        let mut reader = BufReader::new(child.stdout.take().unwrap());
+        for _ in 0..NB_PROCESSES - 1 {
+            let mut line = String::new();
+            reader.read_line(&mut line).expect("Failed to read line");
+            let pid: i32 = line.trim().parse().expect("Failed to parse PID");
+            assert!(children_pids.insert(pid));
+        }
+
+        for process in ProcessDescendentsIterator::new(child.id() as i32) {
+            assert!(
+                children_pids.remove(&process.pid()),
+                "ProcessDescendentsIterator returned unexpected PID {pid}",
+                pid = process.pid()
+            );
+        }
+        assert!(
+            children_pids.is_empty(),
+            "ProcessDescendentsIterator didn’t return all PIDs: {children_pids:?}"
+        );
+
+        nix::sys::signal::kill(
+            nix::unistd::Pid::from_raw(child.id() as i32),
+            nix::sys::signal::Signal::SIGTERM,
+        )
+        .expect("Failed to kill process tree");
+
+        child
+            .wait()
+            .expect("Failed to wait for process tree completion");
+    }
+
+    #[test]
+    fn pfn_set() {
+        let input = vec![0, 64, 65, 66, 128, 136, 255];
+        let expected = vec![(0, 0x1), (1, 0x7), (2, 0x101), (3, 0x8000_0000_0000_0000)];
+
+        let mut pfn_set = PfnSet::new();
+        for i in input {
+            pfn_set.insert(Pfn(i));
+        }
+        let mut output: Vec<_> = pfn_set.into_iter().collect();
+        output.sort_by_key(|(k, _)| *k);
+
+        assert_eq!(output, expected);
+    }
+}

--- a/lading/src/observer/linux/wss/tests/create_process_tree.py
+++ b/lading/src/observer/linux/wss/tests/create_process_tree.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+"""
+This script creates a tree of idle processes with a specified depth and breadth.
+The processes are spawned using fork and will wait for a signal to terminate.
+
+Usage:
+    create_process_tree.py <number_of_processes> <depth>
+
+Example:
+    create_process_tree.py 3 2
+
+This will create a process tree with 3 processes at each level and a depth of 2.
+It would look like:
+
+```
+$ pstree -a -pg 30881
+python3,30881,30881 ./create_process_tree.py 3 2
+  ├─python3,30899,30881 ./create_process_tree.py 3 2
+  │   ├─python3,30902,30881 ./create_process_tree.py 3 2
+  │   ├─python3,30903,30881 ./create_process_tree.py 3 2
+  │   └─python3,30906,30881 ./create_process_tree.py 3 2
+  ├─python3,30900,30881 ./create_process_tree.py 3 2
+  │   ├─python3,30904,30881 ./create_process_tree.py 3 2
+  │   ├─python3,30907,30881 ./create_process_tree.py 3 2
+  │   └─python3,30909,30881 ./create_process_tree.py 3 2
+  └─python3,30901,30881 ./create_process_tree.py 3 2
+      ├─python3,30905,30881 ./create_process_tree.py 3 2
+      ├─python3,30908,30881 ./create_process_tree.py 3 2
+      └─python3,30910,30881 ./create_process_tree.py 3 2
+```
+
+Each process will print its PID.
+
+The script also includes a signal handler to terminate the whole process group
+when a SIGTERM signal is received.
+"""
+
+import argparse
+import logging
+import os
+import signal
+
+
+def spawn_processes(nb: int, depth: int) -> None:
+    """
+    Spawn a number of processes in a tree structure.
+
+    Args:
+        nb (int): Number of processes to spawn.
+        depth (int): Depth of the process tree.
+    """
+    if depth == 0 or nb <= 0:
+        return
+
+    for i in range(nb):
+        pid = os.fork()
+        if pid == 0:  # Child process
+            print(os.getpid(), flush=True)
+            logging.info(f"Child PID: {os.getpid()}, Parent PID: {os.getppid()}")
+            spawn_processes(nb, depth - 1)
+            signal.pause()
+
+
+def handler(signum: int, frame) -> None:
+    """
+    Signal handler to terminate the process group.
+
+    Args:
+        signum (int): Signal number.
+        frame (signal.FrameType): Current stack frame.
+    """
+    signal.signal(signal.SIGTERM, signal.SIG_DFL)
+    os.killpg(os.getpid(), signal.SIGTERM)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Create a process tree.")
+    parser.add_argument("nb", type=int, help="Number of processes to spawn per level")
+    parser.add_argument("depth", type=int, help="Depth of the process tree")
+    parser.add_argument(
+        "--log-level",
+        type=str,
+        default="warning",
+        help="Logging level",
+        choices=["debug", "info", "warning", "error", "critical"],
+    )
+    args = parser.parse_args()
+    logging.basicConfig(level=args.log_level.upper())
+
+    os.setpgid(0, 0)
+
+    spawn_processes(args.nb, args.depth)
+
+    signal.signal(signal.SIGTERM, handler)
+    signal.pause()


### PR DESCRIPTION
### What does this PR do?

Implement WSS (Working Set Size) measurement.

### Motivation

We need a metric that measures how much memory the target workload really uses.
The metric we currently use to asses memory consumption, RSS and PSS, are more measuring the amount of memory that has been allocated and it includes reclaimable memory.

### Related issues

### Additional Notes

See https://www.brendangregg.com/wss.html

Here is how to validate the new `total_wss_bytes` metric reported value:

1. Start an agent with no memory limit with:
```console
$ docker run --rm --cgroupns host --pid host --name dd-agent -e DD_HOSTNAME=lenaic-Precision-5570 -v /var/run/docker.sock:/var/run/docker.sock:ro -v /proc/:/host/proc/:ro -v /sys/fs/cgroup/:/host/sys/fs/cgroup:ro -e DD_API_KEY=$DD_API_KEY gcr.io/datadoghq/agent:7.65.0-rc.9 bash -c 'ln -s /etc/datadog-agent/datadog-docker.yaml /etc/datadog-agent/datadog.yaml && exec /opt/datadog-agent/bin/agent/agent run'
```

2. Collect the memory metrics with `lading`:
```console
$ target/debug/lading --config-path examples/lading-idle.yaml --target-container dd-agent --prometheus-addr 127.0.0.1:8080 --warmup-duration-seconds 0 --experiment-duration-seconds 3600
```

```console
$ curl -s http://localhost:8080 | grep -E 'total_[prw]ss_bytes'
# TYPE total_rss_bytes gauge
total_rss_bytes 190119936
# TYPE total_wss_bytes gauge
total_wss_bytes 108711936
# TYPE total_pss_bytes gauge
total_pss_bytes 190111744
```

| metric | value in bytes |
| :-- | --: |
| `total_pss_bytes` | 190111744 |
| `total_rss_bytes` | 190119936 |
| `total_wss_bytes` | 108711936 |

3. Stop the agent and restart it with a memory limit equal to the measured WSS + 10% of safety margin (119 MiB):

```console
$ docker run --rm --cgroupns host --pid host --name dd-agent -e DD_HOSTNAME=lenaic-Precision-5570 -v /var/run/docker.sock:/var/run/docker.sock:ro -v /proc/:/host/proc/:ro -v /sys/fs/cgroup/:/host/sys/fs/cgroup:ro -e DD_API_KEY=$DD_API_KEY --memory 119m --memory-swap 119m gcr.io/datadoghq/agent:7.65.0-rc.9 bash -c 'ln -s /etc/datadog-agent/datadog-docker.yaml /etc/datadog-agent/datadog.yaml && exec /opt/datadog-agent/bin/agent/agent run'
```

Observe that the agent is stable (10 minutes of uptime with no restart):

```console
$ docker ps
CONTAINER ID   IMAGE                                COMMAND                  CREATED          STATUS                    PORTS                                                                    NAMES
27beb411fc21   gcr.io/datadoghq/agent:7.65.0-rc.9   "bash -c 'ln -s /etc…"   10 minutes ago   Up 10 minutes (healthy)   8125/udp, 8126/tcp                                                       dd-agent
```

5. Stop the agent and restart it with a memory limit equal to 10% less that WSS (98 MiB):

```console
$ docker run --rm --cgroupns host --pid host --name dd-agent -e DD_HOSTNAME=lenaic-Precision-5570 -v /var/run/docker.sock:/var/run/docker.sock:ro -v /proc/:/host/proc/:ro -v /sys/fs/cgroup/:/host/sys/fs/cgroup:ro -e DD_API_KEY=$DD_API_KEY --memory 98m --memory-swap 98m gcr.io/datadoghq/agent:7.65.0-rc.9 bash -c 'ln -s /etc/datadog-agent/datadog-docker.yaml /etc/datadog-agent/datadog.yaml && exec /opt/datadog-agent/bin/agent/agent run'
```

Observe that the agent is eventually OOM killed:
```
avril 16 15:24:44 lenaic-Precision-5570 kernel: Memory cgroup out of memory: Killed process 174731 (agent) total-vm:3400360kB, anon-rss:77848kB, file-rss:96800kB, shmem-rss:0kB, UID:0 pgta>
avril 16 15:24:44 lenaic-Precision-5570 kernel: agent invoked oom-killer: gfp_mask=0xcc0(GFP_KERNEL), order=0, oom_score_adj=0
```

So, the value reported by `total_wss_bytes` represents the boundary between a memory limit too low that triggers OOM kills and a memory limit high enough to let the target workload run fine.