### PR TITLE
Convert opentelemetry_metric to use MemberGenerator method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   a continuous stream of docker containers deletion and re-creation.
 - Block cache generation now logs its number of rejected, success blocks once
   the cache is created.
+- Added configurable metric kind weights in OpenTelemetry metrics payload generator.
 
 ## [0.25.9]
 ## Added

--- a/integration/sheepdog/src/lib.rs
+++ b/integration/sheepdog/src/lib.rs
@@ -493,7 +493,11 @@ generator:
         method:
           post:
             maximum_prebuild_cache_size_bytes: "8 MiB"
-            variant: "opentelemetry_metrics"
+            variant:
+              opentelemetry_metrics:
+                metric_weights:
+                  gauge: 50
+                  sum: 50
         headers:
             Content-Type: "application/x-protobuf"
         "#,

--- a/lading_payload/Cargo.toml
+++ b/lading_payload/Cargo.toml
@@ -53,3 +53,7 @@ doctest = false
 [[bench]]
 name = "default"
 harness = false
+
+[[bench]]
+name = "opentelemetry_metric"
+harness = false

--- a/lading_payload/benches/opentelemetry_metric.rs
+++ b/lading_payload/benches/opentelemetry_metric.rs
@@ -1,6 +1,6 @@
-use criterion::{BenchmarkId, Criterion, Throughput, criterion_group};
+use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
 
-use lading_payload::{OpentelemetryMetrics, Serialize};
+use lading_payload::{OpentelemetryMetrics, Serialize, opentelemetry_metric::Config};
 use rand::{SeedableRng, rngs::SmallRng};
 use std::time::Duration;
 
@@ -8,7 +8,9 @@ fn opentelemetry_metric_setup(c: &mut Criterion) {
     c.bench_function("opentelemetry_metric_setup", |b| {
         b.iter(|| {
             let mut rng = SmallRng::seed_from_u64(19690716);
-            let _ot = OpentelemetryMetrics::new(&mut rng);
+            let config = Config::default();
+            let _ot = OpentelemetryMetrics::new(config, &mut rng)
+                .expect("failed to create metrics generator");
         })
     });
 }
@@ -22,7 +24,9 @@ fn opentelemetry_metric_all(c: &mut Criterion) {
         group.bench_with_input(BenchmarkId::from_parameter(size), size, |b, &size| {
             b.iter(|| {
                 let mut rng = SmallRng::seed_from_u64(19690716);
-                let ot = OpentelemetryMetrics::new(&mut rng);
+                let config = Config::default();
+                let ot = OpentelemetryMetrics::new(config, &mut rng)
+                    .expect("failed to create metrics generator");
                 let mut writer = Vec::with_capacity(size);
 
                 ot.to_bytes(rng, size, &mut writer)
@@ -38,3 +42,5 @@ criterion_group!(
     config = Criterion::default().measurement_time(Duration::from_secs(90));
     targets = opentelemetry_metric_setup, opentelemetry_metric_all
 );
+
+criterion_main!(benches);

--- a/lading_payload/src/block.rs
+++ b/lading_payload/src/block.rs
@@ -328,8 +328,8 @@ impl Cache {
                 let _guard = span.enter();
                 construct_block_cache_inner(rng, &mut pyld, maximum_block_bytes, total_bytes.get())?
             }
-            crate::Config::OpentelemetryMetrics => {
-                let mut pyld = crate::OpentelemetryMetrics::new(&mut rng);
+            crate::Config::OpentelemetryMetrics(config) => {
+                let mut pyld = crate::OpentelemetryMetrics::new(*config, &mut rng)?;
                 let span = span!(Level::INFO, "fixed", payload = "otel-metrics");
                 let _guard = span.enter();
                 construct_block_cache_inner(rng, &mut pyld, maximum_block_bytes, total_bytes.get())?

--- a/lading_payload/src/lib.rs
+++ b/lading_payload/src/lib.rs
@@ -144,7 +144,7 @@ pub enum Config {
     /// Generates OpenTelemetry logs
     OpentelemetryLogs,
     /// Generates OpenTelemetry metrics
-    OpentelemetryMetrics,
+    OpentelemetryMetrics(crate::opentelemetry_metric::Config),
     /// Generates `DogStatsD`
     #[serde(rename = "dogstatsd")]
     DogStatsD(crate::dogstatsd::Config),


### PR DESCRIPTION
### What does this PR do?

This commit adapts the OTel metrics payload internals to use the same
internal mechanism as dogstatsd: a member generator that is capable of
being more fully configured than the previous full-random approach. The
intention here is to support a similar configuration surface among both
payloads.

I have added the ability for users to customize their metric weights,
    in a like manner to dogstatsd. In my follow-on commits I will add more
    of the dogstatsd surface area and interior implementation, like the
    use of templates to avoid reallocation of the same small strings
    over and over again.

### Motivation

REF SMPTNG-659
