### PR TITLE
Allow block cache to have a 'handle' concept

### DIFF
--- a/lading/src/bin/payloadtool.rs
+++ b/lading/src/bin/payloadtool.rs
@@ -50,10 +50,8 @@ fn generate_and_check(
 ) -> Result<(), Error> {
     let mut rng = StdRng::from_seed(seed);
     let start = Instant::now();
-    let blocks = match block::Cache::fixed(&mut rng, total_bytes, max_block_size.as_u128(), config)?
-    {
-        block::Cache::Fixed { blocks, .. } => blocks,
-    };
+    let block_cache = block::Cache::fixed(&mut rng, total_bytes, max_block_size.as_u128(), config)?;
+    let blocks = block_cache.blocks();
     info!("Payload generation took {:?}", start.elapsed());
     trace!("Payload: {:#?}", blocks);
 

--- a/lading/src/generator/file_gen/logrotate_fs.rs
+++ b/lading/src/generator/file_gen/logrotate_fs.rs
@@ -145,6 +145,7 @@ impl Server {
             config.maximum_block_size.as_u128(),
             &config.variant,
         )?;
+        let handle = block_cache.handle();
 
         let start_time = std::time::Instant::now();
         let start_time_system = std::time::SystemTime::now();
@@ -154,7 +155,7 @@ impl Server {
             start_time.elapsed().as_secs(),
             config.total_rotations,
             config.maximum_bytes_per_log.as_u128() as u64,
-            block_cache,
+            handle,
             config.max_depth,
             config.concurrent_logs,
             config.load_profile.to_model(),

--- a/lading_payload/fuzz/fuzz_targets/fixed_cache_creation.rs
+++ b/lading_payload/fuzz/fuzz_targets/fixed_cache_creation.rs
@@ -23,10 +23,16 @@ fuzz_target!(|input: Input| {
     }
 
     let mut rng = SmallRng::from_seed(input.seed);
+    // Use the maximum block size from the array
+    let max_block_size = input.block_bytes_sizes
+        .iter()
+        .map(|size| size.get() as u128)
+        .max()
+        .unwrap_or(1024);
     let _res = Cache::fixed(
         &mut rng,
         input.total_bytes,
-        &input.block_bytes_sizes,
+        max_block_size,
         &input.payload,
     );
 });

--- a/lading_payload/fuzz/fuzz_targets/fixed_cache_creation_apache_common.rs
+++ b/lading_payload/fuzz/fuzz_targets/fixed_cache_creation_apache_common.rs
@@ -22,10 +22,16 @@ fuzz_target!(|input: Input| {
     }
 
     let mut rng = SmallRng::from_seed(input.seed);
+    // Use the maximum block size from the array
+    let max_block_size = input.block_bytes_sizes
+        .iter()
+        .map(|size| size.get() as u128)
+        .max()
+        .unwrap_or(1024);
     let _res = Cache::fixed(
         &mut rng,
         input.total_bytes,
-        &input.block_bytes_sizes,
+        max_block_size,
         &lading_payload::Config::ApacheCommon,
     );
 });

--- a/lading_payload/fuzz/fuzz_targets/fixed_cache_creation_ascii.rs
+++ b/lading_payload/fuzz/fuzz_targets/fixed_cache_creation_ascii.rs
@@ -22,10 +22,16 @@ fuzz_target!(|input: Input| {
     }
 
     let mut rng = SmallRng::from_seed(input.seed);
+    // Use the maximum block size from the array
+    let max_block_size = input.block_bytes_sizes
+        .iter()
+        .map(|size| size.get() as u128)
+        .max()
+        .unwrap_or(1024);
     let _res = Cache::fixed(
         &mut rng,
         input.total_bytes,
-        &input.block_bytes_sizes,
+        max_block_size,
         &lading_payload::Config::Ascii,
     );
 });

--- a/lading_payload/fuzz/fuzz_targets/fixed_cache_creation_datadog_log.rs
+++ b/lading_payload/fuzz/fuzz_targets/fixed_cache_creation_datadog_log.rs
@@ -22,10 +22,16 @@ fuzz_target!(|input: Input| {
     }
 
     let mut rng = SmallRng::from_seed(input.seed);
+    // Use the maximum block size from the array
+    let max_block_size = input.block_bytes_sizes
+        .iter()
+        .map(|size| size.get() as u128)
+        .max()
+        .unwrap_or(1024);
     let _res = Cache::fixed(
         &mut rng,
         input.total_bytes,
-        &input.block_bytes_sizes,
+        max_block_size,
         &lading_payload::Config::DatadogLog,
     );
 });

