### PR TITLE
[CONTINT-4562] Add a parameter to continuously stop and recreate containers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ## Added
+- Compute the Working Set Size of the target thanks to the Linux Idle Page Tracking API.
+  And expose it in the new `total_wss_bytes` metric.
 - Add a `max_lifetime` parameter to the `container` generator to make it generate
   a continuous stream of docker containers deletion and re-creation.
 
@@ -13,8 +15,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Added
 - Introduce a `container` generator able to generate an arbitrary number
   of docker containers.
-- Compute the Working Set Size of the target thanks to the Linux Idle Page Tracking API.
-  And expose it in the new `total_wss_bytes` metric.
 ## Changed
 - Lading's byte-unit crate is now updated to 5.x. This version of the crate is
   very strict about the difference between MiB, Mb etc.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## Added
+- Add a `max_lifetime` parameter to the `container` generator to make it generate
+  a continuous stream of docker containers deletion and re-creation.
 
 ## [0.25.9]
 ## Added
 - Introduce a `container` generator able to generate an arbitrary number
-  of docker containers
+  of docker containers.
 ## Changed
 - Lading's byte-unit crate is now updated to 5.x. This version of the crate is
   very strict about the difference between MiB, Mb etc.

--- a/examples/lading-container.yaml
+++ b/examples/lading-container.yaml
@@ -19,4 +19,5 @@ generator:
       network_disabled: false
       exposed_ports:
         - 5000/tcp
+      max_lifetime: 20
       number_of_containers: 10

--- a/examples/lading-container.yaml
+++ b/examples/lading-container.yaml
@@ -19,5 +19,5 @@ generator:
       network_disabled: false
       exposed_ports:
         - 5000/tcp
-      max_lifetime: 20
+      max_lifetime_seconds: 20
       number_of_containers: 10


### PR DESCRIPTION
### What does this PR do?

Add a new `max_lifetime` parameter to the `container` generator.
This will make `lading` endlessly delete the oldest container and replace it with a newer one.

### Motivation

Some memory leaks inside the agent might happen each time a new container is detected or each time an old container is deleted.
In order to catch them, having a a static set of running containers during the duration of an experiment might not be enough.
We would like to generate a continuous stream of container deletion and container re-creation events.

### Related issues

### Additional Notes