### PR TITLE
Ignore claude code tool private directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /target
+.claude


### PR DESCRIPTION
### What does this PR do?

This commit ignores the private directory of the claude code CLI assistant,
avoiding the need to negotiate between users of the tool.

