### PR TITLE
Introduce data_points_transmitted / second in OTel metrics HTTP, GRPC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Block cache generation now logs its number of rejected, success blocks once
   the cache is created.
 - Added configurable metric kind weights in OpenTelemetry metrics payload generator.
+- Added new telemetry to OpenTelemetry metrics generation: data points per
+  second. This opens the door for doing the same for other payloads.
 
 ## [0.25.9]
 ## Added

--- a/lading/src/generator/grpc.rs
+++ b/lading/src/generator/grpc.rs
@@ -8,6 +8,7 @@
 //! `bytes_written`: Total bytes written
 //! `response_bytes`: Total bytes received
 //! `bytes_per_second`: Configured rate to send data
+//! `data_points_transmitted`: Total data points transmitted (for OpenTelemetry metrics)
 //!
 //! Additional metrics may be emitted by this generator's [throttle].
 //!
@@ -290,6 +291,9 @@ impl Grpc {
                     match res {
                         Ok(res) => {
                             counter!("bytes_written", &self.metric_labels).increment(block_length as u64);
+                            if let Some(data_points) = blk.metadata.data_points {
+                                counter!("data_points_transmitted", &self.metric_labels).increment(data_points);
+                            }
                             counter!("request_ok", &self.metric_labels).increment(1);
                             counter!("response_bytes", &self.metric_labels).increment(res.into_inner() as u64);
                         }

--- a/lading_payload/src/lib.rs
+++ b/lading_payload/src/lib.rs
@@ -104,6 +104,18 @@ pub trait Serialize {
     where
         R: Rng + Sized,
         W: Write;
+
+    /// Reports data points count for the most recently generated content.
+    ///
+    /// IMPORTANT: This method should be called immediately after `to_bytes` to
+    /// get accurate counts for the most recently generated block. The
+    /// information WILL be overwritten by subsequent calls to `to_bytes`.
+    ///
+    /// If this function returns None the serialize does not support tracking
+    /// data points.
+    fn data_points_generated(&self) -> Option<u64> {
+        None
+    }
 }
 
 /// Sub-configuration for `TraceAgent` format
@@ -199,6 +211,14 @@ impl Serialize for Payload {
             Payload::OtelMetrics(ser) => ser.to_bytes(rng, max_bytes, writer),
             Payload::DogStatsdD(ser) => ser.to_bytes(rng, max_bytes, writer),
             Payload::TraceAgent(ser) => ser.to_bytes(rng, max_bytes, writer),
+        }
+    }
+
+    fn data_points_generated(&self) -> Option<u64> {
+        match self {
+            Payload::OtelMetrics(ser) => ser.data_points_generated(),
+            // Other implementations use the default None
+            _ => None,
         }
     }
 }

--- a/lading_payload/src/opentelemetry_metric.rs
+++ b/lading_payload/src/opentelemetry_metric.rs
@@ -297,8 +297,8 @@ impl OpentelemetryMetrics {
         })
     }
 
-    pub fn data_points_generated(&self) -> Option<u64> {
-        Some(self.data_points_in_block)
+    fn data_points_generated(&self) -> u64 {
+        self.data_points_in_block
     }
 }
 
@@ -462,7 +462,7 @@ impl crate::Serialize for OpentelemetryMetrics {
     }
 
     fn data_points_generated(&self) -> Option<u64> {
-        self.data_points_generated()
+        Some(self.data_points_generated())
     }
 }
 


### PR DESCRIPTION
### What does this PR do?

This commit implements a new piece of telemetry: data points transmitted per
    second. This is the equivalent of bytes per second but, when applicable, in
    terms of the metric (or other) "data points" transmitted per second. This
    approach should be immediately applicable to DogStatsD. This further opens the
    door to other block-based metadata.

### Motivation

REF SMPTNG-659

