### PR TITLE
Create lading 0.26.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [0.26.0]
 ## Added
 - Compute the Working Set Size of the target thanks to the Linux Idle Page Tracking API.
   And expose it in the new `total_wss_bytes` metric.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1591,7 +1591,7 @@ dependencies = [
 
 [[package]]
 name = "lading"
-version = "0.25.9"
+version = "0.26.0"
 dependencies = [
  "async-compression",
  "async-pidfd",

--- a/lading/Cargo.toml
+++ b/lading/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lading"
-version = "0.25.9"
+version = "0.26.0"
 authors = [
   "Brian L. Troutwine <brian.troutwine@datadoghq.com>",
   "George Hahn <george.hahn@datadoghq.com>",


### PR DESCRIPTION
### What does this PR do?

This commit is the 0.26.0 lading release. Notable changes include
    the measurement of WSS, recorded as `total_wss_bytes`, improvements
    to the container generator and a revamp of the OpenTelemetry metrics
    payload, inclusion of OTel specific blackholes.