--- a/lading_payload/fuzz/fuzz_targets/fixed_cache_creation_dogstatsd.rs
+++ b/lading_payload/fuzz/fuzz_targets/fixed_cache_creation_dogstatsd.rs
@@ -23,10 +23,16 @@ fuzz_target!(|input: Input| {
     }
 
     let mut rng = SmallRng::from_seed(input.seed);
+    // Use the maximum block size from the array
+    let max_block_size = input.block_bytes_sizes
+        .iter()
+        .map(|size| size.get() as u128)
+        .max()
+        .unwrap_or(1024);
     let _res = Cache::fixed(
         &mut rng,
         input.total_bytes,
-        &input.block_bytes_sizes,
+        max_block_size,
         &lading_payload::Config::DogStatsD(input.config),
     );
 });

--- a/lading_payload/fuzz/fuzz_targets/fixed_cache_creation_fluent.rs
+++ b/lading_payload/fuzz/fuzz_targets/fixed_cache_creation_fluent.rs
@@ -22,10 +22,16 @@ fuzz_target!(|input: Input| {
     }
 
     let mut rng = SmallRng::from_seed(input.seed);
+    // Use the maximum block size from the array
+    let max_block_size = input.block_bytes_sizes
+        .iter()
+        .map(|size| size.get() as u128)
+        .max()
+        .unwrap_or(1024);
     let _res = Cache::fixed(
         &mut rng,
         input.total_bytes,
-        &input.block_bytes_sizes,
+        max_block_size,
         &lading_payload::Config::Fluent,
     );
 });

--- a/lading_payload/fuzz/fuzz_targets/fixed_cache_creation_json.rs
+++ b/lading_payload/fuzz/fuzz_targets/fixed_cache_creation_json.rs
@@ -22,10 +22,16 @@ fuzz_target!(|input: Input| {
     }
 
     let mut rng = SmallRng::from_seed(input.seed);
+    // Use the maximum block size from the array
+    let max_block_size = input.block_bytes_sizes
+        .iter()
+        .map(|size| size.get() as u128)
+        .max()
+        .unwrap_or(1024);
     let _res = Cache::fixed(
         &mut rng,
         input.total_bytes,
-        &input.block_bytes_sizes,
+        max_block_size,
         &lading_payload::Config::Json,
     );
 });

--- a/lading_payload/proptest-regressions/dogstatsd.txt
+++ b/lading_payload/proptest-regressions/dogstatsd.txt
@@ -6,3 +6,4 @@
 # everyone who runs the test benefits from these saved cases.
 cc 97158e48115dce6b53c08d3f3744ebd92cb711273b19aee225daa774f71f6e23 # shrinks to seed = 0, max_bytes = 0
 cc 077dc27bd44ddd568537d3742556e1a422619e126a2fbf86c7e7f54374780baf # shrinks to seed = 11798065272331789525, max_bytes = 3627
+cc d8f772d64e4e56c720e66600e8d2e88fbcaaa60294f5006da3d9ddf2472343bc # shrinks to seed = 0, max_bytes = 1

--- a/lading_payload/src/block.rs
+++ b/lading_payload/src/block.rs
@@ -6,6 +6,7 @@
 //! mechanism by which 'blocks' -- that is, byte blobs of a predetermined size
 //! -- are created.
 use std::num::NonZeroU32;
+use std::sync::Arc;
 
 use byte_unit::{Byte, Unit};
 use bytes::{BufMut, Bytes, BytesMut, buf::Writer};
@@ -147,8 +148,118 @@ pub fn default_maximum_block_size() -> Byte {
     Byte::from_u64_with_unit(1, Unit::MiB).expect("catastrophic programming bug")
 }
 
+/// Internal cache data that is shared across handles
 #[derive(Debug)]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+struct CacheData {
