### PR TITLE
Make tagset generation generic

### DIFF
--- a/lading_payload/src/common.rs
+++ b/lading_payload/src/common.rs
@@ -1,2 +1,3 @@
 pub(crate) mod config;
 pub(crate) mod strings;
+pub(crate) mod tags;

--- a/lading_payload/src/common/config.rs
+++ b/lading_payload/src/common/config.rs
@@ -32,7 +32,7 @@ where
     pub(crate) fn valid(&self) -> (bool, &'static str) {
         match self {
             Self::Constant(_) => (true, ""),
-            Self::Inclusive { min, max } => (min < max, "min must be less than max"),
+            Self::Inclusive { min, max } => (min <= max, "min must be less than or equal to max"),
         }
     }
 

--- a/lading_payload/src/common/strings.rs
+++ b/lading_payload/src/common/strings.rs
@@ -120,6 +120,7 @@ impl Pool {
 
     /// Given an opaque handle returned from `*_with_handle`, return the &str it represents
     #[must_use]
+    #[inline]
     pub(crate) fn using_handle(&self, handle: Handle) -> Option<&str> {
         let (offset, length) = handle;
         if offset + length < self.inner.len() {

--- a/lading_payload/src/common/strings.rs
+++ b/lading_payload/src/common/strings.rs
@@ -22,7 +22,10 @@ pub(crate) struct Pool {
 }
 
 /// Opaque 'str' handle for the pool
-pub(crate) type Handle = (usize, usize);
+///
+// The pool will not index more than 2**32. Using a type smaller than `usize`
+// allows a more compact representation.
+pub(crate) type Handle = (u32, u32);
 
 impl Pool {
     /// Create a new instance of `Pool` with the default alpha-numeric character
@@ -31,6 +34,7 @@ impl Pool {
     where
         R: rand::Rng + ?Sized,
     {
+        assert!(u32::try_from(bytes).is_ok());
         Self::with_size_and_alphabet(rng, bytes, ALPHANUM)
     }
 
@@ -97,10 +101,18 @@ impl Pool {
         }
 
         let max_lower_idx = self.inner.len() - bytes;
-        let lower_idx = rng.random_range(0..max_lower_idx);
-        let upper_idx = lower_idx + bytes;
+        let lower_idx: usize = rng.random_range(0..max_lower_idx);
+        let upper_idx: usize = lower_idx + bytes;
 
-        Some((&self.inner[lower_idx..upper_idx], (lower_idx, bytes)))
+        Some((
+            &self.inner[lower_idx..upper_idx],
+            (
+                lower_idx
+                    .try_into()
+                    .expect("must fit into u32 by construction"),
+                bytes.try_into().expect("must fit in u32 by construction"),
+            ),
+        ))
     }
 
     /// Return a `&str` from the interior storage with size selected from `bytes_range`. Result will
@@ -123,6 +135,8 @@ impl Pool {
     #[inline]
     pub(crate) fn using_handle(&self, handle: Handle) -> Option<&str> {
         let (offset, length) = handle;
+        let offset = offset as usize;
+        let length = length as usize;
         if offset + length < self.inner.len() {
             let str = &self.inner[offset..offset + length];
             Some(str)

--- a/lading_payload/src/common/tags.rs
+++ b/lading_payload/src/common/tags.rs
@@ -391,7 +391,7 @@ mod test {
             tag_size_max in 64..128_u16,
             pool_size in 1_024..10_000_usize
         ) {
-            let tags_per_msg_range = ConfRange::Inclusive { min: 2, max: tags_per_msg_max };
+            let tags_per_msg_range = ConfRange::Inclusive { min: 0, max: tags_per_msg_max };
             let tag_size_range = ConfRange::Inclusive { min: tag_size_min, max: tag_size_max };
             let mut rng = SmallRng::seed_from_u64(seed);
 

--- a/lading_payload/src/common/tags.rs
+++ b/lading_payload/src/common/tags.rs
@@ -1,0 +1,207 @@
+//! Tag generation for dogstatsd payloads
+use std::cell::{Cell, RefCell};
+use std::rc::Rc;
+
+use rand::Rng;
+use rand::{SeedableRng, rngs::SmallRng};
+use rand::{
+    distr::{Distribution, OpenClosed01},
+    seq::IndexedRandom,
+};
+use tracing::warn;
+
+use crate::common::{
+    config::ConfRange,
+    strings::{Handle, Pool},
+};
+
+pub(crate) const MIN_UNIQUE_TAG_RATIO: f32 = 0.01;
+pub(crate) const MAX_UNIQUE_TAG_RATIO: f32 = 1.00;
+pub(crate) const WARN_UNIQUE_TAG_RATIO: f32 = 0.10;
+pub(crate) const MIN_TAG_LENGTH: u16 = 3;
+
+/// List of tags that will be present on a dogstatsd message
+#[derive(Debug, Default, Clone, Copy)]
+pub(crate) struct Tag {
+    pub(crate) key: Handle,
+    pub(crate) value: Handle,
+}
+pub(crate) type Tagset = Vec<Tag>;
+
+/// Generator for tags
+///
+/// This is an unusual generator. Unlike our others this maintains its own RNG
+/// and will reseed it when counter reaches `num_tagsets`. The goal is to
+/// produce only a limited, deterministic set of tags while avoiding needing to
+/// allocate them all in one shot.
+///
+/// The `unique_tag_ratio` is a value between 0.10 and 1.0. It represents the
+/// ratio of new tags to existing tags. If the value is 1.0, then all tags will
+/// be new. If the value 0.0 were allowed, it would conceptually mean "always
+/// use an existing tag", however this is a degenerate case as there would never
+/// be a new tag generated. Therefore a minimum value is enforced.  Despite this
+/// minimum, if the configuration is overly restrictive, it may result in
+/// non-unique tagsets.
+///
+/// As an example:
+/// `unique_tag_probability`: 0.10
+/// `tags_per_msg`: 3
+/// `num_tagsets`: 1000
+///
+/// With 3 tags per message, and a 10% chance of generating a new tag, 1000
+/// calls to generate will result in 3000 "get new tag" decisions.  300 of these
+/// will result in new tags and 2700 of these will re-use an existing tag. With
+/// only 300 chances for new entropy, each individual tagset will likely
+/// over-sample the existing tags and therefore UNDER-generate the desired
+/// number of unique tagsets.
+#[derive(Debug, Clone)]
+pub(crate) struct Generator {
+    seed: Cell<u64>,
+    internal_rng: RefCell<SmallRng>,
+    tagsets_produced: Cell<usize>,
+    num_tagsets: usize,
+    tags_per_msg: ConfRange<u8>,
+    tag_length: ConfRange<u16>,
+    str_pool: Rc<Pool>,
+    unique_tag_probability: f32,
+    unique_tags: RefCell<Vec<Tag>>,
+}
+
+/// Error type for `TagGenerator`
+#[derive(thiserror::Error, Debug)]
+pub(crate) enum Error {
+    /// Invalid construction
+    #[error("Invalid construction: {0}")]
+    InvalidConstruction(String),
+}
+
+impl Generator {
+    /// Creates a new tag generator
+    ///
+    /// # Errors
+    /// - If `tags_per_msg` is invalid or exceeds the maximum
+    /// - If `tag_length` is invalid or has minimum value less than 3
+    /// - If `unique_tag_probability` is not between 0.10 and 1.0
+    pub(crate) fn new(
+        seed: u64,
+        tags_per_msg: ConfRange<u8>,
+        tag_length: ConfRange<u16>,
+        num_tagsets: usize,
+        str_pool: Rc<Pool>,
+        unique_tag_probability: f32,
+    ) -> Result<Self, Error> {
+        let (tag_length_valid, tag_length_valid_msg) = tag_length.valid();
+        if !tag_length_valid {
+            return Err(Error::InvalidConstruction(format!(
+                "Invalid tag length: {tag_length_valid_msg}"
+            )));
+        }
+        if tag_length.start() < MIN_TAG_LENGTH {
+            return Err(Error::InvalidConstruction(format!(
+                "Tag length must be at least {MIN_TAG_LENGTH}, found {start}",
+                start = tag_length.start()
+            )));
+        }
+
+        if !(MIN_UNIQUE_TAG_RATIO..=MAX_UNIQUE_TAG_RATIO).contains(&unique_tag_probability) {
+            return Err(Error::InvalidConstruction(format!(
+                "Unique tag ratio must be between {MIN_UNIQUE_TAG_RATIO} and {MAX_UNIQUE_TAG_RATIO}"
+            )));
+        }
+
+        if (MIN_UNIQUE_TAG_RATIO..=WARN_UNIQUE_TAG_RATIO).contains(&unique_tag_probability) {
+            warn!(
+                "unique_tag_probability is less than {WARN_UNIQUE_TAG_RATIO}. This may result in non-unique tagsets"
+            );
+        }
+
+        let rng = SmallRng::seed_from_u64(seed);
+
+        Ok(Generator {
+            seed: Cell::new(seed),
+            internal_rng: RefCell::new(rng),
+            tags_per_msg,
+            tag_length,
+            str_pool,
+            tagsets_produced: Cell::new(0),
+            num_tagsets,
+            unique_tag_probability,
+            unique_tags: RefCell::new(Vec::new()),
+        })
+    }
+
+    /// Given an opaque handle returned from `generate`, return the &str it
+    /// represents. None if handle is not valid.
+    #[must_use]
+    #[inline]
+    pub(crate) fn using_handle(&self, handle: Handle) -> Option<&str> {
+        self.str_pool.using_handle(handle)
+    }
+}
+
+impl<'a> crate::Generator<'a> for Generator {
+    type Output = Tagset;
+    type Error = crate::Error;
+
+    /// Return a tagset -- a list of tags, each tag having the format `key:value`
+    /// Note that after `num_tagsets` have been produced, the tagsets will loop and produce
+    /// identical tagsets.
+    /// Each tagset is randomly chosen. There is a very high probability that each tagset
+    /// will be unique, however see the note in the component documentation.
+    fn generate<R>(&'a self, _rng: &mut R) -> Result<Self::Output, Self::Error>
+    where
+        R: rand::Rng + ?Sized,
+    {
+        // If we have produced the number of tagsets we are supposed to produce,
+        // then reseed the internal RNG this ensures that we generate the same
+        // tags in a loop
+        if self.tagsets_produced.get() >= self.num_tagsets {
+            // Reseed internal RNG with initial seed
+            self.internal_rng
+                .replace(SmallRng::seed_from_u64(self.seed.get()));
+            self.tagsets_produced.set(0);
+        }
+
+        let mut tagset: Tagset = Vec::new();
+        let mut rng = self.internal_rng.borrow_mut();
+        let tags_count = self.tags_per_msg.sample(&mut *rng) as usize;
+        for _ in 0..tags_count {
+            let choose_existing_prob: f32 = OpenClosed01.sample(&mut *rng);
+
+            let mut unique_tags = self.unique_tags.borrow_mut();
+            let attempted_tag = if choose_existing_prob > self.unique_tag_probability {
+                unique_tags.choose(&mut rng).copied()
+            } else {
+                None
+            };
+
+            // If a tag was chosen from the existing set, no need to grab a new tag.
+            if let Some(tag) = attempted_tag {
+                tagset.push(tag);
+            } else {
+                let desired_size = self.tag_length.sample(&mut *rng) as usize;
+                // randomly split this between two strings
+                let key_size = rng.random_range(1..desired_size);
+                let value_size = desired_size - key_size;
+
+                let key_handle = self.str_pool.of_size_with_handle(&mut *rng, key_size);
+                let value_handle = self.str_pool.of_size_with_handle(&mut *rng, value_size);
+
+                match (key_handle, value_handle) {
+                    (Some((_, key_handle)), Some((_, value_handle))) => {
+                        let tag: Tag = Tag {
+                            key: key_handle,
+                            value: value_handle,
+                        };
+                        unique_tags.push(tag);
+                        tagset.push(tag);
+                    }
+                    _ => panic!("failed to generate tag"),
+                }
+            };
+        }
+
+        self.tagsets_produced.set(self.tagsets_produced.get() + 1);
+        Ok(tagset)
+    }
+}

--- a/lading_payload/src/common/tags.rs
+++ b/lading_payload/src/common/tags.rs
@@ -59,6 +59,11 @@ impl TagStore {
             Some(&self.vec[idx])
         }
     }
+
+    fn clear(&mut self) {
+        self.set.clear();
+        self.vec.clear();
+    }
 }
 
 /// Generator for individual tags
@@ -243,7 +248,7 @@ impl<'a> crate::Generator<'a> for Generator {
             // Reseed internal RNG with initial seed
             self.internal_rng
                 .replace(SmallRng::seed_from_u64(self.seed.get()));
-            self.tag_store.replace(TagStore::new());
+            self.tag_store.borrow_mut().clear();
             self.tagsets_produced.set(0);
         }
 

--- a/lading_payload/src/common/tags.rs
+++ b/lading_payload/src/common/tags.rs
@@ -294,6 +294,7 @@ mod test {
     use crate::Generator;
     use crate::common::config::ConfRange;
     use crate::common::strings::Pool;
+    use crate::common::tags::Handle;
 
     proptest! {
         #[test]
@@ -404,14 +405,20 @@ mod test {
                 unique_tag_ratio
             ).expect("Tag generator to be valid");
 
-            let mut unique_tags = HashSet::new();
+            let mut unique_tagsets: HashSet<Vec<(Handle, Handle)>> = HashSet::new();
             for _ in 0..desired_num_tagsets {
-                let tagset = generator.generate(&mut rng).expect("failed to generate tagset");
-                for tag in tagset {
-                    unique_tags.insert((tag.key, tag.value));
-                }
+                let ts = generator.generate(&mut rng)?;
+                // Hash the tag-set as an ordered list of (key,value) pairs
+                unique_tagsets.insert(
+                    ts.iter().map(|t| (t.key, t.value)).collect()
+                );
             }
-            debug_assert!(unique_tags.len() <= desired_num_tagsets, "Expected at most {desired_num_tagsets} unique tags, got {}", unique_tags.len());
+
+            debug_assert!(
+                unique_tagsets.len() <= desired_num_tagsets,
+                "Expected at most {desired_num_tagsets} unique tag-sets, got {}",
+                unique_tagsets.len()
+            );
         }
     }
 }

--- a/lading_payload/src/dogstatsd/common/tags.rs
+++ b/lading_payload/src/dogstatsd/common/tags.rs
@@ -75,7 +75,11 @@ impl<'a> crate::Generator<'a> for Generator {
                 .inner
                 .using_handle(value)
                 .expect("invalid handle, catastrophic bug");
-            tagset.push(format!("{key_s}:{val_s}"));
+            let mut s = String::with_capacity(key_s.len() + 1 + val_s.len());
+            s.push_str(key_s);
+            s.push(':');
+            s.push_str(val_s);
+            tagset.push(s);
         }
         Ok(tagset)
     }
@@ -142,10 +146,10 @@ mod test {
 
     proptest! {
         #[test]
-        fn tagsets_repeat_after_reaching_tagset_max(seed: u64, num_tagsets in 1..100_000_usize) {
+        fn tagsets_repeat_after_reaching_tagset_max(seed: u64, num_tagsets in 1..10_000_usize) {
             let mut rng = SmallRng::seed_from_u64(seed);
 
-            let str_pool = Rc::new(Pool::with_size(&mut rng, 8_000_000));
+            let str_pool = Rc::new(Pool::with_size(&mut rng, 1_000_000));
             let tags_per_msg_range = ConfRange::Inclusive { min: 0, max: 25 };
             let tag_size_range = ConfRange::Inclusive { min: 3, max: 128 };
             let generator =
@@ -179,10 +183,10 @@ mod test {
 
     proptest! {
         #[test]
-        fn generator_yields_valid_tagsets(seed: u64, num_tagsets in 1..100_000_usize, tags_per_msg_max in 1..u8::MAX) {
+        fn generator_yields_valid_tagsets(seed: u64, num_tagsets in 1..10_000_usize, tags_per_msg_max in 1..u8::MAX) {
             let mut rng = SmallRng::seed_from_u64(seed);
 
-            let str_pool = Rc::new(Pool::with_size(&mut rng, 8_000_000));
+            let str_pool = Rc::new(Pool::with_size(&mut rng, 1_000_000));
             let tags_per_msg_range = ConfRange::Inclusive{min: 0, max: tags_per_msg_max};
             let tag_size_range = ConfRange::Inclusive{min: 3, max: 128};
             let generator = tags::Generator::new(
@@ -214,12 +218,12 @@ mod test {
         /// This test asserts that when the  is 1.0, we always are able to hit
         /// the desired number of unique tagsets no matter what.
         #[test]
-        fn uniquetagsets_respected_always_unique_tags(seed: u64, desired_num_tagsets in 1..100_000_usize) {
-            let tags_per_msg_range = ConfRange::Inclusive { min: 2, max: 50 };
+        fn unique_tagsets_respected_always_unique_tags(seed: u64, desired_num_tagsets in 1..10_000_usize) {
+            let tags_per_msg_range = ConfRange::Inclusive { min: 2, max: 25 };
             let tag_size_range = ConfRange::Inclusive { min: 3, max: 128 };
             let mut rng = SmallRng::seed_from_u64(seed);
 
-            let str_pool = Rc::new(Pool::with_size(&mut rng, 8_000_000));
+            let str_pool = Rc::new(Pool::with_size(&mut rng, 1_000_000));
             let generator = tags::Generator::new(
                 seed,
                 tags_per_msg_range,
@@ -252,12 +256,12 @@ mod test {
         /// The goal of this test is to vary the unique_tag_probability between the WARN and MAX
         /// levels and ensure that we are always able to generate the desired number of unique tagsets
         #[test]
-        fn uniquetagsets_respected_with_varying_ratio(seed: u64, desired_num_tagsets in 5..100_000_usize, unique_tag_ratio in WARN_UNIQUE_TAG_RATIO..MAX_UNIQUE_TAG_RATIO) {
-            let tags_per_msg_range = ConfRange::Inclusive { min: 2, max: 50 };
+        fn unique_tagsets_respected_with_varying_ratio(seed: u64, desired_num_tagsets in 5..10_000_usize, unique_tag_ratio in WARN_UNIQUE_TAG_RATIO..MAX_UNIQUE_TAG_RATIO) {
+            let tags_per_msg_range = ConfRange::Inclusive { min: 2, max: 25 };
             let tag_size_range = ConfRange::Inclusive { min: 3, max: 128 };
             let mut rng = SmallRng::seed_from_u64(seed);
 
-            let str_pool = Rc::new(Pool::with_size(&mut rng, 8_000_000));
+            let str_pool = Rc::new(Pool::with_size(&mut rng, 1_000_000));
             let generator = tags::Generator::new(
                 seed,
                 tags_per_msg_range,


### PR DESCRIPTION
### What does this PR do?

The goal of this commit is to take the dogstatsd specific tagset code and
    allow it to be generally reused among dogstatsd and otel metrics. I have
    demonstrated that dogstatsd is not affected in this PR. I will update the
    otel metrics code in a follow-on.

REF SMPTNG-659
