### PR TITLE
Generate units according to OTel required spec

### DIFF
--- a/lading_payload/src/lib.rs
+++ b/lading_payload/src/lib.rs
@@ -81,6 +81,9 @@ pub enum Error {
     /// See [`weighted::Error`]
     #[error(transparent)]
     Weights(#[from] weighted::Error),
+    /// See [`unit::Error`]
+    #[error(transparent)]
+    Unit(#[from] opentelemetry_metric::unit::Error),
 }
 
 /// To serialize into bytes

--- a/lading_payload/src/opentelemetry_metric/unit.rs
+++ b/lading_payload/src/opentelemetry_metric/unit.rs
@@ -1,0 +1,43 @@
+//! Code to generate units according to
+//! <http://unitsofmeasure.org/ucum.html>. This may be generally
+//! useful in the project and is not specifically tied to the OpenTelemetry metrics
+//! implementation.
+
+// The spec defines a fairly elaborate grammar. It's unclear that we need _all_
+// that for our purposes, so for now we rely on a simple table method. I imagine
+// we can just keep stuffing the table for a while as seems desirable.
+
+const UNITS: &[&str] = &[
+    "bit", "Kbit", "Mbit", "Gbit", // data size, bits, decimal
+    "Kibit", "Mibit", "Gibit", // data size, bits, binary
+    "By", "KBy", "MBy", "GBy", // data size, bytes, decimal
+    "KiBy", "MiBy", "GiBy", // data size, bytes, binary
+    "By/s", "KiBy/s", "bit/s", "Mbit/s", // transfer rate
+    "s", "ms", "us", "ns", // time
+    "W", "kW", "kWh", // power
+];
+
+/// Errors related to generation
+#[derive(thiserror::Error, Debug, Clone, Copy)]
+pub enum Error {}
+
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct UnitGenerator {}
+
+impl UnitGenerator {
+    pub(crate) fn new() -> Self {
+        Self {}
+    }
+}
+
+impl crate::Generator<'_> for UnitGenerator {
+    type Output = &'static str;
+    type Error = Error;
+
+    fn generate<R>(&self, rng: &mut R) -> Result<Self::Output, Self::Error>
+    where
+        R: rand::Rng + ?Sized,
+    {
+        Ok(UNITS[rng.random_range(0..UNITS.len())])
+    }
+}


### PR DESCRIPTION
### What does this PR do?

This commit adds a generator for UCUM units and replaces the purely random
    strings we were using previously. We use an explicitly enumeraged table which
    won't work forever but probably will work for many years until we learn
    otherwise. Note that UCUM specifies a number of units do not produce.

REF SMPTNG-659