+    /// The store of blocks.
+    blocks: Vec<Block>,
+    /// The amount of data stored in one cycle, or all blocks
+    total_cycle_size: u64,
+}
+
+/// A handle to a shared cache with its own private index
+#[derive(Debug, Clone)]
+pub struct Handle {
+    /// Shared cache data
+    cache: Arc<CacheData>,
+    /// The current index into the cache blocks
+    idx: usize,
+}
+
+impl Handle {
+    /// Peek at the next `Block` from the `Handle`.
+    ///
+    /// This returns a reference to the next `Block` instance although the
+    /// handle is not advanced by this call. Callers must call
+    /// [`Self::next_block`] or this handle will not advance.
+    #[must_use]
+    pub fn peek_next(&self) -> &Block {
+        &self.cache.blocks[self.idx]
+    }
+
+    /// Return a `Block` from the `Handle`
+    ///
+    /// This returns a single `Block` instance and advances the internal
+    /// index to the next block.
+    pub fn next_block(&mut self) -> &Block {
+        let block = &self.cache.blocks[self.idx];
+        self.idx = (self.idx + 1) % self.cache.blocks.len();
+        block
+    }
+
+    /// Read data starting from a given offset and up to the specified size.
+    ///
+    /// # Panics
+    ///
+    /// Function will panic if reads are larger than machine word bytes wide.
+    pub fn read_at(&self, offset: u64, size: usize) -> Bytes {
+        let mut data = BytesMut::with_capacity(size);
+
+        let blocks = &self.cache.blocks;
+        let total_cycle_size = usize::try_from(self.cache.total_cycle_size)
+            .expect("cycle size larger than machine word bytes");
+
+        let mut remaining = size;
+        let mut current_offset =
+            usize::try_from(offset).expect("offset larger than machine word bytes");
+
+        while remaining > 0 {
+            // The plan is this. We treat the blocks as one infinite cycle. We
+            // map our offset into the domain of the blocks, then seek forward
+            // until we find the block we need to start reading from. Then we
+            // read into `data`.
+
+            let offset_within_cycle = current_offset % total_cycle_size;
+            let mut block_start = 0;
+            for block in blocks {
+                let block_size = block.total_bytes.get() as usize;
+                if offset_within_cycle < block_start + block_size {
+                    // Offset is within this block. Begin reading into `data`.
+                    let block_offset = offset_within_cycle - block_start;
+                    let bytes_in_block = (block_size - block_offset).min(remaining);
+
+                    data.extend_from_slice(
+                        &block.bytes[block_offset..block_offset + bytes_in_block],
+                    );
+
+                    remaining -= bytes_in_block;
+                    current_offset += bytes_in_block;
+                    break;
+                }
+                block_start += block_size;
+            }
+
+            // If we couldn't find a block this suggests something seriously
+            // wacky has happened.
+            if remaining > 0 && block_start >= total_cycle_size {
+                error!("Offset exceeds total cycle size");
+                break;
+            }
+        }
+
+        data.freeze()
+    }
+
+    /// Run this handle forward on the user-provided mpsc sender.
+    ///
+    /// This is a blocking function that pushes `Block` instances into the
+    /// user-provided mpsc `Sender<Block>`. The user is required to set an
+    /// appropriate size on the channel. This function will never exit.
+    ///
+    /// # Errors
+    ///
+    /// Function will return an error if the user-provided mpsc `Sender<Block>`
+    /// is closed.
+    #[allow(clippy::needless_pass_by_value)]
+    pub fn spin(mut self, snd: Sender<Block>) -> Result<(), SpinError> {
+        loop {
+            snd.blocking_send(self.cache.blocks[self.idx].clone())?;
+            self.idx = (self.idx + 1) % self.cache.blocks.len();
+        }
+    }
+}
+
+#[derive(Debug)]
 /// A mechanism for streaming byte blobs, 'blocks'
 ///
 /// The `Cache` is a mechanism to allow generators to request 'blocks' without
@@ -162,12 +273,8 @@ pub enum Cache {
     /// A fixed size cache of blocks. Blocks are looped over in a round-robin
     /// fashion.
     Fixed {
-        /// The current index into `blocks`
-        idx: usize,
-        /// The store of blocks.
-        blocks: Vec<Block>,
-        /// The amount of data stored in one cycle, or all blocks
-        total_cycle_size: u64,
+        /// Shared cache data
+        data: Arc<CacheData>,
     },
 }
 
@@ -353,10 +460,35 @@ impl Cache {
             .sum();
 
         Ok(Self::Fixed {
-            idx: 0,
-            blocks,
-            total_cycle_size,
+            data: Arc::new(CacheData {
+                blocks,
+                total_cycle_size,
+            }),
         })
+    }
+
+    /// Create a new handle to this cache.
+    ///
+    /// Each handle maintains its own private index into the cache blocks,
+    /// allowing multiple handles to read from the same cache independently.
+    #[must_use]
+    pub fn handle(&self) -> Handle {
+        match self {
+            Self::Fixed { data } => Handle {
+                cache: Arc::clone(data),
+                idx: 0,
+            },
+        }
+    }
+
+    /// Get a reference to the blocks stored in this cache.
+    ///
+    /// This is primarily useful for inspection and debugging purposes.
+    #[must_use]
+    pub fn blocks(&self) -> &[Block] {
+        match self {
+            Self::Fixed { data } => &data.blocks,
+        }
     }
 
     /// Run `Cache` forward on the user-provided mpsc sender.
