### PR TITLE
OpenTelemetry logs improvement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## Added
+- Added configuration surface area to the OTel logs payload generator, in a
+  manner similar to OTel metrics.
 
 ## [0.27.0]
 ## Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,6 +60,10 @@ When handling errors:
 This project enforces code style through automated tooling. Use `ci/validate` to
 check style compliance - it will run formatting and linting checks for you.
 
+**Module organization**: Never use `mod.rs` files. Always name modules directly
+(e.g., use `foo.rs` instead of `foo/mod.rs`). This makes the codebase easier to
+navigate and grep.
+
 We do not allow for warnings: all warnings are errors. Deprecation warnings MUST
 be treated as errors. Lading is written in a "naive" style where abstraction is
 not preferred if a duplicated pattern will satisfy. Our reasoning for this is it
@@ -183,3 +187,4 @@ When in doubt, implement rather than import.
 12. Generators must be deterministic - no randomness without explicit seeding
 13. Pre-compute in initialization, not in hot paths
 14. Think about how your code affects the measurement of the target
+15. NEVER use mod.rs files - always name modules directly (e.g., foo.rs not foo/mod.rs)

--- a/integration/sheepdog/src/lib.rs
+++ b/integration/sheepdog/src/lib.rs
@@ -423,7 +423,8 @@ generator:
         method:
           post:
             maximum_prebuild_cache_size_bytes: "8 MiB"
-            variant: "opentelemetry_logs"
+            variant:
+              opentelemetry_logs: {}
         headers:
             Content-Type: "application/x-protobuf"
         "#,

--- a/lading_payload/proptest-regressions/opentelemetry/log/mod.txt
+++ b/lading_payload/proptest-regressions/opentelemetry/log/mod.txt
@@ -1,0 +1,7 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+cc c936baccbc78a4d1a4c4e3f22ba82ca3c8b3c8e74894e7d64167d8ec10c3eb7c # shrinks to seed = 0, total_contexts = 1, steps = 1

--- a/lading_payload/proptest-regressions/opentelemetry_log.txt
+++ b/lading_payload/proptest-regressions/opentelemetry_log.txt
@@ -1,0 +1,8 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+cc 48f21c68f6a47b5f04cbc25d9d9907b9db94c3c1352438d61a636a1e819f5aa1 # shrinks to seed = 0, total_contexts = 1, steps = 1
+cc 07dda2b662c8e5b8971ea35f997615743e8be3c2e6604e7fe3ad676ff62a9de4 # shrinks to seed = 6751211249958810060, steps = 2, budget = 1460

--- a/lading_payload/src/block.rs
+++ b/lading_payload/src/block.rs
@@ -332,8 +332,15 @@ impl Cache {
                 let _guard = span.enter();
                 construct_block_cache_inner(rng, &mut pyld, maximum_block_bytes, total_bytes.get())?
             }
