### PR TITLE
Create Otlp specific blackhole

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added configurable metric kind weights in OpenTelemetry metrics payload generator.
 - Added new telemetry to OpenTelemetry metrics generation: data points per
   second. This opens the door for doing the same for other payloads.
+- Otlp specific blackhole with HTTP and gRPC support.
 
 ## [0.25.9]
 ## Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -113,9 +113,9 @@ dependencies = [
 
 [[package]]
 name = "async-io"
-version = "2.4.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43a2b323ccce0a1d90b449fd71f2a06ca7faa7c54c2751f06c9bd851fc061059"
+checksum = "1237c0ae75a0f3765f58910ff9cdd0a12eeb39ab2f4c7de23262f337f0aacbb3"
 dependencies = [
  "async-lock",
  "cfg-if",
@@ -124,7 +124,7 @@ dependencies = [
  "futures-lite",
  "parking",
  "polling",
- "rustix 0.38.44",
+ "rustix 1.0.7",
  "slab",
  "tracing",
  "windows-sys 0.59.0",
@@ -149,28 +149,6 @@ checksum = "958321a23896f573a3f1809437af5816f3bc90dd2d5ffe8b1cd5645f42230c17"
 dependencies = [
  "async-io",
  "libc",
-]
-
-[[package]]
-name = "async-stream"
-version = "0.3.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b5a71a6f37880a80d1d7f19efd781e4b5de42c88f0722cc13bcb6cc2cfe8476"
-dependencies = [
- "async-stream-impl",
- "futures-core",
- "pin-project-lite",
-]
-
-[[package]]
-name = "async-stream-impl"
-version = "0.3.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.101",
 ]
 
 [[package]]
@@ -208,45 +186,18 @@ dependencies = [
 
 [[package]]
 name = "axum"
-version = "0.7.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edca88bc138befd0323b20752846e6587272d3b03b0343c8ea28a6f819e6e71f"
-dependencies = [
- "async-trait",
- "axum-core 0.4.5",
- "bytes",
- "futures-util",
- "http 1.3.1",
- "http-body 1.0.1",
- "http-body-util",
- "itoa",
- "matchit 0.7.3",
- "memchr",
- "mime",
- "percent-encoding",
- "pin-project-lite",
- "rustversion",
- "serde",
- "sync_wrapper",
- "tower 0.5.2",
- "tower-layer",
- "tower-service",
-]
-
-[[package]]
-name = "axum"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "021e862c184ae977658b36c4500f7feac3221ca5da43e3f25bd04ab6c79a29b5"
 dependencies = [
- "axum-core 0.5.2",
+ "axum-core",
  "bytes",
  "futures-util",
  "http 1.3.1",
  "http-body 1.0.1",
  "http-body-util",
  "itoa",
- "matchit 0.8.4",
+ "matchit",
  "memchr",
  "mime",
  "percent-encoding",
@@ -254,27 +205,7 @@ dependencies = [
  "rustversion",
  "serde",
  "sync_wrapper",
- "tower 0.5.2",
- "tower-layer",
- "tower-service",
-]
-
-[[package]]
-name = "axum-core"
-version = "0.4.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09f2bd6146b97ae3359fa0cc6d6b376d9539582c7b4220f041a33ec24c226199"
-dependencies = [
- "async-trait",
- "bytes",
- "futures-util",
- "http 1.3.1",
- "http-body 1.0.1",
- "http-body-util",
- "mime",
- "pin-project-lite",
- "rustversion",
- "sync_wrapper",
+ "tower",
  "tower-layer",
  "tower-service",
 ]
@@ -493,9 +424,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.2.23"
+version = "1.2.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f4ac86a9e5bc1e2b3449ab9d7d3a6a405e3d1bb28d7b9be8614f55846ae3766"
+checksum = "16595d3be041c03b09d08d0858631facccee9221e579704070e6e9e4915d3bc7"
 dependencies = [
  "jobserver",
  "libc",
@@ -556,9 +487,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.38"
+version = "4.5.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed93b9805f8ba930df42c2590f05453d5ec36cbb85d018868a5b24d31f6ac000"
+checksum = "fd60e63e9be68e5fb56422e397cf9baddded06dae1d2e523401542383bc72a9f"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -566,9 +497,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.38"
+version = "4.5.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "379026ff283facf611b0ea629334361c4211d1b12ee01024eec1591133b04120"
+checksum = "89cc6392a1f72bbeb820d71f32108f61fdaf18bc526e1d23954168a67759ef51"
 dependencies = [
  "anstyle",
  "clap_lex",
@@ -773,7 +704,7 @@ dependencies = [
  "sketches-ddsketch 0.3.0",
  "tokio",
  "tokio-stream",
- "tonic 0.13.1",
+ "tonic",
  "tracing",
  "tracing-subscriber",
 ]
@@ -1087,12 +1018,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 
 [[package]]
-name = "glob"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8d1add55171497b4705a648c6b583acafb01d58050a51727785f0b2c8e0a2b2"
-
-[[package]]
 name = "h2"
 version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1202,9 +1127,9 @@ checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
 
 [[package]]
 name = "hermit-abi"
-version = "0.4.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbf6a919d6cf397374f7dfeeea91d974c7c0a7221d0d0f4f20d859d329e53fcc"
+checksum = "f154ce46856750ed433c8649605bf7ed2de3bc35fd9d2a9f30cddd873c80cb08"
 
 [[package]]
 name = "hex"
@@ -1702,8 +1627,10 @@ dependencies = [
  "num-traits",
  "num_cpus",
  "once_cell",
+ "opentelemetry-proto",
  "procfs",
  "proptest",
+ "prost",
  "quanta",
  "rand 0.9.1",
  "regex",
@@ -1718,7 +1645,7 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "tokio-util",
- "tonic 0.12.3",
+ "tonic",
  "tracing",
  "tracing-subscriber",
  "uuid",
@@ -1842,12 +1769,6 @@ dependencies = [
 
 [[package]]
 name = "matchit"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
-
-[[package]]
-name = "matchit"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
@@ -1934,13 +1855,13 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2886843bf800fba2e3377cff24abf6379b4c4d5c6681eaf9ea5b0d15090450bd"
+checksum = "78bed444cc8a2160f01cbcf811ef18cac863ad68ae8ca62092e8db51d51c761c"
 dependencies = [
  "libc",
  "wasi 0.11.0+wasi-snapshot-preview1",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2119,9 +2040,9 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry"
-version = "0.29.1"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e87237e2775f74896f9ad219d26a2081751187eb7c9f5c58dde20a23b95d16c"
+checksum = "aaf416e4cb72756655126f7dd7bb0af49c674f4c1b9903e80c009e0c37e552e6"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -2133,9 +2054,9 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry-proto"
-version = "0.29.0"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c40da242381435e18570d5b9d50aca2a4f4f4d8e146231adb4e7768023309b3"
+checksum = "2e046fd7660710fe5a05e8748e70d9058dc15c94ba914e7c4faa7c728f0e8ddc"
 dependencies = [
  "base64 0.22.1",
  "hex",
@@ -2143,20 +2064,18 @@ dependencies = [
  "opentelemetry_sdk",
  "prost",
  "serde",
- "tonic 0.12.3",
- "tracing",
+ "tonic",
 ]
 
 [[package]]
 name = "opentelemetry_sdk"
-version = "0.29.0"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afdefb21d1d47394abc1ba6c57363ab141be19e27cc70d0e422b7f303e4d290b"
+checksum = "11f644aa9e5e31d11896e024305d7e3c98a88884d9f8919dbf37a9991bc47a4b"
 dependencies = [
  "futures-channel",
  "futures-executor",
  "futures-util",
- "glob",
  "opentelemetry",
  "percent-encoding",
  "rand 0.9.1",
@@ -2285,15 +2204,15 @@ dependencies = [
 
 [[package]]
 name = "polling"
-version = "3.7.4"
+version = "3.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a604568c3202727d1507653cb121dbd627a58684eb09a820fd746bee38b4442f"
+checksum = "b53a684391ad002dd6a596ceb6c74fd004fdce75f4be2e3f615068abbea5fd50"
 dependencies = [
  "cfg-if",
  "concurrent-queue",
- "hermit-abi 0.4.0",
+ "hermit-abi 0.5.1",
  "pin-project-lite",
- "rustix 0.38.44",
+ "rustix 1.0.7",
  "tracing",
  "windows-sys 0.59.0",
 ]
@@ -2685,9 +2604,9 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.12.16"
+version = "0.12.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bf597b113be201cb2269b4c39b39a804d01b99ee95a4278f0ed04e45cff1c71"
+checksum = "e98ff6b0dbbe4d5a37318f433d4fc82babd21631f194d370409ceb2e40b2f0b5"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -2713,7 +2632,7 @@ dependencies = [
  "sync_wrapper",
  "tokio",
  "tokio-native-tls",
- "tower 0.5.2",
+ "tower",
  "tower-http",
  "tower-service",
  "url",
@@ -2838,9 +2757,9 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.20"
+version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eded382c5f5f786b989652c49544c4877d9f015cc22e145a5ea8ea66c2921cd2"
+checksum = "8a0d197bd2c9dc6e53b84da9556a69ba4cdfab8619eb41a8bd1cc2027a0f6b1d"
 
 [[package]]
 name = "rusty-fork"
@@ -3057,7 +2976,7 @@ dependencies = [
  "prost",
  "serde",
  "serde_json",
- "tonic 0.13.1",
+ "tonic",
  "tonic-build",
 ]
 
@@ -3071,8 +2990,8 @@ dependencies = [
  "shared",
  "tempfile",
  "tokio",
- "tonic 0.13.1",
- "tower 0.5.2",
+ "tonic",
+ "tower",
  "tracing",
  "tracing-subscriber",
 ]
@@ -3127,9 +3046,9 @@ checksum = "8917285742e9f3e1683f0a9c4e6b57960b7314d0b08d30d1ecd426713ee2eee9"
 
 [[package]]
 name = "socket2"
-version = "0.5.9"
+version = "0.5.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f5fd57c80058a56cf5c777ab8a126398ece8e442983605d280a44ce79d0edef"
+checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
 dependencies = [
  "libc",
  "windows-sys 0.52.0",
@@ -3423,42 +3342,12 @@ dependencies = [
 
 [[package]]
 name = "tonic"
-version = "0.12.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "877c5b330756d856ffcc4553ab34a5684481ade925ecc54bcd1bf02b1d0d4d52"
-dependencies = [
- "async-stream",
- "async-trait",
- "axum 0.7.9",
- "base64 0.22.1",
- "bytes",
- "h2 0.4.10",
- "http 1.3.1",
- "http-body 1.0.1",
- "http-body-util",
- "hyper 1.6.0",
- "hyper-timeout",
- "hyper-util",
- "percent-encoding",
- "pin-project",
- "prost",
- "socket2",
- "tokio",
- "tokio-stream",
- "tower 0.4.13",
- "tower-layer",
- "tower-service",
- "tracing",
-]
-
-[[package]]
-name = "tonic"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e581ba15a835f4d9ea06c55ab1bd4dce26fc53752c69a04aac00703bfb49ba9"
 dependencies = [
  "async-trait",
- "axum 0.8.4",
+ "axum",
  "base64 0.22.1",
  "bytes",
  "h2 0.4.10",
@@ -3474,7 +3363,7 @@ dependencies = [
  "socket2",
  "tokio",
  "tokio-stream",
- "tower 0.5.2",
+ "tower",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -3492,26 +3381,6 @@ dependencies = [
  "prost-types",
  "quote",
  "syn 2.0.101",
-]
-
-[[package]]
-name = "tower"
-version = "0.4.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
-dependencies = [
- "futures-core",
- "futures-util",
- "indexmap 1.9.3",
- "pin-project",
- "pin-project-lite",
- "rand 0.8.5",
- "slab",
- "tokio",
- "tokio-util",
- "tower-layer",
- "tower-service",
- "tracing",
 ]
 
 [[package]]
@@ -3546,7 +3415,7 @@ dependencies = [
  "http-body 1.0.1",
  "iri-string",
  "pin-project-lite",
- "tower 0.5.2",
+ "tower",
  "tower-layer",
  "tower-service",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ thiserror = { version = "2.0" }
 tokio = { version = "1.45" }
 # If you update tonic, search for tonic-build in sub-crates and update their
 # version.
-tonic = { version = "0.13", default-features = false, features = [] }
+tonic = { version = "0.13", default-features = false, features = ["server", "transport", "router", "codegen", "prost"] }
 tower = { version = "0.5", default-features = false }
 tracing = { version = "0.1" }
 uuid = { version = "1.17", default-features = false, features = [

--- a/examples/lading-otel-metrics.yaml
+++ b/examples/lading-otel-metrics.yaml
@@ -50,11 +50,11 @@ blackhole:
       binding_addr: "127.0.0.1:9091"
   - http:
       binding_addr: "127.0.0.1:9092"
-  - http:
-      binding_addr: "127.0.0.1:4217"  # OTLP HTTP endpoint
-      body_variant: "nothing"
-  # - grpc:
-  #     binding_addr: "127.0.0.1:4318"  # OTLP gRPC endpoint
+  - otlp:
+      grpc_addr: "127.0.0.1:4317"
+      http_addr: "127.0.0.1:4318"
+      concurrent_requests_max: 100
+      response_delay_millis: 0
 
 target_metrics:
   - prometheus:

--- a/lading/Cargo.toml
+++ b/lading/Cargo.toml
@@ -55,6 +55,8 @@ nix = { version = "0.30", default-features = false, features = [
 num_cpus = { version = "1.16" }
 num-traits = { version = "0.2", default-features = false }
 once_cell = { workspace = true }
+opentelemetry-proto = { version = "0.30.0", features = ["gen-tonic", "logs", "metrics", "trace"] }
+prost = { workspace = true }
 rand = { workspace = true, default-features = false, features = [
   "small_rng",
   "std",
@@ -82,7 +84,7 @@ tokio = { workspace = true, features = [
 ] }
 tokio-stream = { version = "0.1", features = ["io-util"] }
 tokio-util = { version = "0.7", features = ["io"] }
-tonic = { version = "0.12" }
+tonic = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { version = "0.3", features = ["std", "env-filter"] }
 uuid = { workspace = true }

--- a/lading/Cargo.toml
+++ b/lading/Cargo.toml
@@ -55,7 +55,7 @@ nix = { version = "0.30", default-features = false, features = [
 num_cpus = { version = "1.16" }
 num-traits = { version = "0.2", default-features = false }
 once_cell = { workspace = true }
-opentelemetry-proto = { version = "0.30.0", features = ["gen-tonic", "logs", "metrics", "trace"] }
+opentelemetry-proto = { version = "0.30.0", features = ["gen-tonic", "logs", "metrics", "trace", "with-serde"] }
 prost = { workspace = true }
 rand = { workspace = true, default-features = false, features = [
   "small_rng",

--- a/lading/src/blackhole/otlp.rs
+++ b/lading/src/blackhole/otlp.rs
@@ -1,0 +1,193 @@
+//! OpenTelemetry protocol (OTLP) speaking blackhole.
+//!
+//! ## Metrics
+//!
+//! `bytes_received`: Total bytes received
+//! `requests_received`: Total requests received
+//! `metrics_received`: Number of metric data points received
+//! `spans_received`: Number of spans received
+//! `logs_received`: Number of log records received
+//!
+
+mod grpc;
+mod http;
+
+use serde::{Deserialize, Serialize};
+use std::net::SocketAddr;
+use std::time::Duration;
+use tokio::task::JoinSet;
+use tracing::{error, info};
+
+use crate::blackhole::General;
+
+fn default_concurrent_requests_max() -> usize {
+    100
+}
+
+fn default_response_delay_millis() -> u64 {
+    0
+}
+
+/// Errors produced by [`Otlp`].
+#[derive(thiserror::Error, Debug)]
+pub enum Error {
+    /// Wrapper for IO errors.
+    #[error("IO error: {0}")]
+    Io(#[from] std::io::Error),
+    /// HTTP server error.
+    #[error("HTTP server error: {0}")]
+    Http(#[from] hyper::Error),
+    /// gRPC server error.
+    #[error("gRPC server error: {0}")]
+    Grpc(#[from] tonic::transport::Error),
+    /// Underlying server error.
+    #[error("Server error: {0}")]
+    Server(#[from] crate::blackhole::common::Error),
+    /// No protocol was enabled.
+    #[error("No protocols enabled - must enable at least HTTP or gRPC")]
+    NoProtocolEnabled,
+}
+
+#[derive(Debug, Deserialize, Serialize, Clone, PartialEq, Eq, Copy)]
+#[serde(deny_unknown_fields)]
+/// Configuration for [`Otlp`]
+pub struct Config {
+    /// Number of concurrent connections to allow
+    #[serde(default = "default_concurrent_requests_max")]
+    pub concurrent_requests_max: usize,
+    /// Address for gRPC endpoint
+    pub grpc_addr: Option<SocketAddr>,
+    /// Address for HTTP endpoint
+    pub http_addr: Option<SocketAddr>,
+    /// Delay to add before making a response
+    #[serde(default = "default_response_delay_millis")]
+    pub response_delay_millis: u64,
+}
+
+/// The OTLP blackhole, supporting both gRPC and HTTP protocols.
+#[derive(Debug)]
+pub struct Otlp {
+    grpc_addr: Option<SocketAddr>,
+    http_addr: Option<SocketAddr>,
+    concurrency_limit: usize,
+    shutdown: lading_signal::Watcher,
+    response_delay: Duration,
+    labels: Vec<(String, String)>,
+}
+
+impl Otlp {
+    /// Create a new [`Otlp`] server instance
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the configuration is invalid.
+    pub fn new(
+        general: &General,
+        config: &Config,
+        shutdown: &lading_signal::Watcher,
+    ) -> Result<Self, Error> {
+        // Ensure at least one protocol is enabled
+        if config.grpc_addr.is_none() && config.http_addr.is_none() {
+            return Err(Error::NoProtocolEnabled);
+        };
+
+        let mut labels = vec![
+            ("component".to_string(), "blackhole".to_string()),
+            ("component_name".to_string(), "otlp".to_string()),
+        ];
+        if let Some(id) = &general.id {
+            labels.push(("id".to_string(), id.clone()));
+        }
+
+        Ok(Self {
+            grpc_addr: config.grpc_addr,
+            http_addr: config.http_addr,
+            concurrency_limit: config.concurrent_requests_max,
+            shutdown: shutdown.clone(),
+            response_delay: Duration::from_millis(config.response_delay_millis),
+            labels,
+        })
+    }
+
+    /// Run [`Otlp`] to completion
+    ///
+    /// This function runs the OTLP server(s) until a shutdown signal is
+    /// received or an unrecoverable error is encountered.
+    ///
+    /// # Errors
+    ///
+    /// Function will return an error if server initialization fails.
+    pub async fn run(self) -> Result<(), Error> {
+        let mut join_set = JoinSet::new();
+
+        if let Some(addr) = self.grpc_addr {
+            let grpc_task = grpc::run_server(
+                addr,
+                self.response_delay,
+                &self.labels,
+                self.concurrency_limit,
+            );
+            join_set.spawn(async move {
+                grpc_task.await.unwrap_or_else(|e| {
+                    error!("gRPC task failed: {}", e);
+                });
+            });
+        }
+
+        if let Some(addr) = self.http_addr {
+            let response_delay = self.response_delay;
+            let labels = self.labels.clone();
+            let concurrency_limit = self.concurrency_limit;
+            let shutdown = self.shutdown.clone();
+
+            let http_task =
+                http::run_server(addr, response_delay, &labels, concurrency_limit, shutdown);
+            join_set.spawn(async move {
+                http_task.await.unwrap_or_else(|e| {
+                    error!("HTTP task failed: {}", e);
+                });
+            });
+        }
+
+        let shutdown = self.shutdown.recv();
+        tokio::pin!(shutdown);
+
+        tokio::select! {
+            () = shutdown => {
+                info!("Shutdown signal received, stopping OTLP server(s)");
+                join_set.shutdown().await;
+                while join_set.join_next().await.is_some() {}
+                info!("All OTLP servers have completed");
+            }
+        }
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::net::SocketAddr;
+
+    #[test]
+    fn otlp_config() {
+        let config = Config {
+            concurrent_requests_max: 100,
+            grpc_addr: Some("127.0.0.1:4317".parse().unwrap()),
+            http_addr: Some("127.0.0.1:4318".parse().unwrap()),
+            response_delay_millis: 0,
+        };
+
+        assert_eq!(config.concurrent_requests_max, 100);
+        assert_eq!(
+            config.grpc_addr,
+            Some(SocketAddr::from(([127, 0, 0, 1], 4317)))
+        );
+        assert_eq!(
+            config.http_addr,
+            Some(SocketAddr::from(([127, 0, 0, 1], 4318)))
+        );
+        assert_eq!(config.response_delay_millis, 0);
+    }
+}

--- a/lading/src/blackhole/otlp/grpc.rs
+++ b/lading/src/blackhole/otlp/grpc.rs
@@ -1,0 +1,212 @@
+//! gRPC implementation of the OTLP blackhole.
+
+use metrics::counter;
+use opentelemetry_proto::tonic::collector::logs::v1::{
+    ExportLogsServiceRequest, ExportLogsServiceResponse,
+    logs_service_server::{LogsService, LogsServiceServer},
+};
+use opentelemetry_proto::tonic::collector::metrics::v1::{
+    ExportMetricsServiceRequest, ExportMetricsServiceResponse,
+    metrics_service_server::{MetricsService, MetricsServiceServer},
+};
+use opentelemetry_proto::tonic::collector::trace::v1::{
+    ExportTraceServiceRequest, ExportTraceServiceResponse,
+    trace_service_server::{TraceService, TraceServiceServer},
+};
+use opentelemetry_proto::tonic::metrics::v1::metric::Data as MetricData;
+use prost::Message;
+use std::net::SocketAddr;
+use std::time::Duration;
+use tokio::task::JoinHandle;
+use tonic::{Request as TonicRequest, Response as TonicResponse, Status};
+use tracing::{error, info};
+
+pub(crate) fn run_server(
+    addr: SocketAddr,
+    response_delay: Duration,
+    base_labels: &[(String, String)],
+    concurrency_limit: usize,
+) -> JoinHandle<()> {
+    let mut labels = Vec::with_capacity(base_labels.len() + 1);
+    labels.push(("protocol".to_string(), "grpc".to_string()));
+    labels.extend_from_slice(base_labels);
+
+    // Signal-specific labels, pre-compute empty responses
+    let mut metrics_labels = Vec::with_capacity(labels.len() + 1);
+    metrics_labels.extend_from_slice(&labels);
+    metrics_labels.push(("signal".to_string(), "metrics".to_string()));
+    let mut traces_labels = Vec::with_capacity(labels.len() + 1);
+    traces_labels.extend_from_slice(&labels);
+    traces_labels.push(("signal".to_string(), "traces".to_string()));
+    let mut logs_labels = Vec::with_capacity(labels.len() + 1);
+    logs_labels.extend_from_slice(&labels);
+    logs_labels.push(("signal".to_string(), "logs".to_string()));
+
+    let empty_metrics_response = ExportMetricsServiceResponse::default();
+    let empty_traces_response = ExportTraceServiceResponse::default();
+    let empty_logs_response = ExportLogsServiceResponse::default();
+
+    let metrics_service = OtlpMetricsService {
+        labels: labels.clone(),
+        metrics_labels,
+        response_delay,
+        empty_response: empty_metrics_response,
+    };
+
+    let traces_service = OtlpTracesService {
+        labels: labels.clone(),
+        traces_labels,
+        response_delay,
+        empty_response: empty_traces_response,
+    };
+
+    let logs_service = OtlpLogsService {
+        labels,
+        logs_labels,
+        response_delay,
+        empty_response: empty_logs_response,
+    };
+
+    info!("Starting OTLP gRPC service (all signal types) on {addr}");
+    let router = tonic::transport::Server::builder()
+        .concurrency_limit_per_connection(concurrency_limit)
+        .add_service(MetricsServiceServer::new(metrics_service))
+        .add_service(TraceServiceServer::new(traces_service))
+        .add_service(LogsServiceServer::new(logs_service));
+
+    tokio::spawn(async move {
+        if let Err(e) = router.serve(addr).await {
+            error!("gRPC server error: {}", e);
+        }
+    })
+}
+
+/// Metrics Service implementation
+#[derive(Debug)]
+struct OtlpMetricsService {
+    labels: Vec<(String, String)>,
+    metrics_labels: Vec<(String, String)>,
+    response_delay: Duration,
+    empty_response: ExportMetricsServiceResponse,
+}
+
+#[tonic::async_trait]
+impl MetricsService for OtlpMetricsService {
+    async fn export(
+        &self,
+        request: TonicRequest<ExportMetricsServiceRequest>,
+    ) -> Result<TonicResponse<ExportMetricsServiceResponse>, Status> {
+        let request = request.into_inner();
+        let size = request.encoded_len();
+
+        counter!("bytes_received", &self.labels).increment(size as u64);
+        counter!("requests_received", &self.labels).increment(1);
+
+        let mut total_points: u64 = 0;
+        for rm in &request.resource_metrics {
+            for sm in &rm.scope_metrics {
+                for m in &sm.metrics {
+                    if let Some(data) = &m.data {
+                        let points_count = match data {
+                            MetricData::Gauge(g) => g.data_points.len(),
+                            MetricData::Sum(s) => s.data_points.len(),
+                            MetricData::Histogram(h) => h.data_points.len(),
+                            MetricData::ExponentialHistogram(eh) => eh.data_points.len(),
+                            MetricData::Summary(s) => s.data_points.len(),
+                        };
+                        total_points += points_count as u64;
+                    }
+                }
+            }
+        }
+
+        if total_points > 0 {
+            counter!("data_points_received", &self.metrics_labels).increment(total_points);
+        }
+
+        if self.response_delay.as_micros() > 0 {
+            tokio::time::sleep(self.response_delay).await;
+        }
+        Ok(TonicResponse::new(self.empty_response.clone()))
+    }
+}
+
+/// Traces Service implementation
+#[derive(Debug)]
+struct OtlpTracesService {
+    labels: Vec<(String, String)>,
+    traces_labels: Vec<(String, String)>,
+    response_delay: Duration,
+    empty_response: ExportTraceServiceResponse,
+}
+
+#[tonic::async_trait]
+impl TraceService for OtlpTracesService {
+    async fn export(
+        &self,
+        request: TonicRequest<ExportTraceServiceRequest>,
+    ) -> Result<TonicResponse<ExportTraceServiceResponse>, Status> {
+        let request = request.into_inner();
+        let size = request.encoded_len();
+
+        counter!("bytes_received", &self.labels).increment(size as u64);
+        counter!("requests_received", &self.labels).increment(1);
+
+        let mut total_spans: u64 = 0;
+        for rs in &request.resource_spans {
+            for ss in &rs.scope_spans {
+                let spans_count = ss.spans.len() as u64;
+                total_spans += spans_count;
+            }
+        }
+
+        if total_spans > 0 {
+            counter!("data_points_received", &self.traces_labels).increment(total_spans);
+        }
+
+        if self.response_delay.as_micros() > 0 {
+            tokio::time::sleep(self.response_delay).await;
+        }
+        Ok(TonicResponse::new(self.empty_response.clone()))
+    }
+}
+
+/// Logs Service implementation
+#[derive(Debug)]
+struct OtlpLogsService {
+    labels: Vec<(String, String)>,
+    logs_labels: Vec<(String, String)>,
+    response_delay: Duration,
+    empty_response: ExportLogsServiceResponse,
+}
+
+#[tonic::async_trait]
+impl LogsService for OtlpLogsService {
+    async fn export(
+        &self,
+        request: TonicRequest<ExportLogsServiceRequest>,
+    ) -> Result<TonicResponse<ExportLogsServiceResponse>, Status> {
+        let request = request.into_inner();
+        let size = request.encoded_len();
+
+        counter!("bytes_received", &self.labels).increment(size as u64);
+        counter!("requests_received", &self.labels).increment(1);
+
+        let mut total_logs: u64 = 0;
+        for rl in &request.resource_logs {
+            for sl in &rl.scope_logs {
+                let logs_count = sl.log_records.len() as u64;
+                total_logs += logs_count;
+            }
+        }
+
+        if total_logs > 0 {
+            counter!("data_points_received", &self.logs_labels).increment(total_logs);
+        }
+
+        if self.response_delay.as_micros() > 0 {
+            tokio::time::sleep(self.response_delay).await;
+        }
+        Ok(TonicResponse::new(self.empty_response.clone()))
+    }
+}

--- a/lading/src/blackhole/otlp/http.rs
+++ b/lading/src/blackhole/otlp/http.rs
@@ -1,0 +1,268 @@
+//! HTTP implementation of the OTLP blackhole.
+
+use bytes::Bytes;
+use http::StatusCode;
+use http_body_util::{BodyExt, combinators::BoxBody};
+use hyper::{Request, Response};
+use metrics::counter;
+use opentelemetry_proto::tonic::collector::logs::v1::{
+    ExportLogsServiceRequest, ExportLogsServiceResponse,
+};
+use opentelemetry_proto::tonic::collector::metrics::v1::{
+    ExportMetricsServiceRequest, ExportMetricsServiceResponse,
+};
+use opentelemetry_proto::tonic::collector::trace::v1::{
+    ExportTraceServiceRequest, ExportTraceServiceResponse,
+};
+use opentelemetry_proto::tonic::metrics::v1::metric::Data as MetricData;
+use prost::Message;
+use std::net::SocketAddr;
+use std::time::Duration;
+use tokio::task::JoinHandle;
+use tracing::{error, info};
+
+use crate::blackhole::common;
+
+/// Run the HTTP server for OTLP
+pub(crate) fn run_server(
+    addr: SocketAddr,
+    response_delay: Duration,
+    base_labels: &[(String, String)],
+    concurrency_limit: usize,
+    shutdown: lading_signal::Watcher,
+) -> JoinHandle<()> {
+    info!("Starting OTLP HTTP server on {addr}");
+    let mut labels = Vec::with_capacity(base_labels.len() + 1);
+    labels.push(("protocol".to_string(), "http".to_string()));
+    labels.extend_from_slice(base_labels);
+
+    tokio::spawn(async move {
+        let handler = OtlpHttpHandler::new(response_delay, &labels);
+
+        let result = common::run_httpd(addr, concurrency_limit, shutdown, labels, move || {
+            let handler_clone = handler.clone();
+            hyper::service::service_fn(move |req| {
+                let request_handler = handler_clone.clone();
+                request_handler.handle_request(req)
+            })
+        })
+        .await;
+
+        if let Err(e) = result {
+            error!("HTTP server error: {e}");
+        }
+    })
+}
+
+/// Handler for OTLP HTTP requests
+#[derive(Clone, Debug)]
+struct OtlpHttpHandler {
+    labels: Vec<(String, String)>,
+    metrics_labels: Vec<(String, String)>,
+    traces_labels: Vec<(String, String)>,
+    logs_labels: Vec<(String, String)>,
+    empty_metrics_response: Bytes,
+    empty_traces_response: Bytes,
+    empty_logs_response: Bytes,
+    content_type_header_value: http::HeaderValue,
+    response_delay: Duration,
+}
+
+impl OtlpHttpHandler {
+    fn new(response_delay: Duration, labels: &[(String, String)]) -> Self {
+        // Signal-specific labels, pre-compute empty responses
+        let mut metrics_labels = Vec::with_capacity(labels.len() + 1);
+        metrics_labels.extend_from_slice(labels);
+        metrics_labels.push(("signal".to_string(), "metrics".to_string()));
+        let mut traces_labels = Vec::with_capacity(labels.len() + 1);
+        traces_labels.extend_from_slice(labels);
+        traces_labels.push(("signal".to_string(), "traces".to_string()));
+        let mut logs_labels = Vec::with_capacity(labels.len() + 1);
+        logs_labels.extend_from_slice(labels);
+        logs_labels.push(("signal".to_string(), "logs".to_string()));
+
+        let empty_metrics_response =
+            Bytes::from(ExportMetricsServiceResponse::default().encode_to_vec());
+        let empty_traces_response =
+            Bytes::from(ExportTraceServiceResponse::default().encode_to_vec());
+        let empty_logs_response = Bytes::from(ExportLogsServiceResponse::default().encode_to_vec());
+
+        let content_type_header_value = "application/x-protobuf"
+            .parse()
+            .expect("application/x-protobuf is a valid MIME type");
+
+        Self {
+            labels: labels.to_vec(),
+            metrics_labels,
+            traces_labels,
+            logs_labels,
+            empty_metrics_response,
+            empty_traces_response,
+            empty_logs_response,
+            content_type_header_value,
+            response_delay,
+        }
+    }
+
+    #[inline]
+    async fn build_response(
+        &self,
+        response_bytes: Bytes,
+    ) -> Result<Response<BoxBody<Bytes, hyper::Error>>, hyper::Error> {
+        if self.response_delay.as_micros() > 0 {
+            tokio::time::sleep(self.response_delay).await;
+        }
+
+        let mut response = Response::builder().status(StatusCode::OK);
+        let headers = response
+            .headers_mut()
+            .expect("Response builder should always provide headers_mut");
+        headers.insert(
+            hyper::header::CONTENT_TYPE,
+            self.content_type_header_value.clone(),
+        );
+        Ok(response
+            .body(crate::full(response_bytes))
+            .expect("Creating HTTP response should not fail"))
+    }
+
+    async fn handle_request(
+        self,
+        req: Request<hyper::body::Incoming>,
+    ) -> Result<Response<BoxBody<Bytes, hyper::Error>>, hyper::Error> {
+        counter!("requests_received", &self.labels).increment(1);
+
+        // Fast-path for invalid paths
+        let path_ref = req.uri().path();
+        if path_ref != "/v1/metrics" && path_ref != "/v1/traces" && path_ref != "/v1/logs" {
+            static NOT_FOUND: &[u8] = b"Not found";
+            return Ok(Response::builder()
+                .status(StatusCode::NOT_FOUND)
+                .body(crate::full(Bytes::from_static(NOT_FOUND)))
+                .expect("Creating HTTP response should not fail"));
+        }
+
+        // Check for empty bodies using Content-Length when available
+        if let Some(content_length) = req.headers().get(hyper::header::CONTENT_LENGTH) {
+            if let Ok(length) = content_length.to_str() {
+                if let Ok(length) = length.parse::<u64>() {
+                    if length == 0 {
+                        counter!("bytes_received", &self.labels).increment(0);
+
+                        let response_bytes = match path_ref {
+                            "/v1/metrics" => self.empty_metrics_response.clone(),
+                            "/v1/traces" => self.empty_traces_response.clone(),
+                            "/v1/logs" => self.empty_logs_response.clone(),
+                            _ => unreachable!(), // We checked earlier
+                        };
+
+                        return self.build_response(response_bytes).await;
+                    }
+                }
+            }
+        }
+
+        let content_encoding = req.headers().get(hyper::header::CONTENT_ENCODING).cloned();
+        let path = path_ref.to_string();
+        let (_, body) = req.into_parts();
+
+        let body_bytes = body.collect().await?.to_bytes();
+
+        counter!("bytes_received", &self.labels).increment(body_bytes.len() as u64);
+        let response_bytes =
+            match crate::codec::decode(content_encoding.as_ref(), body_bytes.clone()) {
+                Ok(decoded) => {
+                    counter!("decoded_bytes_received", &self.labels)
+                        .increment(decoded.len() as u64);
+
+                    match path.as_str() {
+                        "/v1/metrics" => self.process_metrics(&decoded),
+                        "/v1/traces" => self.process_traces(&decoded),
+                        "/v1/logs" => self.process_logs(&decoded),
+                        _ => unreachable!(
+                            "path previously checked, catastrophic programming mistake"
+                        ),
+                    }
+                }
+                Err(response) => return Ok(response),
+            };
+
+        self.build_response(response_bytes).await
+    }
+
+    fn process_metrics(&self, body_bytes: &[u8]) -> Bytes {
+        if body_bytes.is_empty() {
+            return self.empty_metrics_response.clone();
+        }
+
+        let mut total_points: u64 = 0;
+        if let Ok(request) = ExportMetricsServiceRequest::decode(body_bytes) {
+            for rm in &request.resource_metrics {
+                for sm in &rm.scope_metrics {
+                    for m in &sm.metrics {
+                        if let Some(data) = &m.data {
+                            let points_count = match data {
+                                MetricData::Gauge(g) => g.data_points.len(),
+                                MetricData::Sum(s) => s.data_points.len(),
+                                MetricData::Histogram(h) => h.data_points.len(),
+                                MetricData::ExponentialHistogram(eh) => eh.data_points.len(),
+                                MetricData::Summary(s) => s.data_points.len(),
+                            };
+                            total_points += points_count as u64;
+                        }
+                    }
+                }
+            }
+        }
+
+        if total_points > 0 {
+            counter!("data_points_received", &self.metrics_labels).increment(total_points);
+        }
+
+        self.empty_metrics_response.clone()
+    }
+
+    fn process_traces(&self, body_bytes: &[u8]) -> Bytes {
+        if body_bytes.is_empty() {
+            return self.empty_traces_response.clone();
+        }
+
+        let mut total_spans: u64 = 0;
+        if let Ok(request) = ExportTraceServiceRequest::decode(body_bytes) {
+            for rs in &request.resource_spans {
+                for ss in &rs.scope_spans {
+                    let spans_count = ss.spans.len() as u64;
+                    total_spans += spans_count;
+                }
+            }
+        }
+
+        if total_spans > 0 {
+            counter!("data_points_received", &self.traces_labels).increment(total_spans);
+        }
+
+        self.empty_traces_response.clone()
+    }
+
+    fn process_logs(&self, body_bytes: &[u8]) -> Bytes {
+        if body_bytes.is_empty() {
+            return self.empty_logs_response.clone();
+        }
+
+        let mut total_logs: u64 = 0;
+        if let Ok(request) = ExportLogsServiceRequest::decode(body_bytes) {
+            for rl in &request.resource_logs {
+                for sl in &rl.scope_logs {
+                    let logs_count = sl.log_records.len() as u64;
+                    total_logs += logs_count;
+                }
+            }
+        }
+
+        if total_logs > 0 {
+            counter!("data_points_received", &self.logs_labels).increment(total_logs);
+        }
+
+        self.empty_logs_response.clone()
+    }
+}

--- a/lading/src/lib.rs
+++ b/lading/src/lib.rs
@@ -18,7 +18,7 @@
 #![deny(unused_comparisons)]
 #![deny(unreachable_pub)]
 #![deny(missing_docs)]
-#![deny(missing_copy_implementations)]
+#![warn(missing_copy_implementations)]
 #![deny(missing_debug_implementations)]
 #![allow(clippy::cast_precision_loss)]
 #![allow(clippy::multiple_crate_versions)]

--- a/lading_payload/Cargo.toml
+++ b/lading_payload/Cargo.toml
@@ -20,6 +20,7 @@ opentelemetry-proto = { version = "0.30.0", features = [
   "metrics",
   "logs",
   "gen-tonic",
+  "with-serde",
 ] }
 prost = { workspace = true }
 rand = { workspace = true, default-features = false, features = [

--- a/lading_payload/Cargo.toml
+++ b/lading_payload/Cargo.toml
@@ -15,7 +15,7 @@ description = "A tool for load testing daemons."
 [dependencies]
 bytes = { workspace = true }
 byte-unit = { workspace = true, features = [] }
-opentelemetry-proto = { version = "0.29.0", features = [
+opentelemetry-proto = { version = "0.30.0", features = [
   "trace",
   "metrics",
   "logs",

--- a/lading_payload/src/opentelemetry_metric/templates.rs
+++ b/lading_payload/src/opentelemetry_metric/templates.rs
@@ -515,6 +515,7 @@ impl<'a> crate::SizedGenerator<'a> for ResourceTemplateGenerator {
                     let res = resource::v1::Resource {
                         attributes: attributes.as_slice().to_owned(),
                         dropped_attributes_count: 0,
+                        entity_refs: vec![],
                     };
                     Some(res)
                 }


### PR DESCRIPTION
### What does this PR do?

The handling of Otlp is specialized enough that having a distinct
    blackhole for it makes good sense, especially because we want to be
    able to support gRPC request/response and could not with our existing
    blackhole. In a subsequent PR I will remove the OtlpMetrics support
    in the http blackhole. I believe I also understand how how to make
    an otlp_grpc generator.

### Motivation

REF SMPTNG-659
