### PR TITLE
Allow lading_payload::Serialize to be mutable

### DIFF
--- a/lading_payload/proptest-regressions/dogstatsd.txt
+++ b/lading_payload/proptest-regressions/dogstatsd.txt
@@ -5,3 +5,4 @@
 # It is recommended to check this file in to source control so that
 # everyone who runs the test benefits from these saved cases.
 cc 97158e48115dce6b53c08d3f3744ebd92cb711273b19aee225daa774f71f6e23 # shrinks to seed = 0, max_bytes = 0
+cc 077dc27bd44ddd568537d3742556e1a422619e126a2fbf86c7e7f54374780baf # shrinks to seed = 11798065272331789525, max_bytes = 3627

--- a/lading_payload/src/apache_common.rs
+++ b/lading_payload/src/apache_common.rs
@@ -341,7 +341,7 @@ impl<'a> Generator<'a> for ApacheCommon {
 }
 
 impl crate::Serialize for ApacheCommon {
-    fn to_bytes<W, R>(&self, mut rng: R, max_bytes: usize, writer: &mut W) -> Result<(), Error>
+    fn to_bytes<W, R>(&mut self, mut rng: R, max_bytes: usize, writer: &mut W) -> Result<(), Error>
     where
         R: Rng + Sized,
         W: Write,
@@ -377,7 +377,7 @@ mod test {
         fn payload_not_exceed_max_bytes(seed: u64, max_bytes: u16) {
             let max_bytes = max_bytes as usize;
             let mut rng = SmallRng::seed_from_u64(seed);
-            let apache = ApacheCommon::new(&mut rng);
+            let mut apache = ApacheCommon::new(&mut rng);
 
             let mut bytes = Vec::with_capacity(max_bytes);
             apache.to_bytes(rng, max_bytes, &mut bytes).expect("failed to convert to bytes");

--- a/lading_payload/src/ascii.rs
+++ b/lading_payload/src/ascii.rs
@@ -29,7 +29,7 @@ impl Ascii {
 }
 
 impl crate::Serialize for Ascii {
-    fn to_bytes<W, R>(&self, mut rng: R, max_bytes: usize, writer: &mut W) -> Result<(), Error>
+    fn to_bytes<W, R>(&mut self, mut rng: R, max_bytes: usize, writer: &mut W) -> Result<(), Error>
     where
         R: Rng + Sized,
         W: Write,
@@ -69,7 +69,7 @@ mod test {
         fn payload_not_exceed_max_bytes(seed: u64, max_bytes: u16) {
             let max_bytes = max_bytes as usize;
             let mut rng = SmallRng::seed_from_u64(seed);
-            let ascii = Ascii::new(&mut rng);
+            let mut ascii = Ascii::new(&mut rng);
 
             let mut bytes = Vec::with_capacity(max_bytes);
             ascii.to_bytes(rng, max_bytes, &mut bytes)?;

--- a/lading_payload/src/datadog_logs.rs
+++ b/lading_payload/src/datadog_logs.rs
@@ -126,7 +126,7 @@ impl<'a> Generator<'a> for DatadogLog {
 }
 
 impl crate::Serialize for DatadogLog {
-    fn to_bytes<W, R>(&self, mut rng: R, max_bytes: usize, writer: &mut W) -> Result<(), Error>
+    fn to_bytes<W, R>(&mut self, mut rng: R, max_bytes: usize, writer: &mut W) -> Result<(), Error>
     where
         W: Write,
         R: Rng + Sized,
@@ -178,7 +178,7 @@ mod test {
         fn payload_not_exceed_max_bytes(seed: u64, max_bytes: u16) {
             let max_bytes = max_bytes as usize;
             let mut rng = SmallRng::seed_from_u64(seed);
-            let ddlogs = DatadogLog::new(&mut rng);
+            let mut ddlogs = DatadogLog::new(&mut rng);
 
             let mut bytes = Vec::with_capacity(max_bytes);
             ddlogs.to_bytes(rng, max_bytes, &mut bytes).expect("failed to convert to bytes");
@@ -197,7 +197,7 @@ mod test {
         fn every_payload_deserializes(seed: u64, max_bytes: u16)  {
             let max_bytes = max_bytes as usize;
             let mut rng = SmallRng::seed_from_u64(seed);
-            let ddlogs = DatadogLog::new(&mut rng);
+            let mut ddlogs = DatadogLog::new(&mut rng);
 
             let mut bytes: Vec<u8> = Vec::with_capacity(max_bytes);
             ddlogs.to_bytes(rng, max_bytes, &mut bytes).expect("failed to convert to bytes");

--- a/lading_payload/src/fluent.rs
+++ b/lading_payload/src/fluent.rs
@@ -152,7 +152,7 @@ struct Entry<'a> {
 }
 
 impl crate::Serialize for Fluent {
-    fn to_bytes<W, R>(&self, mut rng: R, max_bytes: usize, writer: &mut W) -> Result<(), Error>
+    fn to_bytes<W, R>(&mut self, mut rng: R, max_bytes: usize, writer: &mut W) -> Result<(), Error>
     where
         W: Write,
         R: Rng + Sized,
@@ -218,7 +218,7 @@ mod test {
         fn payload_not_exceed_max_bytes(seed: u64, max_bytes: u16) {
             let max_bytes = max_bytes as usize;
             let mut rng = SmallRng::seed_from_u64(seed);
-            let fluent = Fluent::new(&mut rng);
+            let mut fluent = Fluent::new(&mut rng);
 
             let mut bytes = Vec::with_capacity(max_bytes);
             fluent.to_bytes(rng, max_bytes, &mut bytes).expect("failed to convert to bytes");

--- a/lading_payload/src/json.rs
+++ b/lading_payload/src/json.rs
@@ -57,7 +57,7 @@ impl<'a> Generator<'a> for Json {
 }
 
 impl crate::Serialize for Json {
-    fn to_bytes<W, R>(&self, mut rng: R, max_bytes: usize, writer: &mut W) -> Result<(), Error>
+    fn to_bytes<W, R>(&mut self, mut rng: R, max_bytes: usize, writer: &mut W) -> Result<(), Error>
     where
         R: Rng + Sized,
         W: Write,
@@ -96,7 +96,7 @@ mod test {
         fn payload_not_exceed_max_bytes(seed: u64, max_bytes: u16) {
             let max_bytes = max_bytes as usize;
             let rng = SmallRng::seed_from_u64(seed);
-            let json = Json;
+            let mut json = Json;
 
             let mut bytes = Vec::with_capacity(max_bytes);
             json.to_bytes(rng, max_bytes, &mut bytes).expect("failed to convert to bytes");
@@ -111,7 +111,7 @@ mod test {
         fn every_payload_deserializes(seed: u64, max_bytes: u16) {
             let max_bytes = max_bytes as usize;
             let rng = SmallRng::seed_from_u64(seed);
-            let json = Json;
+            let mut json = Json;
 
             let mut bytes: Vec<u8> = Vec::with_capacity(max_bytes);
             json.to_bytes(rng, max_bytes, &mut bytes).expect("failed to convert to bytes");

--- a/lading_payload/src/lib.rs
+++ b/lading_payload/src/lib.rs
@@ -91,7 +91,7 @@ pub trait Serialize {
     ///
     /// Most implementations are serializing data in some way. The errors that
     /// result come from serialization crackups.
-    fn to_bytes<W, R>(&self, rng: R, max_bytes: usize, writer: &mut W) -> Result<(), Error>
+    fn to_bytes<W, R>(&mut self, rng: R, max_bytes: usize, writer: &mut W) -> Result<(), Error>
     where
         R: Rng + Sized,
         W: Write;
@@ -171,7 +171,7 @@ pub(crate) enum Payload {
 }
 
 impl Serialize for Payload {
-    fn to_bytes<W, R>(&self, rng: R, max_bytes: usize, writer: &mut W) -> Result<(), Error>
+    fn to_bytes<W, R>(&mut self, rng: R, max_bytes: usize, writer: &mut W) -> Result<(), Error>
     where
         W: Write,
         R: Rng + Sized,

--- a/lading_payload/src/opentelemetry_log.rs
+++ b/lading_payload/src/opentelemetry_log.rs
@@ -95,7 +95,7 @@ impl<'a> Generator<'a> for OpentelemetryLogs {
 }
 
 impl crate::Serialize for OpentelemetryLogs {
-    fn to_bytes<W, R>(&self, mut rng: R, max_bytes: usize, writer: &mut W) -> Result<(), Error>
+    fn to_bytes<W, R>(&mut self, mut rng: R, max_bytes: usize, writer: &mut W) -> Result<(), Error>
     where
         R: Rng + Sized,
         W: Write,
@@ -143,7 +143,7 @@ mod test {
         fn payload_not_exceed_max_bytes(seed: u64, max_bytes: u16) {
             let max_bytes = max_bytes as usize;
             let mut rng = SmallRng::seed_from_u64(seed);
-            let logs = OpentelemetryLogs::new(&mut rng);
+            let mut logs = OpentelemetryLogs::new(&mut rng);
 
             let mut bytes = Vec::with_capacity(max_bytes);
             logs.to_bytes(rng, max_bytes, &mut bytes).expect("failed to convert to bytes");
@@ -157,7 +157,7 @@ mod test {
         fn payload_is_at_least_half_of_max_bytes(seed: u64, max_bytes in 16u16..u16::MAX) {
             let max_bytes = max_bytes as usize;
             let mut rng = SmallRng::seed_from_u64(seed);
-            let logs = OpentelemetryLogs::new(&mut rng);
+            let mut logs = OpentelemetryLogs::new(&mut rng);
 
             let mut bytes = Vec::with_capacity(max_bytes);
             logs.to_bytes(rng, max_bytes, &mut bytes).expect("failed to convert to bytes");
@@ -173,7 +173,7 @@ mod test {
         fn payload_deserializes(seed: u64, max_bytes: u16)  {
             let max_bytes = max_bytes as usize;
             let mut rng = SmallRng::seed_from_u64(seed);
-            let logs = OpentelemetryLogs::new(&mut rng);
+            let mut logs = OpentelemetryLogs::new(&mut rng);
 
             let mut bytes: Vec<u8> = Vec::with_capacity(max_bytes);
             logs.to_bytes(rng, max_bytes, &mut bytes).expect("failed to convert to bytes");

--- a/lading_payload/src/opentelemetry_metric.rs
+++ b/lading_payload/src/opentelemetry_metric.rs
@@ -167,7 +167,7 @@ impl<'a> Generator<'a> for OpentelemetryMetrics {
 }
 
 impl crate::Serialize for OpentelemetryMetrics {
-    fn to_bytes<W, R>(&self, mut rng: R, max_bytes: usize, writer: &mut W) -> Result<(), Error>
+    fn to_bytes<W, R>(&mut self, mut rng: R, max_bytes: usize, writer: &mut W) -> Result<(), Error>
     where
         R: Rng + Sized,
         W: Write,
@@ -213,7 +213,7 @@ mod test {
         fn payload_not_exceed_max_bytes(seed: u64, max_bytes: u16) {
             let max_bytes = max_bytes as usize;
             let mut rng = SmallRng::seed_from_u64(seed);
-            let logs = OpentelemetryMetrics::new(&mut rng);
+            let mut logs = OpentelemetryMetrics::new(&mut rng);
 
             let mut bytes = Vec::with_capacity(max_bytes);
             logs.to_bytes(rng, max_bytes, &mut bytes).expect("failed to convert to bytes");
@@ -227,7 +227,7 @@ mod test {
         fn payload_is_at_least_half_of_max_bytes(seed: u64, max_bytes in 16u16..u16::MAX) {
             let max_bytes = max_bytes as usize;
             let mut rng = SmallRng::seed_from_u64(seed);
-            let logs = OpentelemetryMetrics::new(&mut rng);
+            let mut logs = OpentelemetryMetrics::new(&mut rng);
 
             let mut bytes = Vec::with_capacity(max_bytes);
             logs.to_bytes(rng, max_bytes, &mut bytes).expect("failed to convert to bytes");
@@ -243,7 +243,7 @@ mod test {
         fn payload_deserializes(seed: u64, max_bytes: u16)  {
             let max_bytes = max_bytes as usize;
             let mut rng = SmallRng::seed_from_u64(seed);
-            let logs = OpentelemetryMetrics::new(&mut rng);
+            let mut logs = OpentelemetryMetrics::new(&mut rng);
 
             let mut bytes: Vec<u8> = Vec::with_capacity(max_bytes);
             logs.to_bytes(rng, max_bytes, &mut bytes).expect("failed to convert to bytes");

--- a/lading_payload/src/opentelemetry_trace.rs
+++ b/lading_payload/src/opentelemetry_trace.rs
@@ -105,7 +105,7 @@ impl<'a> Generator<'a> for OpentelemetryTraces {
 }
 
 impl crate::Serialize for OpentelemetryTraces {
-    fn to_bytes<W, R>(&self, mut rng: R, max_bytes: usize, writer: &mut W) -> Result<(), Error>
+    fn to_bytes<W, R>(&mut self, mut rng: R, max_bytes: usize, writer: &mut W) -> Result<(), Error>
     where
         R: Rng + Sized,
         W: Write,
@@ -152,7 +152,7 @@ mod test {
         fn payload_not_exceed_max_bytes(seed: u64, max_bytes: u16) {
             let max_bytes = max_bytes as usize;
             let mut rng = SmallRng::seed_from_u64(seed);
-            let traces = OpentelemetryTraces::new(&mut rng);
+            let mut traces = OpentelemetryTraces::new(&mut rng);
 
             let mut bytes = Vec::with_capacity(max_bytes);
             traces.to_bytes(rng, max_bytes, &mut bytes).expect("failed to convert to bytes");
@@ -166,7 +166,7 @@ mod test {
         fn payload_is_at_least_half_of_max_bytes(seed: u64, max_bytes in 16u16..u16::MAX) {
             let max_bytes = max_bytes as usize;
             let mut rng = SmallRng::seed_from_u64(seed);
-            let traces = OpentelemetryTraces::new(&mut rng);
+            let mut traces = OpentelemetryTraces::new(&mut rng);
 
             let mut bytes = Vec::with_capacity(max_bytes);
             traces.to_bytes(rng, max_bytes, &mut bytes).expect("failed to convert to bytes");
@@ -182,7 +182,7 @@ mod test {
         fn payload_deserializes(seed: u64, max_bytes: u16)  {
             let max_bytes = max_bytes as usize;
             let mut rng = SmallRng::seed_from_u64(seed);
-            let traces = OpentelemetryTraces::new(&mut rng);
+            let mut traces = OpentelemetryTraces::new(&mut rng);
 
             let mut bytes: Vec<u8> = Vec::with_capacity(max_bytes);
             traces.to_bytes(rng, max_bytes, &mut bytes).expect("failed to convert to bytes");

--- a/lading_payload/src/splunk_hec.rs
+++ b/lading_payload/src/splunk_hec.rs
@@ -152,7 +152,7 @@ impl SplunkHec {
 }
 
 impl crate::Serialize for SplunkHec {
-    fn to_bytes<W, R>(&self, mut rng: R, max_bytes: usize, writer: &mut W) -> Result<(), Error>
+    fn to_bytes<W, R>(&mut self, mut rng: R, max_bytes: usize, writer: &mut W) -> Result<(), Error>
     where
         R: Rng + Sized,
         W: Write,
@@ -200,7 +200,7 @@ mod test {
         fn payload_not_exceed_max_bytes(seed: u64, max_bytes: u16) {
             let max_bytes = max_bytes as usize;
             let rng = SmallRng::seed_from_u64(seed);
-            let hec = SplunkHec::default();
+            let mut hec = SplunkHec::default();
 
             let mut bytes = Vec::with_capacity(max_bytes);
             hec.to_bytes(rng, max_bytes, &mut bytes).expect("failed to convert to bytes");
@@ -215,7 +215,7 @@ mod test {
         fn every_payload_deserializes(seed: u64, max_bytes in 0..u16::MAX)  {
             let max_bytes = max_bytes as usize;
             let rng = SmallRng::seed_from_u64(seed);
-            let hec = SplunkHec::default();
+            let mut hec = SplunkHec::default();
 
             let mut bytes: Vec<u8> = Vec::with_capacity(max_bytes);
             hec.to_bytes(rng, max_bytes, &mut bytes).expect("failed to convert to bytes");

--- a/lading_payload/src/statik.rs
+++ b/lading_payload/src/statik.rs
@@ -69,7 +69,7 @@ impl Static {
 
 impl crate::Serialize for Static {
     fn to_bytes<W, R>(
-        &self,
+        &mut self,
         mut rng: R,
         max_bytes: usize,
         writer: &mut W,

--- a/lading_payload/src/syslog.rs
+++ b/lading_payload/src/syslog.rs
@@ -100,7 +100,7 @@ impl Member {
 }
 
 impl crate::Serialize for Syslog5424 {
-    fn to_bytes<W, R>(&self, rng: R, max_bytes: usize, writer: &mut W) -> Result<(), Error>
+    fn to_bytes<W, R>(&mut self, rng: R, max_bytes: usize, writer: &mut W) -> Result<(), Error>
     where
         R: Rng + Sized,
         W: Write,
@@ -142,7 +142,7 @@ mod test {
         fn payload_not_exceed_max_bytes(seed: u64, max_bytes: u16) {
             let max_bytes = max_bytes as usize;
             let rng = SmallRng::seed_from_u64(seed);
-            let syslog = Syslog5424::default();
+            let mut syslog = Syslog5424::default();
 
             let mut bytes = Vec::with_capacity(max_bytes);
             syslog.to_bytes(rng, max_bytes, &mut bytes).expect("failed to convert to bytes");

--- a/lading_payload/src/trace_agent.rs
+++ b/lading_payload/src/trace_agent.rs
@@ -194,7 +194,7 @@ impl<'a> Generator<'a> for TraceAgent {
 }
 
 impl crate::Serialize for TraceAgent {
-    fn to_bytes<W, R>(&self, mut rng: R, max_bytes: usize, writer: &mut W) -> Result<(), Error>
+    fn to_bytes<W, R>(&mut self, mut rng: R, max_bytes: usize, writer: &mut W) -> Result<(), Error>
     where
         R: Rng + Sized,
         W: Write,
@@ -279,7 +279,7 @@ mod test {
         fn payload_not_exceed_max_bytes_json(seed: u64, max_bytes: u16) {
             let max_bytes = max_bytes as usize;
             let mut rng = SmallRng::seed_from_u64(seed);
-            let trace_agent = TraceAgent::json(&mut rng);
+            let mut trace_agent = TraceAgent::json(&mut rng);
 
             let mut bytes = Vec::with_capacity(max_bytes);
             trace_agent.to_bytes(rng, max_bytes, &mut bytes)?;
@@ -296,7 +296,7 @@ mod test {
         fn payload_not_exceed_max_bytes_msg_pack(seed: u64, max_bytes: u16) {
             let max_bytes = max_bytes as usize;
             let mut rng = SmallRng::seed_from_u64(seed);
-            let trace_agent = TraceAgent::json(&mut rng);
+            let mut trace_agent = TraceAgent::json(&mut rng);
 
             let mut bytes = Vec::with_capacity(max_bytes);
             trace_agent.to_bytes(rng, max_bytes, &mut bytes)?;


### PR DESCRIPTION
### What does this PR do?

This commit allows the Serialize trait defined in lading_payload
    to mutate itself. This will improve the ergonimics of writing
    a serializer that must have some form of memory, without requiring
    other serializers to opt into this behavior.

Curiously, this did turn up two problems with dogstatsd: an aliased
    function and a framing bug. Both are now corrected. I'm not sure
    why this didn't trigger before.


### Motivation

REF SMPTNG-659