-            crate::Config::OpentelemetryLogs => {
-                let mut pyld = crate::OpentelemetryLogs::new(&mut rng);
+            crate::Config::OpentelemetryLogs(config) => {
+                match config.valid() {
+                    Ok(()) => (),
+                    Err(e) => {
+                        warn!("Invalid OpentelemetryLogs configuration: {}", e);
+                        return Err(Error::InvalidConfig(e));
+                    }
+                }
+                let mut pyld = crate::OpentelemetryLogs::new(*config, &mut rng)?;
                 let span = span!(Level::INFO, "fixed", payload = "otel-logs");
                 let _guard = span.enter();
                 construct_block_cache_inner(rng, &mut pyld, maximum_block_bytes, total_bytes.get())?

--- a/lading_payload/src/block.rs
+++ b/lading_payload/src/block.rs
@@ -336,7 +336,7 @@ impl Cache {
                 match config.valid() {
                     Ok(()) => (),
                     Err(e) => {
-                        warn!("Invalid OpentelemetryLogs configuration: {}", e);
+                        warn!("Invalid OpentelemetryLogs configuration: {e}");
                         return Err(Error::InvalidConfig(e));
                     }
                 }

--- a/lading_payload/src/lib.rs
+++ b/lading_payload/src/lib.rs
@@ -96,9 +96,14 @@ pub enum Error {
     /// See [`prost::EncodeError`]
     #[error(transparent)]
     ProstEncode(#[from] prost::EncodeError),
-    /// See [`opentelemetry_metric::templates::PoolError`]
+    /// See [`opentelemetry::common::PoolError`]
     #[error("Unable to choose from pool: {0}")]
-    Pool(#[from] opentelemetry::metric::templates::PoolError),
+    Pool(
+        #[from] opentelemetry::common::templates::PoolError<opentelemetry::common::GeneratorError>,
+    ),
+    /// Validation error
+    #[error("Validation error: {0}")]
+    Validation(String),
 }
 
 /// To serialize into bytes
@@ -172,7 +177,7 @@ pub enum Config {
     /// Generates OpenTelemetry traces
     OpentelemetryTraces,
     /// Generates OpenTelemetry logs
-    OpentelemetryLogs,
+    OpentelemetryLogs(crate::opentelemetry::log::Config),
     /// Generates OpenTelemetry metrics
     OpentelemetryMetrics(crate::opentelemetry::metric::Config),
     /// Generates `DogStatsD`

--- a/lading_payload/src/opentelemetry.rs
+++ b/lading_payload/src/opentelemetry.rs
@@ -2,6 +2,7 @@
 //!
 //! This module contains payload generators for OpenTelemetry formats.
 
+pub mod common;
 pub mod log;
 pub mod metric;
 pub mod trace;

--- a/lading_payload/src/opentelemetry/common.rs
+++ b/lading_payload/src/opentelemetry/common.rs
@@ -1,19 +1,36 @@
-//! Tag generation for OpenTelemetry metric payloads
-use std::{cmp, rc::Rc};
+//! Common utilities and types for OpenTelemetry payload generation
+//!
+//! This module contains shared code used by both metrics and logs implementations.
 
-use super::templates::GeneratorError;
-use crate::{Error, Generator, common::config::ConfRange, common::strings::Pool};
+pub(crate) mod templates;
+
+use crate::{Error, Generator, SizedGenerator, common::config::ConfRange, common::strings::Pool};
 use opentelemetry_proto::tonic::common::v1::{AnyValue, KeyValue, any_value};
 use prost::Message;
+use std::{cmp, rc::Rc};
 
+/// Errors that can occur during generation
+#[derive(thiserror::Error, Debug, Clone, Copy)]
+pub enum GeneratorError {
+    /// Generator exhausted bytes budget prematurely
+    #[error("Generator exhausted bytes budget prematurely")]
+    SizeExhausted,
+    /// Failed to generate string
+    #[error("Failed to generate string")]
+    StringGenerate,
+}
+
+/// Ratio of unique tags to use in tag generation
+pub(crate) const UNIQUE_TAG_RATIO: f32 = 0.75;
+
+/// Smallest useful `KeyValue` protobuf, determined by experimentation and enforced in tests
+pub(crate) const SMALLEST_KV_PROTOBUF: usize = 10;
+
+/// Tag generator for OpenTelemetry attributes
 #[derive(Debug, Clone)]
 pub(crate) struct TagGenerator {
     inner: crate::common::tags::Generator,
 }
-
-// smallest useful protobuf, determined by experimentation and enforced in
-// smallest_kv_protobuf test
-const SMALLEST_KV_PROTOBUF: usize = 10;
 
 impl TagGenerator {
     /// Creates a new tag generator
@@ -43,7 +60,8 @@ impl TagGenerator {
     }
 }
 
-fn varint_len(v: usize) -> usize {
+/// Calculate the length of a varint encoding
+pub(crate) fn varint_len(v: usize) -> usize {
     let mut v = v;
     let mut n = 1;
     while v > 0x7f {
@@ -53,14 +71,15 @@ fn varint_len(v: usize) -> usize {
     n
 }
 
-fn overhead(v: usize) -> usize {
+/// Calculate the overhead for a `KeyValue` in a repeated field
+pub(crate) fn overhead(v: usize) -> usize {
     // overhead in a repeated field is per-item, so:
     //
     // [tag-byte] [varint-length] [kv-bytes…]
     varint_len(v) + 1 + v
 }
 
-impl<'a> crate::SizedGenerator<'a> for TagGenerator {
+impl<'a> SizedGenerator<'a> for TagGenerator {
     type Output = Vec<KeyValue>;
     type Error = GeneratorError;
 
@@ -143,11 +162,11 @@ mod test {
             }),
         };
 
-        let encoded_size = overhead(kv.encoded_len());
+        let sz = overhead(kv.encoded_len());
 
-        assert!(
-            encoded_size == SMALLEST_KV_PROTOBUF,
-            "Minimal useful request size ({encoded_size}) should be == SMALLEST_KV_PROTOBUF ({SMALLEST_KV_PROTOBUF})"
+        assert_eq!(
+            sz, SMALLEST_KV_PROTOBUF,
+            "Minimal useful key/value pair should have size {SMALLEST_KV_PROTOBUF}, was {sz}"
         );
     }
 }

--- a/lading_payload/src/opentelemetry/common/templates.rs
+++ b/lading_payload/src/opentelemetry/common/templates.rs
@@ -1,0 +1,91 @@
+//! Template utilities for OpenTelemetry payload generation
+
+use prost::Message;
+use rand::{Rng, prelude::*, seq::IteratorRandom};
+use std::collections::BTreeMap;
+
+/// Errors related to pool operations
+#[derive(thiserror::Error, Debug, Clone, Copy)]
+pub enum PoolError<E> {
+    /// Choice could not be made on empty container
+    #[error("Choice could not be made on empty container.")]
+    EmptyChoice,
+    /// Generation error
+    #[error("Generation error: {0}")]
+    Generator(E),
+}
+
+/// A pool that stores pre-generated instances indexed by their encoded size
+#[derive(Debug, Clone)]
+pub(crate) struct Pool<T, G> {
+    context_cap: u32,
+    /// key: encoded size; val: templates with that size
+    by_size: BTreeMap<usize, Vec<T>>,
+    generator: G,
+    len: u32,
+}
+
+impl<T, G> Pool<T, G>
+where
+    T: Message,
+{
+    /// Build an empty pool that can hold at most `context_cap` templates.
+    pub(crate) fn new(context_cap: u32, generator: G) -> Self {
+        Self {
+            context_cap,
+            by_size: BTreeMap::new(),
+            generator,
+            len: 0,
+        }
+    }
+
+    /// Return a reference to an item from the pool.
+    ///
+    /// Instances returned by this function are guaranteed to be of an encoded
+    /// size no greater than budget. No greater than `context_cap` instances
+    /// will ever be stored in this structure.
+    pub(crate) fn fetch<'a, R>(
+        &'a mut self,
+        rng: &mut R,
+        budget: &mut usize,
+    ) -> Result<&'a T, PoolError<G::Error>>
+    where
+        R: Rng + ?Sized,
+        G: crate::SizedGenerator<'a, Output = T>,
+        G::Error: 'a,
+    {
+        // If we are at context cap, search by_size for templates <= budget and
+        // return a random choice. If we are not at context cap, call
+        // generator with the budget and then store the result
+        // for future use in `by_size`.
+        //
+        // Size search is in the interval (0, budget].
+
+        let upper = *budget;
+
+        // Generate new instances until either context_cap is hit or the
+        // remaining space drops below our lookup interval.
+        if self.len < self.context_cap {
+            let mut limit = *budget;
+            match self.generator.generate(rng, &mut limit) {
+                Ok(item) => {
+                    let sz = item.encoded_len();
+                    self.by_size.entry(sz).or_default().push(item);
+                    self.len += 1;
+                }
+                Err(e) => return Err(PoolError::Generator(e)),
+            }
+        }
+
+        let (choice_sz, choices) = self
+            .by_size
+            .range(..=upper)
+            .choose(rng)
+            .ok_or(PoolError::EmptyChoice)?;
+
+        let choice = choices.choose(rng).ok_or(PoolError::EmptyChoice)?;
+        *budget = budget.saturating_sub(*choice_sz);
+
+        Ok(choice)
+    }
+}

--- a/lading_payload/src/opentelemetry/log.rs
+++ b/lading_payload/src/opentelemetry/log.rs
@@ -7,90 +7,290 @@
 //! experimental JSON OTLP/HTTP format can also be supported but is not
 //! currently implemented.
 
-use crate::{Error, common::strings};
+// Alright, to summarize this payload generator's understanding of the
+// data-model described above:
+//
+// The central concern is a `LogRecord`. That has:
+//
+// * `time_unit_nano`: time the event occurred
+// * `observed_time_unix_nano`: time the event was observed by the collection system
+// * `severity_number`: severity (INFO etc) defined from an enum of options
+// * `severity_text`: same, but text and optional so we do not set this
+// * `body`: the actual content of the log record
+// * `attributes`: key/value tag pairs
+// * `dropped_attributes_count`: always 0 in this implementation
+// * `flags`: optional and unset by this implementation
+// * `trace-id`: the unique identifier of a trace and all logs from a trace share the same id
+// * `span-id`: the unique id for a span in a trace, optional but if set
+//    trace-id must be set. Unused in this implementation.
+// * `event_name`: optional, unset by this implementation
+//
+// The `LogRecord` is stored inside `ScopeLogs` which has its own
+// InstrumentationScope similarly to how metrics works, and a `schema_url` which
+// we leave unset in this implementation. `ScopeLogs` are stored inside
+// `ResourceLogs` which again has a `schema_url` we do not set and an optional
+// `Resource` which is like to the metrics Resource.
+//
+// A 'context' in this implementation is understood as the product of attributes
+// per resource, scope, log records but NOT trace or span IDs. We do however
+// expose a trace_cardinality configuration option to generate a limited pool of
+// trace-ids that will be assigned to `LogRecord` instances but DO NOT count for
+// context cardinality.
+
+mod templates;
+
+use self::templates::{Pool, ResourceTemplateGenerator};
+use crate::{
+    Error, SizedGenerator,
+    common::{config::ConfRange, strings},
+    opentelemetry::common::templates::PoolError,
+};
+use bytes::BytesMut;
 use opentelemetry_proto::tonic::{
-    common::v1::{AnyValue, any_value},
-    logs::v1,
+    collector::logs::v1::ExportLogsServiceRequest, logs::v1::ResourceLogs,
 };
 use prost::Message;
 use rand::Rng;
-use std::io::Write;
+use serde::{Deserialize, Serialize as SerdeSerialize};
+use std::{cell::RefCell, io::Write, rc::Rc};
 
-use crate::Generator;
+// smallest useful protobuf, determined by experimentation and enforced in
+// smallest_protobuf test
+const SMALLEST_PROTOBUF: usize = 12;
 
-/// Wrapper to generate arbitrary OpenTelemetry [`ExportLogsServiceRequests`](opentelemetry_proto::tonic::collector::logs::v1::ExportLogsServiceRequest)
-struct ExportLogsServiceRequest(Vec<LogRecord>);
+/// Time increment per tick in nanoseconds (1 millisecond)
+const TIME_INCREMENT_NANOS: u64 = 1_000_000;
 
-impl ExportLogsServiceRequest {
-    fn into_prost_type(
-        self,
-    ) -> opentelemetry_proto::tonic::collector::logs::v1::ExportLogsServiceRequest {
-        opentelemetry_proto::tonic::collector::logs::v1::ExportLogsServiceRequest {
-            resource_logs: vec![v1::ResourceLogs {
-                resource: None,
-                scope_logs: vec![v1::ScopeLogs {
-                    scope: None,
-                    log_records: self.0.into_iter().map(|log| log.0).collect(),
-                    schema_url: String::new(),
-                }],
-                schema_url: String::new(),
-            }],
+/// Configure the OpenTelemetry log contexts
+#[derive(Debug, Deserialize, SerdeSerialize, Clone, PartialEq, Copy)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[serde(deny_unknown_fields, default)]
+pub struct Contexts {
+    /// The range of contexts that will be generated.
+    pub total_contexts: ConfRange<u32>,
+
+    /// The range of attributes for resources.
+    pub attributes_per_resource: ConfRange<u8>,
+    /// The range of scopes that will be generated per resource.
+    pub scopes_per_resource: ConfRange<u8>,
+    /// The range of attributes for each scope.
+    pub attributes_per_scope: ConfRange<u8>,
+    /// The range of logs that will be generated per scope.
+    pub logs_per_scope: ConfRange<u8>,
+    /// The range of attributes for each log record.
+    pub attributes_per_log: ConfRange<u8>,
+}
+
+impl Default for Contexts {
+    fn default() -> Self {
+        Self {
+            total_contexts: ConfRange::Constant(100),
+            attributes_per_resource: ConfRange::Inclusive { min: 1, max: 20 },
+            scopes_per_resource: ConfRange::Inclusive { min: 1, max: 20 },
+            attributes_per_scope: ConfRange::Constant(0),
+            logs_per_scope: ConfRange::Inclusive { min: 1, max: 20 },
+            attributes_per_log: ConfRange::Inclusive { min: 0, max: 10 },
         }
     }
 }
 
-pub(crate) struct LogRecord(v1::LogRecord);
+/// Defines log severity levels
+#[derive(Debug, Deserialize, SerdeSerialize, Clone, PartialEq, Copy)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[serde(deny_unknown_fields, default)]
+pub struct SeverityWeights {
+    /// Relative weight for TRACE severity
+    pub trace: u8,
+    /// Relative weight for DEBUG severity
+    pub debug: u8,
+    /// Relative weight for INFO severity
+    pub info: u8,
+    /// Relative weight for WARN severity
+    pub warn: u8,
+    /// Relative weight for ERROR severity
+    pub error: u8,
+    /// Relative weight for FATAL severity
+    pub fatal: u8,
+}
+
+impl Default for SeverityWeights {
+    fn default() -> Self {
+        Self {
+            trace: 5,
+            debug: 10,
+            info: 50,
+            warn: 20,
+            error: 10,
+            fatal: 5,
+        }
+    }
+}
+
+/// Configure the OpenTelemetry log payload.
+#[derive(Debug, Deserialize, SerdeSerialize, Clone, PartialEq, Copy)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[serde(deny_unknown_fields, default)]
+pub struct Config {
+    /// Defines the relative probability of each severity level
+    pub severity_weights: SeverityWeights,
+    /// Define the contexts available when generating logs
+    pub contexts: Contexts,
+    /// Number of unique trace IDs to generate. 0 means no trace context.
+    pub trace_cardinality: ConfRange<u32>,
+    /// The range of body sizes (in words) for log messages
+    pub body_size: ConfRange<u16>,
+}
+
+impl Config {
+    /// Determine whether the passed configuration obeys validation criteria.
+    ///
+    /// # Errors
+    /// Function will error if the configuration is invalid
+    pub fn valid(&self) -> Result<(), String> {
+        // Validate severity weights - at least one must be non-zero
+        if self.severity_weights.trace == 0
+            && self.severity_weights.debug == 0
+            && self.severity_weights.info == 0
+            && self.severity_weights.warn == 0
+            && self.severity_weights.error == 0
+            && self.severity_weights.fatal == 0
+        {
+            return Err("At least one severity weight must be non-zero".to_string());
+        }
+
+        // Validate total_contexts - we need at least one context
+        match self.contexts.total_contexts {
+            ConfRange::Constant(0) => return Err("total_contexts cannot be zero".to_string()),
+            ConfRange::Constant(_) => (),
+            ConfRange::Inclusive { min, max } => {
+                if min == 0 {
+                    return Err("total_contexts minimum cannot be zero".to_string());
+                }
+                if min > max {
+                    return Err("total_contexts minimum cannot be greater than maximum".to_string());
+                }
+            }
+        }
+
+        // Validate scopes_per_resource
+        match self.contexts.scopes_per_resource {
+            ConfRange::Constant(0) => return Err("scopes_per_resource cannot be zero".to_string()),
+            ConfRange::Constant(_) => (),
+            ConfRange::Inclusive { min, max } => {
+                if min == 0 {
+                    return Err("scopes_per_resource minimum cannot be zero".to_string());
+                }
+                if min > max {
+                    return Err(
+                        "scopes_per_resource minimum cannot be greater than maximum".to_string()
+                    );
+                }
+            }
+        }
+
+        // Validate logs_per_scope
+        match self.contexts.logs_per_scope {
+            ConfRange::Constant(0) => return Err("logs_per_scope cannot be zero".to_string()),
+            ConfRange::Constant(_) => (),
+            ConfRange::Inclusive { min, max } => {
+                if min == 0 {
+                    return Err("logs_per_scope minimum cannot be zero".to_string());
+                }
+                if min > max {
+                    return Err("logs_per_scope minimum cannot be greater than maximum".to_string());
+                }
+            }
+        }
+
+        // Validate body_size
+        match self.body_size {
+            ConfRange::Constant(0) => return Err("body_size cannot be zero".to_string()),
+            ConfRange::Constant(_) => (),
+            ConfRange::Inclusive { min, max } => {
+                if min == 0 {
+                    return Err("body_size minimum cannot be zero".to_string());
+                }
+                if min > max {
+                    return Err("body_size minimum cannot be greater than maximum".to_string());
+                }
+            }
+        }
+
+        Ok(())
+    }
+}
+
+impl Default for Config {
+    fn default() -> Self {
+        Self {
+            severity_weights: SeverityWeights::default(),
+            contexts: Contexts::default(),
+            trace_cardinality: ConfRange::Constant(0),
+            body_size: ConfRange::Inclusive { min: 1, max: 16 },
+        }
+    }
+}
 
 #[derive(Debug, Clone)]
 /// OTLP log payload
 pub struct OpentelemetryLogs {
-    str_pool: strings::Pool,
+    pool: Pool,
+    scratch: RefCell<BytesMut>,
+    tick: u64,
+    log_records_per_resource: u64,
+    log_records_per_block: u64,
 }
 
 impl OpentelemetryLogs {
     /// Construct a new instance of `OpentelemetryLogs`
-    pub fn new<R>(rng: &mut R) -> Self
+    ///
+    /// # Errors
+    /// Function will error if the configuration is invalid
+    pub fn new<R>(config: Config, rng: &mut R) -> Result<Self, Error>
     where
         R: rand::Rng + ?Sized,
     {
-        Self {
-            str_pool: strings::Pool::with_size(rng, 1_000_000),
-        }
+        let context_cap = config.contexts.total_contexts.sample(rng);
+        let str_pool = Rc::new(strings::Pool::with_size(rng, 128_000));
+        let rt_gen = ResourceTemplateGenerator::new(&config, &str_pool, rng)?;
+
+        Ok(Self {
+            pool: Pool::new(context_cap, rt_gen),
+            scratch: RefCell::new(BytesMut::with_capacity(4096)),
+            tick: 0,
+            log_records_per_resource: 0,
+            log_records_per_block: 0,
+        })
     }
 }
 
-impl<'a> Generator<'a> for OpentelemetryLogs {
-    type Output = LogRecord;
+impl<'a> SizedGenerator<'a> for OpentelemetryLogs {
+    type Output = ResourceLogs;
     type Error = Error;
 
-    fn generate<R>(&'a self, mut rng: &mut R) -> Result<Self::Output, Error>
+    fn generate<R>(&'a mut self, rng: &mut R, budget: &mut usize) -> Result<Self::Output, Error>
     where
         R: rand::Rng + ?Sized,
     {
-        let body: String = String::from(
-            self.str_pool
-                .of_size_range(&mut rng, 1_u16..16_u16)
-                .ok_or(Error::StringGenerate)?,
-        );
+        self.tick += rng.random_range(1..=60);
 
-        Ok(
-            #[allow(deprecated)]
-            LogRecord(v1::LogRecord {
-                time_unix_nano: rng.random(),
-                observed_time_unix_nano: rng.random(),
-                severity_number: rng.gen_range(1..=24),
-                severity_text: String::new(),
-                event_name: String::new(),
-                body: Some(AnyValue {
-                    value: Some(any_value::Value::StringValue(body)),
-                }),
-                attributes: Vec::new(),
-                dropped_attributes_count: 0,
-                flags: 0,
-                trace_id: Vec::new(),
-                span_id: Vec::new(),
-            }),
-        )
+        let mut tpl: ResourceLogs = match self.pool.fetch(rng, budget) {
+            Ok(t) => t.to_owned(),
+            Err(PoolError::EmptyChoice) => Err(PoolError::EmptyChoice)?,
+            Err(e) => Err(e)?,
+        };
+
+        let mut data_points_count = 0;
+        for scope_logs in &mut tpl.scope_logs {
+            for log_record in &mut scope_logs.log_records {
+                log_record.time_unix_nano = self.tick * TIME_INCREMENT_NANOS;
+                data_points_count += 1;
+            }
+        }
+
+        self.log_records_per_resource = data_points_count;
+
+        Ok(tpl)
     }
 }
 
@@ -100,38 +300,57 @@ impl crate::Serialize for OpentelemetryLogs {
         R: Rng + Sized,
         W: Write,
     {
-        // An Export*ServiceRequest message has 5 bytes of fixed values plus
-        // a varint-encoded message length field. The worst case for the message
-        // length field is the max message size divided by 0x7F.
-        let bytes_remaining = max_bytes.checked_sub(5 + max_bytes.div_ceil(0x7F));
-        let Some(mut bytes_remaining) = bytes_remaining else {
-            return Ok(());
+        let mut bytes_remaining = max_bytes;
+        let mut request = ExportLogsServiceRequest {
+            resource_logs: Vec::with_capacity(8),
         };
 
-        let mut acc = ExportLogsServiceRequest(Vec::new());
-        loop {
-            let member: LogRecord = self.generate(&mut rng)?;
-            // Note: this 2 is a guessed value for an unknown size factor.
-            let len = member.0.encoded_len() + 2;
-            match bytes_remaining.checked_sub(len) {
-                Some(remainder) => {
-                    acc.0.push(member);
-                    bytes_remaining = remainder;
+        let mut total_log_records = 0;
+
+        while bytes_remaining >= SMALLEST_PROTOBUF {
+            if let Ok(rl) = self.generate(&mut rng, &mut bytes_remaining) {
+                total_log_records += self.log_records_per_resource;
+                request.resource_logs.push(rl);
+
+                let required_bytes = request.encoded_len();
+                if required_bytes > max_bytes {
+                    total_log_records -= self.log_records_per_resource;
+                    drop(request.resource_logs.pop());
+                    break;
                 }
-                None => break,
+                bytes_remaining = max_bytes.saturating_sub(required_bytes);
+            } else {
+                break;
             }
         }
 
-        let buf = acc.into_prost_type().encode_to_vec();
-        writer.write_all(&buf)?;
+        let needed = request.encoded_len();
+        {
+            let mut buf = self.scratch.borrow_mut();
+            buf.clear();
+            let capacity = buf.capacity();
+            let diff = capacity.saturating_sub(needed);
+            if buf.capacity() < needed {
+                buf.reserve(diff);
+            }
+            request.encode(&mut *buf)?;
+            writer.write_all(&buf)?;
+        }
+
+        self.log_records_per_block = total_log_records;
+
         Ok(())
+    }
+
+    fn data_points_generated(&self) -> Option<u64> {
+        Some(self.log_records_per_block)
     }
 }
 
 #[cfg(test)]
 mod test {
-    use super::OpentelemetryLogs;
-    use crate::Serialize;
+    use super::{Config, Contexts, OpentelemetryLogs, SMALLEST_PROTOBUF, SeverityWeights};
+    use crate::{Serialize, SizedGenerator, common::config::ConfRange};
     use proptest::prelude::*;
     use prost::Message;
     use rand::{SeedableRng, rngs::SmallRng};
@@ -143,26 +362,12 @@ mod test {
         fn payload_not_exceed_max_bytes(seed: u64, max_bytes: u16) {
             let max_bytes = max_bytes as usize;
             let mut rng = SmallRng::seed_from_u64(seed);
-            let mut logs = OpentelemetryLogs::new(&mut rng);
+            let config = Config::default();
+            let mut logs = OpentelemetryLogs::new(config, &mut rng)?;
 
             let mut bytes = Vec::with_capacity(max_bytes);
             logs.to_bytes(rng, max_bytes, &mut bytes).expect("failed to convert to bytes");
             assert!(bytes.len() <= max_bytes, "max len: {max_bytes}, actual: {}", bytes.len());
-        }
-    }
-
-    // We want to be sure that the payloads are not being left empty.
-    proptest! {
-        #[test]
-        fn payload_is_at_least_half_of_max_bytes(seed: u64, max_bytes in 16u16..u16::MAX) {
-            let max_bytes = max_bytes as usize;
-            let mut rng = SmallRng::seed_from_u64(seed);
-            let mut logs = OpentelemetryLogs::new(&mut rng);
-
-            let mut bytes = Vec::with_capacity(max_bytes);
-            logs.to_bytes(rng, max_bytes, &mut bytes).expect("failed to convert to bytes");
-
-            assert!(!bytes.is_empty());
         }
     }
 
@@ -173,12 +378,229 @@ mod test {
         fn payload_deserializes(seed: u64, max_bytes: u16)  {
             let max_bytes = max_bytes as usize;
             let mut rng = SmallRng::seed_from_u64(seed);
-            let mut logs = OpentelemetryLogs::new(&mut rng);
+            let config = Config::default();
+            let mut logs = OpentelemetryLogs::new(config, &mut rng)?;
 
             let mut bytes: Vec<u8> = Vec::with_capacity(max_bytes);
             logs.to_bytes(rng, max_bytes, &mut bytes).expect("failed to convert to bytes");
 
             opentelemetry_proto::tonic::collector::logs::v1::ExportLogsServiceRequest::decode(bytes.as_slice()).expect("failed to decode the message from the buffer");
         }
+    }
+
+    // Generation of logs must be deterministic
+    proptest! {
+        #[test]
+        fn is_deterministic(
+            seed: u64,
+            total_contexts in 1..100_u32,
+            steps in 1..10_u8,
+            budget in 128..2048_usize,
+        ) {
+            let config = Config {
+                contexts: Contexts {
+                    total_contexts: ConfRange::Constant(total_contexts),
+                    ..Default::default()
+                },
+                ..Default::default()
+            };
+
+            let mut b1 = budget;
+            let mut rng1 = SmallRng::seed_from_u64(seed);
+            let mut logs1 = OpentelemetryLogs::new(config, &mut rng1)?;
+            let mut b2 = budget;
+            let mut rng2 = SmallRng::seed_from_u64(seed);
+            let mut logs2 = OpentelemetryLogs::new(config, &mut rng2)?;
+
+            for _ in 0..steps {
+                if let Ok(gen_1) = logs1.generate(&mut rng1, &mut b1) {
+                    let gen_2 = logs2.generate(&mut rng2, &mut b2).expect("gen_2 was not Ok");
+                    prop_assert_eq!(gen_1, gen_2);
+                    prop_assert_eq!(b1, b2);
+                } else {
+                    break;
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn config_validation() {
+        // Valid configuration
+        let valid = Config::default();
+        assert!(valid.valid().is_ok());
+
+        // Invalid: all severity weights are zero
+        let zero_severities = Config {
+            severity_weights: SeverityWeights {
+                trace: 0,
+                debug: 0,
+                info: 0,
+                warn: 0,
+                error: 0,
+                fatal: 0,
+            },
+            ..Default::default()
+        };
+        assert!(zero_severities.valid().is_err());
+
+        // Invalid: zero total_contexts
+        let zero_contexts = Config {
+            contexts: Contexts {
+                total_contexts: ConfRange::Constant(0),
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        assert!(zero_contexts.valid().is_err());
+
+        // Invalid: zero logs_per_scope
+        let zero_logs = Config {
+            contexts: Contexts {
+                logs_per_scope: ConfRange::Constant(0),
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        assert!(zero_logs.valid().is_err());
+
+        // Invalid: zero body_size
+        let zero_body = Config {
+            body_size: ConfRange::Constant(0),
+            ..Default::default()
+        };
+        assert!(zero_body.valid().is_err());
+    }
+
+    // Budget always decreases equivalent to the size of the returned value
+    proptest! {
+        #[test]
+        fn generate_decrease_budget(
+            seed: u64,
+            total_contexts in 1..100_u32,
+            steps in 1..10_u8,
+        ) {
+            let config = Config {
+                contexts: Contexts {
+                    total_contexts: ConfRange::Constant(total_contexts),
+                    ..Default::default()
+                },
+                ..Default::default()
+            };
+
+            let mut budget = 10_000_000;
+            let mut rng = SmallRng::seed_from_u64(seed);
+            let mut logs = OpentelemetryLogs::new(config, &mut rng)?;
+
+            for _ in 0..steps {
+                let prev = budget;
+                match logs.generate(&mut rng, &mut budget) {
+                    Ok(_rl) => {
+                        // The pool manages its own budget tracking based on cached sizes
+                        // Just verify that budget decreased
+                        prop_assert!(budget < prev);
+                    }
+                    Err(_) => break,
+                }
+            }
+        }
+    }
+
+    // This test verifies:
+    //
+    // * Timestamps actually increase, are not all a constant value
+    // * Each timestamp is a monotonic increase
+    proptest! {
+        #[test]
+        fn timestamps_increase_monotonically(
+            seed: u64,
+            steps in 2..20_u8,
+            budget in SMALLEST_PROTOBUF..2048_usize,
+        ) {
+            let config = Config::default();
+            let mut rng = SmallRng::seed_from_u64(seed);
+            let mut logs = OpentelemetryLogs::new(config, &mut rng)?;
+
+            let mut timestamps = Vec::new();
+
+            for _ in 0..steps {
+                let mut step_budget = budget;
+                if let Ok(resource_logs) = logs.generate(&mut rng, &mut step_budget) {
+                    // All logs within a single generate() call have the same timestamp
+                    // We just need to verify one
+                    if let Some(scope_logs) = resource_logs.scope_logs.first() {
+                        if let Some(log) = scope_logs.log_records.first() {
+                            timestamps.push(log.time_unix_nano);
+                        }
+                    }
+                } else {
+                    break;
+                }
+            }
+
+            if timestamps.len() > 1 {
+                for i in 1..timestamps.len() {
+                    prop_assert!(
+                        timestamps[i] > timestamps[i-1],
+                        "Timestamps did not increase monotonically: {} <= {}",
+                        timestamps[i], timestamps[i-1]
+                    );
+                }
+            }
+        }
+    }
+
+    // The goal of the test is to experimentally determine the value of
+    // SMALLEST_PROTOBUF. Anything that encode/decodes and obeys the semantics
+    // of the OTLP spec is acceptable. It's possible that as the protobuf
+    // definition changes the value demonstrated by this test and
+    // SMALLEST_PROTOBUF will differ.
+    #[test]
+    fn smallest_protobuf() {
+        use opentelemetry_proto::tonic::{
+            collector::logs::v1::ExportLogsServiceRequest,
+            common::v1::{AnyValue, any_value},
+            logs::v1::{LogRecord, ResourceLogs, ScopeLogs, SeverityNumber},
+        };
+
+        let log_record = LogRecord {
+            time_unix_nano: 0,
+            observed_time_unix_nano: 0,
+            severity_number: SeverityNumber::Info as i32,
+            severity_text: String::new(),
+            body: Some(AnyValue {
+                value: Some(any_value::Value::StringValue(String::new())),
+            }),
+            attributes: Vec::new(),
+            dropped_attributes_count: 0,
+            flags: 0,
+            trace_id: Vec::new(),
+            span_id: Vec::new(),
+            event_name: String::new(),
+        };
+
+        let scope_logs = ScopeLogs {
+            scope: None,
+            log_records: vec![log_record],
+            schema_url: String::new(),
+        };
+
+        let resource_logs = ResourceLogs {
+            resource: None,
+            scope_logs: vec![scope_logs],
+            schema_url: String::new(),
+        };
+
+        // The most minimal request we care to support, just one single log record
+        let minimal_request = ExportLogsServiceRequest {
+            resource_logs: vec![resource_logs],
+        };
+
+        let encoded_size = minimal_request.encoded_len();
+
+        assert!(
+            encoded_size == SMALLEST_PROTOBUF,
+            "Minimal useful request size ({encoded_size}) should be == SMALLEST_PROTOBUF ({SMALLEST_PROTOBUF})"
+        );
     }
 }

--- a/lading_payload/src/opentelemetry/log.rs
+++ b/lading_payload/src/opentelemetry/log.rs
@@ -250,6 +250,8 @@ impl OpentelemetryLogs {
     where
         R: rand::Rng + ?Sized,
     {
+        config.valid().map_err(Error::Validation)?;
+
         let context_cap = config.contexts.total_contexts.sample(rng);
         let str_pool = Rc::new(strings::Pool::with_size(rng, 128_000));
         let rt_gen = ResourceTemplateGenerator::new(&config, &str_pool, rng)?;

--- a/lading_payload/src/opentelemetry/log/templates.rs
+++ b/lading_payload/src/opentelemetry/log/templates.rs
@@ -94,6 +94,13 @@ impl<'a> crate::SizedGenerator<'a> for LogTemplateGenerator {
                 if inner_budget == original_budget {
                     return Err(GeneratorError::SizeExhausted);
                 }
+                // If attribute population was partial -- signaled by
+                // inner_budget being drawn down on -- we return the budget back
+                // and live with no attributes. We do this because OTLP is
+                // expensive to generate and we may be able to create a
+                // reasonable instance of a `LogRecord` with the budget
+                // otherwise on hand.
+                inner_budget = original_budget;
                 Vec::new()
             }
             Err(e) => return Err(e),

--- a/lading_payload/src/opentelemetry/log/templates.rs
+++ b/lading_payload/src/opentelemetry/log/templates.rs
@@ -1,0 +1,360 @@
+use std::rc::Rc;
+
+use opentelemetry_proto::tonic::{
+    common::v1::{AnyValue, InstrumentationScope, any_value},
+    logs::v1::{LogRecord, ResourceLogs, ScopeLogs, SeverityNumber},
+    resource::v1::Resource,
+};
+use prost::Message;
+use rand::{
+    Rng,
+    distr::{Distribution, weighted::WeightedIndex},
+};
+
+use super::Config;
+use crate::opentelemetry::common::templates::Pool as GenericPool;
+use crate::opentelemetry::common::{GeneratorError, TagGenerator, UNIQUE_TAG_RATIO};
+use crate::{Error, common::config::ConfRange, common::strings};
+
+pub(crate) type Pool = GenericPool<ResourceLogs, ResourceTemplateGenerator>;
+
+#[derive(Debug, Clone)]
+pub(crate) struct LogTemplateGenerator {
+    severity_dist: WeightedIndex<u16>,
+    str_pool: Rc<strings::Pool>,
+    tags: TagGenerator,
+    body_size: ConfRange<u16>,
+    trace_ids: Vec<Vec<u8>>,
+}
+
+impl LogTemplateGenerator {
+    pub(crate) fn new<R>(
+        config: &Config,
+        str_pool: &Rc<strings::Pool>,
+        rng: &mut R,
+    ) -> Result<Self, Error>
+    where
+        R: Rng + ?Sized,
+    {
+        let tags = TagGenerator::new(
+            rng.random(),
+            config.contexts.attributes_per_log,
+            ConfRange::Inclusive { min: 3, max: 32 },
+            config.contexts.total_contexts.end() as usize,
+            Rc::clone(str_pool),
+            UNIQUE_TAG_RATIO,
+        )?;
+
+        let trace_count = config.trace_cardinality.sample(rng) as usize;
+        let mut trace_ids = Vec::with_capacity(trace_count);
+        for _ in 0..trace_count {
+            let mut trace_id = vec![0u8; 16];
+            rng.fill_bytes(&mut trace_id);
+            trace_ids.push(trace_id);
+        }
+
+        Ok(Self {
+            // NOTE if you change the ordering here update the code below that
+            // sets `severity_number` to match. If indexes DO NOT match we will
+            // not generate the right severity.
+            severity_dist: WeightedIndex::new([
+                u16::from(config.severity_weights.trace),
+                u16::from(config.severity_weights.debug),
+                u16::from(config.severity_weights.warn),
+                u16::from(config.severity_weights.error),
+                u16::from(config.severity_weights.fatal),
+                u16::from(config.severity_weights.info),
+            ])?,
+            str_pool: Rc::clone(str_pool),
+            tags,
+            body_size: config.body_size,
+            trace_ids,
+        })
+    }
+}
+
+impl<'a> crate::SizedGenerator<'a> for LogTemplateGenerator {
+    type Output = LogRecord;
+    type Error = GeneratorError;
+
+    fn generate<R>(
+        &'a mut self,
+        rng: &mut R,
+        budget: &mut usize,
+    ) -> Result<Self::Output, Self::Error>
+    where
+        R: Rng + ?Sized,
+    {
+        let original_budget: usize = *budget;
+        let mut inner_budget: usize = *budget;
+
+        let attributes = match self.tags.generate(rng, &mut inner_budget) {
+            Ok(attrs) => attrs,
+            Err(GeneratorError::SizeExhausted) => {
+                if inner_budget == original_budget {
+                    return Err(GeneratorError::SizeExhausted);
+                }
+                Vec::new()
+            }
+            Err(e) => return Err(e),
+        };
+
+        let severity_idx = self.severity_dist.sample(rng);
+        let severity_number = match severity_idx {
+            0 => SeverityNumber::Trace as i32,
+            1 => SeverityNumber::Debug as i32,
+            2 => SeverityNumber::Warn as i32,
+            3 => SeverityNumber::Error as i32,
+            4 => SeverityNumber::Fatal as i32,
+            _ => SeverityNumber::Info as i32,
+        };
+
+        let body_size = self.body_size.sample(rng);
+        let body = self
+            .str_pool
+            .of_size(rng, body_size as usize)
+            .ok_or(GeneratorError::StringGenerate)?;
+
+        let trace_id = if self.trace_ids.is_empty() {
+            Vec::new()
+        } else {
+            let idx = rng.random_range(0..self.trace_ids.len());
+            self.trace_ids[idx].clone()
+        };
+
+        let log_record = LogRecord {
+            time_unix_nano: 0,
+            observed_time_unix_nano: 0,
+            severity_number,
+            severity_text: String::new(),
+            body: Some(AnyValue {
+                value: Some(any_value::Value::StringValue(body.to_string())),
+            }),
+            attributes,
+            dropped_attributes_count: 0,
+            flags: 0,
+            trace_id,
+            span_id: Vec::new(),
+            event_name: String::new(),
+        };
+
+        let encoded_size = log_record.encoded_len();
+        if encoded_size > inner_budget {
+            return Err(GeneratorError::SizeExhausted);
+        }
+
+        *budget = original_budget.saturating_sub(encoded_size);
+        Ok(log_record)
+    }
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct ScopeTemplateGenerator {
+    log_gen: LogTemplateGenerator,
+    tags: TagGenerator,
+    str_pool: Rc<strings::Pool>,
+    logs_per_scope: ConfRange<u8>,
+}
+
+impl ScopeTemplateGenerator {
+    pub(crate) fn new<R>(
+        config: &Config,
+        str_pool: &Rc<strings::Pool>,
+        rng: &mut R,
+    ) -> Result<Self, Error>
+    where
+        R: Rng + ?Sized,
+    {
+        let tags = TagGenerator::new(
+            rng.random(),
+            config.contexts.attributes_per_scope,
+            ConfRange::Inclusive { min: 3, max: 32 },
+            config.contexts.total_contexts.end() as usize,
+            Rc::clone(str_pool),
+            UNIQUE_TAG_RATIO,
+        )?;
+
+        Ok(Self {
+            log_gen: LogTemplateGenerator::new(config, str_pool, rng)?,
+            tags,
+            str_pool: Rc::clone(str_pool),
+            logs_per_scope: config.contexts.logs_per_scope,
+        })
+    }
+}
+
+impl<'a> crate::SizedGenerator<'a> for ScopeTemplateGenerator {
+    type Output = ScopeLogs;
+    type Error = GeneratorError;
+
+    fn generate<R>(
+        &'a mut self,
+        rng: &mut R,
+        budget: &mut usize,
+    ) -> Result<Self::Output, Self::Error>
+    where
+        R: Rng + ?Sized,
+    {
+        let original_budget: usize = *budget;
+        let mut inner_budget: usize = *budget;
+
+        let scope_attributes = match self.tags.generate(rng, &mut inner_budget) {
+            Ok(attrs) => attrs,
+            Err(GeneratorError::SizeExhausted) => {
+                if inner_budget == original_budget {
+                    return Err(GeneratorError::SizeExhausted);
+                }
+                Vec::new()
+            }
+            Err(e) => return Err(e),
+        };
+
+        let scope = if scope_attributes.is_empty() {
+            None
+        } else {
+            Some(InstrumentationScope {
+                name: self
+                    .str_pool
+                    .of_size_range(rng, 1_u16..32_u16)
+                    .ok_or(GeneratorError::StringGenerate)?
+                    .to_string(),
+                version: String::new(),
+                attributes: scope_attributes,
+                dropped_attributes_count: 0,
+            })
+        };
+
+        let num_logs = self.logs_per_scope.sample(rng);
+        let mut log_records = Vec::with_capacity(num_logs as usize);
+
+        for _ in 0..num_logs {
+            match self.log_gen.generate(rng, &mut inner_budget) {
+                Ok(log) => log_records.push(log),
+                Err(GeneratorError::SizeExhausted) => {
+                    if log_records.is_empty() {
+                        return Err(GeneratorError::SizeExhausted);
+                    }
+                    break;
+                }
+                Err(e) => return Err(e),
+            }
+        }
+
+        let scope_logs = ScopeLogs {
+            scope,
+            log_records,
+            schema_url: String::new(),
+        };
+
+        let encoded_size = scope_logs.encoded_len();
+        if encoded_size > inner_budget {
+            return Err(GeneratorError::SizeExhausted);
+        }
+
+        *budget -= encoded_size;
+        Ok(scope_logs)
+    }
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct ResourceTemplateGenerator {
+    scope_gen: ScopeTemplateGenerator,
+    tags: TagGenerator,
+    scopes_per_resource: ConfRange<u8>,
+}
+
+impl ResourceTemplateGenerator {
+    pub(crate) fn new<R>(
+        config: &Config,
+        str_pool: &Rc<strings::Pool>,
+        rng: &mut R,
+    ) -> Result<Self, Error>
+    where
+        R: Rng + ?Sized,
+    {
+        config.valid().map_err(Error::Validation)?;
+
+        let tags = TagGenerator::new(
+            rng.random(),
+            config.contexts.attributes_per_resource,
+            ConfRange::Inclusive { min: 3, max: 32 },
+            config.contexts.total_contexts.end() as usize,
+            Rc::clone(str_pool),
+            UNIQUE_TAG_RATIO,
+        )?;
+
+        Ok(Self {
+            scope_gen: ScopeTemplateGenerator::new(config, str_pool, rng)?,
+            tags,
+            scopes_per_resource: config.contexts.scopes_per_resource,
+        })
+    }
+}
+
+impl<'a> crate::SizedGenerator<'a> for ResourceTemplateGenerator {
+    type Output = ResourceLogs;
+    type Error = GeneratorError;
+
+    fn generate<R>(
+        &'a mut self,
+        rng: &mut R,
+        budget: &mut usize,
+    ) -> Result<Self::Output, Self::Error>
+    where
+        R: Rng + ?Sized,
+    {
+        let original_budget: usize = *budget;
+        let mut inner_budget: usize = *budget;
+
+        let resource_attributes = match self.tags.generate(rng, &mut inner_budget) {
+            Ok(attrs) => attrs,
+            Err(GeneratorError::SizeExhausted) => {
+                if inner_budget == original_budget {
+                    return Err(GeneratorError::SizeExhausted);
+                }
+                Vec::new()
+            }
+            Err(e) => return Err(e),
+        };
+
+        let resource = if resource_attributes.is_empty() {
+            None
+        } else {
+            Some(Resource {
+                attributes: resource_attributes,
+                dropped_attributes_count: 0,
+                entity_refs: Vec::new(),
+            })
+        };
+
+        let num_scopes = self.scopes_per_resource.sample(rng);
+        let mut scope_logs = Vec::with_capacity(num_scopes as usize);
+
+        for _ in 0..num_scopes {
+            match self.scope_gen.generate(rng, &mut inner_budget) {
+                Ok(scope) => scope_logs.push(scope),
+                Err(GeneratorError::SizeExhausted) => {
+                    if scope_logs.is_empty() {
+                        return Err(GeneratorError::SizeExhausted);
+                    }
+                    break;
+                }
+                Err(e) => return Err(e),
+            }
+        }
+
+        let resource_logs = ResourceLogs {
+            resource,
+            scope_logs,
+            schema_url: String::new(),
+        };
+
+        let encoded_size = resource_logs.encoded_len();
+        if encoded_size > original_budget {
+            return Err(GeneratorError::SizeExhausted);
+        }
+
+        *budget -= encoded_size;
+        Ok(resource_logs)
+    }
+}

--- a/lading_payload/src/opentelemetry/log/templates.rs
+++ b/lading_payload/src/opentelemetry/log/templates.rs
@@ -223,12 +223,15 @@ impl<'a> crate::SizedGenerator<'a> for ScopeTemplateGenerator {
         let original_budget: usize = *budget;
         let mut inner_budget: usize = *budget;
 
+        // For an explanation of this pattern, please see the note in
+        // `LogTemplateGenerator::generate`.
         let scope_attributes = match self.tags.generate(rng, &mut inner_budget) {
             Ok(attrs) => attrs,
             Err(GeneratorError::SizeExhausted) => {
                 if inner_budget == original_budget {
                     return Err(GeneratorError::SizeExhausted);
                 }
+                inner_budget = original_budget;
                 Vec::new()
             }
             Err(e) => return Err(e),
@@ -331,12 +334,15 @@ impl<'a> crate::SizedGenerator<'a> for ResourceTemplateGenerator {
         let original_budget: usize = *budget;
         let mut inner_budget: usize = *budget;
 
+        // For an explanation of this pattern, please see the note in
+        // `LogTemplateGenerator::generate`.
         let resource_attributes = match self.tags.generate(rng, &mut inner_budget) {
             Ok(attrs) => attrs,
             Err(GeneratorError::SizeExhausted) => {
                 if inner_budget == original_budget {
                     return Err(GeneratorError::SizeExhausted);
                 }
+                inner_budget = original_budget;
                 Vec::new()
             }
             Err(e) => return Err(e),

--- a/lading_payload/src/opentelemetry/metric.rs
+++ b/lading_payload/src/opentelemetry/metric.rs
@@ -38,7 +38,6 @@
 // * value: enum { u64, f64 } -- the value
 // * flags: uu32 -- I'm not sure what to make of this yet
 
-// tags module moved to common
 pub(crate) mod templates;
 pub(crate) mod unit;
 

--- a/lading_payload/src/opentelemetry/metric.rs
+++ b/lading_payload/src/opentelemetry/metric.rs
@@ -38,7 +38,7 @@
 // * value: enum { u64, f64 } -- the value
 // * flags: uu32 -- I'm not sure what to make of this yet
 
-pub(crate) mod tags;
+// tags module moved to common
 pub(crate) mod templates;
 pub(crate) mod unit;
 
@@ -53,7 +53,7 @@ use opentelemetry_proto::tonic::metrics::v1::metric::Data;
 use opentelemetry_proto::tonic::metrics::v1::{self, number_data_point};
 use prost::Message;
 use serde::{Deserialize, Serialize as SerdeSerialize};
-use templates::{Pool, PoolError, ResourceTemplateGenerator};
+use templates::{Pool, ResourceTemplateGenerator};
 use tracing::{debug, error};
 use unit::UnitGenerator;
 
@@ -323,9 +323,9 @@ impl<'a> SizedGenerator<'a> for OpentelemetryMetrics {
 
         let mut tpl: v1::ResourceMetrics = match self.pool.fetch(rng, budget) {
             Ok(t) => t.to_owned(),
-            Err(PoolError::EmptyChoice) => {
+            Err(crate::opentelemetry::common::templates::PoolError::EmptyChoice) => {
                 error!("Pool was unable to satify request for {budget} size");
-                Err(PoolError::EmptyChoice)?
+                Err(crate::opentelemetry::common::templates::PoolError::EmptyChoice)?
             }
             Err(e) => Err(e)?,
         };

--- a/lading_payload/src/opentelemetry/metric/unit.rs
+++ b/lading_payload/src/opentelemetry/metric/unit.rs
@@ -7,7 +7,7 @@
 // that for our purposes, so for now we rely on a simple table method. I imagine
 // we can just keep stuffing the table for a while as seems desirable.
 
-use super::templates::GeneratorError;
+use crate::opentelemetry::common::GeneratorError;
 
 const UNITS: &[&str] = &[
     "bit", "Kbit", "Mbit", "Gbit", // data size, bits, decimal


### PR DESCRIPTION
### What does this PR do?

This commit updates our OTel logs payload to be configurable by the end user. We
    allow in a manner similar to metrics for the contexts to be capped, attributes
    per level of the message format to be set and seprately from the context
    consideration we allow for generation and constraint of total trace-ids.

### Motivation

REF SMPTNG-659
