### PR TITLE
Use prop_assert* in property tests

### DIFF
--- a/lading/src/generator/file_gen/logrotate_fs/model.rs
+++ b/lading/src/generator/file_gen/logrotate_fs/model.rs
@@ -1092,7 +1092,7 @@ mod test {
         // read past the maximum bytes available.
         for node in state.nodes.values() {
             if let Node::File { file } = node {
-                assert!(
+                prop_assert!(
                     file.bytes_written >= file.max_offset_observed,
                     "bytes_written ({}) < max_offset_observed ({})",
                     file.bytes_written,
@@ -1104,7 +1104,7 @@ mod test {
         // Property 2: status_tick == modified_tick || status_tick == access_tick
         for node in state.nodes.values() {
             if let Node::File { file } = node {
-                assert!(
+                prop_assert!(
                     file.status_tick == file.modified_tick || file.status_tick == file.access_tick,
                     "status_tick ({}) != modified_tick ({}) or access_tick ({})",
                     file.status_tick,
@@ -1134,9 +1134,12 @@ mod test {
                         }
 
                         if let Some(Node::File { file: peer_file }) = state.nodes.get(&peer_inode) {
-                            assert!(!peer_file.unlinked, "File was found in peer chain unlinked");
+                            prop_assert!(
+                                !peer_file.unlinked,
+                                "File was found in peer chain unlinked"
+                            );
                             expected_ordinal += 1;
-                            assert_eq!(
+                            prop_assert_eq!(
                                 peer_file.ordinal,
                                 expected_ordinal,
                                 "Expected ordinal {expected_ordinal}, got {peer_file_ordinal}",
@@ -1159,7 +1162,7 @@ mod test {
                 if file.unlinked {
                     continue;
                 }
-                assert!(
+                prop_assert!(
                     file.ordinal <= state.max_rotations,
                     "Ordinal {ordinal} exceeds max_rotations {max_rotations}: {state:#?}",
                     ordinal = file.ordinal,
@@ -1199,7 +1202,7 @@ mod test {
                 if let Some(names) = state.group_names.get(file.group_id as usize) {
                     if let Some(expected_name) = names.get(file.ordinal as usize) {
                         let actual_name = state.get_name(inode).unwrap_or("");
-                        assert_eq!(
+                        prop_assert_eq!(
                             actual_name,
                             expected_name.as_str(),
                             "Inode {inode} name mismatch: expected {expected_name}, got {actual_name}",
@@ -1229,8 +1232,9 @@ mod test {
                     file.created_tick,
                     end_tick,
                 );
-                assert_eq!(
-                    file.bytes_written, expected_bytes,
+                prop_assert_eq!(
+                    file.bytes_written,
+                    expected_bytes,
                     "bytes_written ({}) does not match expected_bytes_written ({expected_bytes}) for file with inode {inode}",
                     file.bytes_written,
                 );
@@ -1253,7 +1257,7 @@ mod test {
                 let max_size = state
                     .max_bytes_per_file
                     .saturating_add(2 * file.bytes_per_tick);
-                assert!(
+                prop_assert!(
                     file.bytes_written >= min_size && file.bytes_written <= max_size,
                     "Rotated file size {actual} not in expected range [{min_size}, {max_size}]",
                     actual = file.bytes_written
@@ -1273,7 +1277,7 @@ mod test {
                 if file.unlinked && file.read_only {
                     if file.open_handles > 0 {
                         // Should remain in state.nodes
-                        assert!(
+                        prop_assert!(
                             state.nodes.contains_key(&inode),
                             "Unlinked, read-only file with open handles should remain in state.nodes"
                         );
@@ -1291,13 +1295,13 @@ mod test {
                             })
                             .collect();
 
-                        assert!(
+                        prop_assert!(
                             !valid_handles.is_empty(),
                             "Unlinked, read-only file with open handles should have valid file handles"
                         );
                     } else {
                         // Should be removed from state.nodes after GC
-                        assert!(
+                        prop_assert!(
                             !state.nodes.contains_key(&inode),
                             "Unlinked, read-only file with zero open handles should be removed from state.nodes"
                         );

--- a/lading/src/generator/file_gen/logrotate_fs/model.rs
+++ b/lading/src/generator/file_gen/logrotate_fs/model.rs
@@ -1370,7 +1370,7 @@ mod test {
                 Operation::Open => {
                     let inode = random_inode(&mut rng, &state);
                     if let Some(handle) = state.open_file(now, inode) {
-                        assert!(handle.inode == inode);
+                        prop_assert!(handle.inode == inode);
                         open_handles.insert(handle.inode, handle);
                     }
                 }

--- a/lading_payload/proptest-regressions/dogstatsd/common/tags.txt
+++ b/lading_payload/proptest-regressions/dogstatsd/common/tags.txt
@@ -5,3 +5,4 @@
 # It is recommended to check this file in to source control so that
 # everyone who runs the test benefits from these saved cases.
 cc 9c7455b354ddc3d731190002edf0877dd19bf97e09f4bb0450ec2306334b07ff # shrinks to seed = 0, desired_num_tagsets = 1
+cc b3ca67731c6c3eb6721e97865edaa68be560099593954e61d2e5265102389b8a # shrinks to seed = 3082872044793773844, desired_num_tagsets = 5, unique_tag_ratio = 0.1

--- a/lading_payload/src/apache_common.rs
+++ b/lading_payload/src/apache_common.rs
@@ -381,7 +381,7 @@ mod test {
 
             let mut bytes = Vec::with_capacity(max_bytes);
             apache.to_bytes(rng, max_bytes, &mut bytes).expect("failed to convert to bytes");
-            debug_assert!(
+            prop_assert!(
                 bytes.len() <= max_bytes,
                 "{:?}",
                 std::str::from_utf8(&bytes).expect("failed to convert from utf-8 to str")

--- a/lading_payload/src/common/strings.rs
+++ b/lading_payload/src/common/strings.rs
@@ -228,7 +228,7 @@ mod test {
             let pool = Pool::with_size_and_alphabet(&mut rng, max_bytes, ALPHANUM);
             if let Some(s) = pool.of_size(&mut rng, of_size_bytes) {
                 for c in s.bytes() {
-                    assert!(ALPHANUM.contains(&c));
+                    prop_assert!(ALPHANUM.contains(&c));
                 }
             }
         }
@@ -244,7 +244,7 @@ mod test {
 
             let pool = Pool::with_size_and_alphabet(&mut rng, max_bytes, ALPHANUM);
             if let Some(s) = pool.of_size(&mut rng, of_size_bytes) {
-                assert!(s.len() == of_size_bytes);
+                prop_assert!(s.len() == of_size_bytes);
             }
         }
     }
@@ -260,7 +260,7 @@ mod test {
 
             let pool = Pool::with_size_and_alphabet(&mut rng, max_bytes, ALPHANUM);
             if pool.of_size(&mut rng, of_size_bytes).is_none() {
-                assert!(of_size_bytes >= max_bytes);
+                prop_assert!(of_size_bytes >= max_bytes);
             }
         }
     }

--- a/lading_payload/src/datadog_logs.rs
+++ b/lading_payload/src/datadog_logs.rs
@@ -182,7 +182,7 @@ mod test {
 
             let mut bytes = Vec::with_capacity(max_bytes);
             ddlogs.to_bytes(rng, max_bytes, &mut bytes).expect("failed to convert to bytes");
-            debug_assert!(
+            prop_assert!(
                 bytes.len() <= max_bytes,
                 "{:?}",
                 std::str::from_utf8(&bytes).expect("failed to convert from utf-8 to str")

--- a/lading_payload/src/dogstatsd.rs
+++ b/lading_payload/src/dogstatsd.rs
@@ -665,7 +665,7 @@ mod test {
 
             let mut bytes = Vec::with_capacity(max_bytes);
             dogstatsd.to_bytes(rng, max_bytes, &mut bytes)?;
-            debug_assert!(
+            prop_assert!(
                 bytes.len() <= max_bytes,
                 "{:?}",
                 std::str::from_utf8(&bytes).expect("failed to convert from utf-8 to str")
@@ -686,7 +686,7 @@ mod test {
 
             let mut bytes = Vec::with_capacity(max_bytes);
             dogstatsd.to_bytes(rng, max_bytes, &mut bytes).expect("failed to convert to bytes");
-            debug_assert!(
+            prop_assert!(
                 bytes.len() <= max_bytes,
                 "{:?}",
                 std::str::from_utf8(&bytes).expect("failed to convert from utf-8 to str")

--- a/lading_payload/src/dogstatsd/common/tags.rs
+++ b/lading_payload/src/dogstatsd/common/tags.rs
@@ -172,11 +172,11 @@ mod test {
                 })
                 .collect::<Vec<_>>();
 
-            assert_eq!(first_batch.len(), second_batch.len());
+            prop_assert_eq!(first_batch.len(), second_batch.len());
             for i in 0..first_batch.len() {
                 let first = &first_batch[i];
                 let second = &second_batch[i];
-                assert_eq!(first, second);
+                prop_assert_eq!(first, second);
             }
         }
     }
@@ -203,13 +203,13 @@ mod test {
                 for tag in &tagset {
                     let start = tag_size_range.start().into();
                     let end = tag_size_range.end().into();
-                    debug_assert!(tag.len() <= end, "tag len: {}, tag_size_range end: {end}", tag.len());
-                    debug_assert!(tag.len() >= start, "tag len: {}, tag_size_range start: {start}", tag.len());
+                    prop_assert!(tag.len() <= end, "tag len: {}, tag_size_range end: {end}", tag.len());
+                    prop_assert!(tag.len() >= start, "tag len: {}, tag_size_range start: {start}", tag.len());
                     let num_delimiters = tag.chars().filter(|c| *c == ':').count();
-                    assert_eq!(num_delimiters, 1);
+                    prop_assert_eq!(num_delimiters, 1);
                 }
-                assert!(tagset.len() <= tags_per_msg_range.end() as usize);
-                assert!(tagset.len() >= tags_per_msg_range.start() as usize);
+                prop_assert!(tagset.len() <= tags_per_msg_range.end() as usize);
+                prop_assert!(tagset.len() >= tags_per_msg_range.start() as usize);
             }
         }
     }
@@ -244,7 +244,7 @@ mod test {
                 .collect::<Vec<_>>();
 
             let num_contexts = count_num_contexts(&tagsets);
-            assert_eq!(num_contexts, desired_num_tagsets);
+            prop_assert_eq!(num_contexts, desired_num_tagsets);
         }
     }
 
@@ -282,7 +282,7 @@ mod test {
 
             let margin_of_error = 3;
             let num_contexts = count_num_contexts(&tagsets);
-            assert!(num_contexts >= desired_num_tagsets - margin_of_error || num_contexts <= desired_num_tagsets + margin_of_error);
+            prop_assert!(num_contexts >= desired_num_tagsets - margin_of_error || num_contexts <= desired_num_tagsets + margin_of_error);
         }
     }
 }

--- a/lading_payload/src/dogstatsd/common/tags.rs
+++ b/lading_payload/src/dogstatsd/common/tags.rs
@@ -280,9 +280,8 @@ mod test {
                 })
                 .collect::<Vec<_>>();
 
-            let margin_of_error = 3;
             let num_contexts = count_num_contexts(&tagsets);
-            prop_assert!(num_contexts >= desired_num_tagsets - margin_of_error || num_contexts <= desired_num_tagsets + margin_of_error);
+            prop_assert_eq!(num_contexts, desired_num_tagsets);
         }
     }
 }

--- a/lading_payload/src/fluent.rs
+++ b/lading_payload/src/fluent.rs
@@ -222,7 +222,7 @@ mod test {
 
             let mut bytes = Vec::with_capacity(max_bytes);
             fluent.to_bytes(rng, max_bytes, &mut bytes).expect("failed to convert to bytes");
-            debug_assert!(
+            prop_assert!(
                 bytes.len() <= max_bytes,
                 "{:?}",
                 std::str::from_utf8(&bytes).expect("failed to convert from utf-8 to str")

--- a/lading_payload/src/json.rs
+++ b/lading_payload/src/json.rs
@@ -100,7 +100,7 @@ mod test {
 
             let mut bytes = Vec::with_capacity(max_bytes);
             json.to_bytes(rng, max_bytes, &mut bytes).expect("failed to convert to bytes");
-            assert!(bytes.len() <= max_bytes);
+            prop_assert!(bytes.len() <= max_bytes);
         }
     }
 

--- a/lading_payload/src/opentelemetry_log.rs
+++ b/lading_payload/src/opentelemetry_log.rs
@@ -147,7 +147,7 @@ mod test {
 
             let mut bytes = Vec::with_capacity(max_bytes);
             logs.to_bytes(rng, max_bytes, &mut bytes).expect("failed to convert to bytes");
-            assert!(bytes.len() <= max_bytes, "max len: {max_bytes}, actual: {}", bytes.len());
+            prop_assert!(bytes.len() <= max_bytes, "max len: {max_bytes}, actual: {}", bytes.len());
         }
     }
 
@@ -162,7 +162,7 @@ mod test {
             let mut bytes = Vec::with_capacity(max_bytes);
             logs.to_bytes(rng, max_bytes, &mut bytes).expect("failed to convert to bytes");
 
-            assert!(!bytes.is_empty());
+            prop_assert!(!bytes.is_empty());
         }
     }
 

--- a/lading_payload/src/opentelemetry_metric.rs
+++ b/lading_payload/src/opentelemetry_metric.rs
@@ -668,9 +668,9 @@ mod test {
             let metric2 = otel_metrics.generate(&mut rng)?;
 
             // Ensure that the metrics are equal.
-            assert_eq!(metric1, metric2);
+            prop_assert_eq!(metric1, metric2);
             // If the metrics are equal then their contexts must be equal.
-            assert_eq!(context_id(&metric1), context_id(&metric2));
+            prop_assert_eq!(context_id(&metric1), context_id(&metric2));
         }
     }
 

--- a/lading_payload/src/opentelemetry_metric.rs
+++ b/lading_payload/src/opentelemetry_metric.rs
@@ -659,18 +659,20 @@ mod test {
             };
 
             let mut rng = SmallRng::seed_from_u64(seed);
-            let otel_metrics = OpentelemetryMetrics::new(config.clone(), &mut rng)?;
+            let otel_metrics1 = OpentelemetryMetrics::new(config.clone(), &mut rng)?;
+            let metric1 = otel_metrics1.generate(&mut rng)?;
 
-            // Generate two identical metrics
-            let metric1 = otel_metrics.generate(&mut rng)?;
             let mut rng = SmallRng::seed_from_u64(seed);
-            let otel_metrics = OpentelemetryMetrics::new(config.clone(), &mut rng)?;
-            let metric2 = otel_metrics.generate(&mut rng)?;
+            let otel_metrics2 = OpentelemetryMetrics::new(config.clone(), &mut rng)?;
+            let metric2 = otel_metrics2.generate(&mut rng)?;
+
+            let context_id1 = context_id(&metric1);
+            let context_id2 = context_id(&metric2);
 
             // Ensure that the metrics are equal.
             prop_assert_eq!(metric1, metric2);
             // If the metrics are equal then their contexts must be equal.
-            prop_assert_eq!(context_id(&metric1), context_id(&metric2));
+            prop_assert_eq!(context_id1, context_id2);
         }
     }
 

--- a/lading_payload/src/opentelemetry_metric/attributes.rs
+++ b/lading_payload/src/opentelemetry_metric/attributes.rs
@@ -174,11 +174,11 @@ mod test {
                 })
                 .collect::<Vec<_>>();
 
-            assert_eq!(first_batch.len(), second_batch.len());
+            prop_assert_eq!(first_batch.len(), second_batch.len());
             for i in 0..first_batch.len() {
                 let first = &first_batch[i];
                 let second = &second_batch[i];
-                assert_eq!(first, second);
+                prop_assert_eq!(first, second);
             }
         }
     }
@@ -205,13 +205,13 @@ mod test {
                 for tag in &tagset {
                     let start = tag_size_range.start().into();
                     let end = tag_size_range.end().into();
-                    debug_assert!(tag.len() <= end, "tag len: {}, tag_size_range end: {end}", tag.len());
-                    debug_assert!(tag.len() >= start, "tag len: {}, tag_size_range start: {start}", tag.len());
+                    prop_assert!(tag.len() <= end, "tag len: {}, tag_size_range end: {end}", tag.len());
+                    prop_assert!(tag.len() >= start, "tag len: {}, tag_size_range start: {start}", tag.len());
                     let num_delimiters = tag.chars().filter(|c| *c == ':').count();
-                    assert_eq!(num_delimiters, 1);
+                    prop_assert_eq!(num_delimiters, 1);
                 }
-                assert!(tagset.len() <= tags_per_msg_range.end() as usize);
-                assert!(tagset.len() >= tags_per_msg_range.start() as usize);
+                prop_assert!(tagset.len() <= tags_per_msg_range.end() as usize);
+                prop_assert!(tagset.len() >= tags_per_msg_range.start() as usize);
             }
         }
     }
@@ -246,7 +246,7 @@ mod test {
                 .collect::<Vec<_>>();
 
             let num_contexts = count_num_contexts(&tagsets);
-            assert_eq!(num_contexts, desired_num_tagsets);
+            prop_assert_eq!(num_contexts, desired_num_tagsets);
         }
     }
 
@@ -284,7 +284,7 @@ mod test {
 
             let margin_of_error = 3;
             let num_contexts = count_num_contexts(&tagsets);
-            assert!(num_contexts >= desired_num_tagsets - margin_of_error || num_contexts <= desired_num_tagsets + margin_of_error);
+            prop_assert!(num_contexts >= desired_num_tagsets - margin_of_error || num_contexts <= desired_num_tagsets + margin_of_error);
         }
     }
 }

--- a/lading_payload/src/opentelemetry_trace.rs
+++ b/lading_payload/src/opentelemetry_trace.rs
@@ -156,7 +156,7 @@ mod test {
 
             let mut bytes = Vec::with_capacity(max_bytes);
             traces.to_bytes(rng, max_bytes, &mut bytes).expect("failed to convert to bytes");
-            assert!(bytes.len() <= max_bytes, "max len: {max_bytes}, actual: {}", bytes.len());
+            prop_assert!(bytes.len() <= max_bytes, "max len: {max_bytes}, actual: {}", bytes.len());
         }
     }
 
@@ -171,7 +171,7 @@ mod test {
             let mut bytes = Vec::with_capacity(max_bytes);
             traces.to_bytes(rng, max_bytes, &mut bytes).expect("failed to convert to bytes");
 
-            assert!(!bytes.is_empty());
+            prop_assert!(!bytes.is_empty());
         }
     }
 

--- a/lading_payload/src/splunk_hec.rs
+++ b/lading_payload/src/splunk_hec.rs
@@ -204,7 +204,7 @@ mod test {
 
             let mut bytes = Vec::with_capacity(max_bytes);
             hec.to_bytes(rng, max_bytes, &mut bytes).expect("failed to convert to bytes");
-            assert!(bytes.len() <= max_bytes);
+            prop_assert!(bytes.len() <= max_bytes);
         }
     }
 

--- a/lading_payload/src/syslog.rs
+++ b/lading_payload/src/syslog.rs
@@ -146,7 +146,7 @@ mod test {
 
             let mut bytes = Vec::with_capacity(max_bytes);
             syslog.to_bytes(rng, max_bytes, &mut bytes).expect("failed to convert to bytes");
-            debug_assert!(
+            prop_assert!(
                 bytes.len() <= max_bytes,
                 "{:?}",
                 std::str::from_utf8(&bytes).expect("failed to convert from utf-8 to str")

--- a/lading_payload/src/trace_agent.rs
+++ b/lading_payload/src/trace_agent.rs
@@ -283,7 +283,7 @@ mod test {
 
             let mut bytes = Vec::with_capacity(max_bytes);
             trace_agent.to_bytes(rng, max_bytes, &mut bytes)?;
-            debug_assert!(
+            prop_assert!(
                 bytes.len() <= max_bytes,
                 "{:?}",
                 std::str::from_utf8(&bytes)?
@@ -300,7 +300,7 @@ mod test {
 
             let mut bytes = Vec::with_capacity(max_bytes);
             trace_agent.to_bytes(rng, max_bytes, &mut bytes)?;
-            debug_assert!(
+            prop_assert!(
                 bytes.len() <= max_bytes,
                 "{:?}",
                 std::str::from_utf8(&bytes)?


### PR DESCRIPTION
### What does this PR do?

This commit adjusts our use of assertions in property tests to make
    use of the macro provided by proptest. This gives that rig a little
    more information and makes debugging for us a little better. It also
    is going to work with --release flipped on.

REF SMPTNG-659