### PR TITLE
Adds structure to support lading subcommands, 'run' is an alias for the current root cmd

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added a `/proc/vmstat` observer.
 ## Changed
 - 'lading process-tree-gen' command is removed as it is currently unused
+- 'lading run' sub-command added as alias for current top-level CLI usage.
 
 ## [0.26.0]
 ## Added


### PR DESCRIPTION
### What does this PR do?

Adds better support for lading subcommands and adds a subcommand 'run' that acts as a drop-in replacement for today's "bare" cli usage.

### Motivation

A clean separation of concerns is needed for lading CLI invocations, currently the "main" cli invocation starts all components of lading (observers, generators, target metrics, etc). 

By separating 'run' out into its own subcommand, we pave the way to support lading invocations that only need a subset of the functionality, eg 'lading generate' could _only_ run generators.

Concretely, this is needed for the up-stack PR adding `lading config-check`

### Related issues


### Additional Notes