@@ -372,100 +504,15 @@ impl Cache {
     #[allow(clippy::needless_pass_by_value)]
     pub fn spin(self, snd: Sender<Block>) -> Result<(), SpinError> {
         match self {
-            Self::Fixed {
-                mut idx, blocks, ..
-            } => loop {
-                snd.blocking_send(blocks[idx].clone())?;
-                idx = (idx + 1) % blocks.len();
-            },
-        }
-    }
-
-    /// Peek at the next `Block` from the `Cache`.
-    ///
-    /// This is a block function that returns a reference to the next `Block`
-    /// instance although the cache is not advanced by this call. Callers must
-    /// call [`Self::next_block`] or this cache will not advance.
-    #[must_use]
-    pub fn peek_next(&self) -> &Block {
-        match self {
-            Self::Fixed { idx, blocks, .. } => &blocks[*idx],
-        }
-    }
-
-    /// Return a `Block` from the `Cache`
-    ///
-    /// This is a blocking function that returns a single `Block` instance as
-    /// soon as one is ready, blocking the caller until one is available.
-    pub fn next_block(&mut self) -> &Block {
-        match self {
-            Self::Fixed { idx, blocks, .. } => {
-                let block = &blocks[*idx];
-                *idx = (*idx + 1) % blocks.len();
-                block
-            }
-        }
-    }
-
-    /// Read data starting from a given offset and up to the specified size.
-    ///
-    /// # Panics
-    ///
-    /// Function will panic if reads are larger than machine word bytes wide.
-    pub fn read_at(&self, offset: u64, size: usize) -> Bytes {
-        let mut data = BytesMut::with_capacity(size);
-
-        let (blocks, total_cycle_size) = match self {
-            Cache::Fixed {
-                blocks,
-                total_cycle_size,
-                ..
-            } => (
-                blocks,
-                usize::try_from(*total_cycle_size)
-                    .expect("cycle size larger than machine word bytes"),
-            ),
-        };
-
-        let mut remaining = size;
-        let mut current_offset =
-            usize::try_from(offset).expect("offset larger than machine word bytes");
-
-        while remaining > 0 {
-            // The plan is this. We treat the blocks as one infinite cycle. We
-            // map our offset into the domain of the blocks, then seek forward
-            // until we find the block we need to start reading from. Then we
-            // read into `data`.
-
-            let offset_within_cycle = current_offset % total_cycle_size;
-            let mut block_start = 0;
-            for block in blocks {
-                let block_size = block.total_bytes.get() as usize;
-                if offset_within_cycle < block_start + block_size {
-                    // Offset is within this block. Begin reading into `data`.
-                    let block_offset = offset_within_cycle - block_start;
-                    let bytes_in_block = (block_size - block_offset).min(remaining);
-
-                    data.extend_from_slice(
-                        &block.bytes[block_offset..block_offset + bytes_in_block],
-                    );
-
-                    remaining -= bytes_in_block;
-                    current_offset += bytes_in_block;
-                    break;
+            Self::Fixed { data } => {
+                let mut idx = 0;
+                let blocks = &data.blocks;
+                loop {
+                    snd.blocking_send(blocks[idx].clone())?;
+                    idx = (idx + 1) % blocks.len();
                 }
-                block_start += block_size;
-            }
-
-            // If we couldn't find a block this suggests something seriously
-            // wacky has happened.
-            if remaining > 0 && block_start >= total_cycle_size {
-                error!("Offset exceeds total cycle size");
-                break;
             }
         }
-
-        data.freeze()
     }
 }
 

--- a/lading_payload/src/block.rs
+++ b/lading_payload/src/block.rs
@@ -208,7 +208,6 @@ impl Handle {
             // map our offset into the domain of the blocks, then seek forward
             // until we find the block we need to start reading from. Then we
             // read into `data`.
-
             let offset_within_cycle = current_offset % total_cycle_size;
             let mut block_start = 0;
             for block in blocks {


### PR DESCRIPTION
### What does this PR do?

With the parallel_connection addition to unix_stream we now must solve
    the problem of high connection count causing non-trivial cache duplication.
    This is done by allowing for a 'handle' on the cache which maintains a separate
    index per handle, meaning we do not need to synchronize the cache indexes between
    peers and peers are able to reference the singular cache.

