### PR TITLE
Fix dogstatsd property test

### DIFF
--- a/lading/src/generator/unix_stream.rs
+++ b/lading/src/generator/unix_stream.rs
@@ -109,10 +109,7 @@ impl UnixStream {
 
         let bytes_per_second =
             NonZeroU32::new(config.bytes_per_second.as_u128() as u32).ok_or(Error::Zero)?;
-        // Report total load: per-connection rate * number of connections
-        let total_bytes_per_second =
-            u64::from(bytes_per_second.get()) * u64::from(config.parallel_connections);
-        gauge!("bytes_per_second", &labels).set(total_bytes_per_second as f64);
+        gauge!("bytes_per_second", &labels).set(f64::from(bytes_per_second.get()));
 
         let total_bytes =
             NonZeroU32::new(config.maximum_prebuild_cache_size_bytes.as_u128() as u32)

--- a/lading/src/generator/unix_stream.rs
+++ b/lading/src/generator/unix_stream.rs
@@ -109,7 +109,10 @@ impl UnixStream {
 
         let bytes_per_second =
             NonZeroU32::new(config.bytes_per_second.as_u128() as u32).ok_or(Error::Zero)?;
-        gauge!("bytes_per_second", &labels).set(f64::from(bytes_per_second.get()));
+        // Report total load: per-connection rate * number of connections
+        let total_bytes_per_second =
+            u64::from(bytes_per_second.get()) * u64::from(config.parallel_connections);
+        gauge!("bytes_per_second", &labels).set(total_bytes_per_second as f64);
 
         let total_bytes =
             NonZeroU32::new(config.maximum_prebuild_cache_size_bytes.as_u128() as u32)

--- a/lading_payload/src/dogstatsd.rs
+++ b/lading_payload/src/dogstatsd.rs
@@ -491,7 +491,7 @@ impl DogStatsD {
     /// # Errors
     ///
     /// Function will error if a member could not be generated
-    pub fn generate<R>(&self, rng: &mut R) -> Result<Member, crate::Error>
+    pub fn generate<R>(&self, rng: &mut R) -> Result<Member<'_>, crate::Error>
     where
         R: rand::Rng + ?Sized,
     {


### PR DESCRIPTION
### What does this PR do?

This commit fixes our prefix length calculation, triggered only when max_bytes
    is low. We were removing the size of a `usize` when `u32` was appropriate, as
    that is the proper length of the payload prefix.
