### PR TITLE
Ignore .docs-cache in gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /target
 .claude
+.docs-cache


### PR DESCRIPTION
### What does this PR do?

This commit avoids checking in docs-cache. It's useful to have local,
    not useful to have checked into the repo.