### PR TITLE
Migrate OTel/dogstatsd common functions to src/common

### DIFF
--- a/lading_payload/src/common.rs
+++ b/lading_payload/src/common.rs
@@ -1,1 +1,2 @@
+pub(crate) mod config;
 pub(crate) mod strings;

--- a/lading_payload/src/common/config.rs
+++ b/lading_payload/src/common/config.rs
@@ -1,0 +1,67 @@
+use rand::distr::uniform::SampleUniform;
+use serde::{Deserialize, Serialize as SerdeSerialize};
+use std::cmp;
+
+/// Range expression for configuration
+#[derive(Debug, Deserialize, SerdeSerialize, Clone, PartialEq, Copy)]
+#[serde(deny_unknown_fields)]
+#[serde(rename_all = "snake_case")]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+
+pub enum ConfRange<T>
+where
+    T: PartialEq + cmp::PartialOrd + Clone + Copy,
+{
+    /// A constant T
+    Constant(T),
+    /// In which a T is chosen between `min` and `max`, inclusive of `max`.
+    Inclusive {
+        /// The minimum of the range.
+        min: T,
+        /// The maximum of the range.
+        max: T,
+    },
+}
+
+impl<T> ConfRange<T>
+where
+    T: PartialEq + cmp::PartialOrd + Clone + Copy,
+{
+    /// Returns true if the range provided by the user is valid, false
+    /// otherwise.
+    pub(crate) fn valid(&self) -> (bool, &'static str) {
+        match self {
+            Self::Constant(_) => (true, ""),
+            Self::Inclusive { min, max } => (min < max, "min must be less than max"),
+        }
+    }
+
+    pub(crate) fn start(&self) -> T {
+        match self {
+            ConfRange::Constant(c) => *c,
+            ConfRange::Inclusive { min, .. } => *min,
+        }
+    }
+
+    pub(crate) fn end(&self) -> T {
+        match self {
+            ConfRange::Constant(c) => *c,
+            ConfRange::Inclusive { max, .. } => *max,
+        }
+    }
+}
+
+impl<T> ConfRange<T>
+where
+    T: PartialEq + cmp::PartialOrd + Clone + Copy + SampleUniform,
+{
+    pub(crate) fn sample<R>(&self, rng: &mut R) -> T
+    where
+        R: rand::Rng + ?Sized,
+    {
+        match self {
+            ConfRange::Constant(c) => *c,
+            ConfRange::Inclusive { min, max } => rng.random_range(*min..=*max),
+        }
+    }
+}

--- a/lading_payload/src/dogstatsd/event.rs
+++ b/lading_payload/src/dogstatsd/event.rs
@@ -5,7 +5,9 @@ use rand::{Rng, distr::StandardUniform, prelude::Distribution};
 
 use crate::{Error, Generator, common::strings};
 
-use super::{ConfRange, choose_or_not_fn, common};
+use self::strings::choose_or_not_fn;
+
+use super::{ConfRange, common};
 
 #[derive(Debug, Clone)]
 pub(crate) struct EventGenerator {

--- a/lading_payload/src/dogstatsd/metric.rs
+++ b/lading_payload/src/dogstatsd/metric.rs
@@ -11,8 +11,10 @@ use rand::{
 use crate::{Error, Generator, common::strings, dogstatsd::metric::template::Template};
 use tracing::debug;
 
+use self::strings::choose_or_not_ref;
+
 use super::{
-    ConfRange, ValueConf, choose_or_not_ref,
+    ConfRange, ValueConf,
     common::{self, NumValueGenerator},
 };
 

--- a/lading_payload/src/dogstatsd/service_check.rs
+++ b/lading_payload/src/dogstatsd/service_check.rs
@@ -3,12 +3,9 @@ use std::fmt;
 
 use rand::{Rng, distr::StandardUniform, prelude::Distribution, seq::IndexedRandom};
 
-use crate::{Error, Generator};
+use crate::{Error, Generator, common::strings::choose_or_not_ref};
 
-use super::{
-    choose_or_not_ref,
-    common::{self, tags::Tagset},
-};
+use super::common::{self, tags::Tagset};
 
 #[derive(Debug, Clone)]
 pub(crate) struct ServiceCheckGenerator {


### PR DESCRIPTION
### What does this PR do?

 Migrate OTel/dogstatsd common functions to src/common

This commit is in preparation for more extensive changes to the OTel metrics
    payload. I have scooted common configuration and string selection functions up
    into the crate common sub-tree.


### Motivation

REF SMPTNG-659
