### PR TITLE
Use local recorder for Prometheus unit tests to avoid global collision.

### DIFF
--- a/lading/src/target_metrics/prometheus.rs
+++ b/lading/src/target_metrics/prometheus.rs
@@ -367,9 +367,10 @@ mod tests {
     > {
         let dr = metrics_util::debugging::DebuggingRecorder::new();
         let snapshotter = dr.snapshotter();
-        dr.install().expect("failed to install recorder");
 
-        parse_prometheus_metrics(s, tags.as_ref(), None);
+        metrics::with_local_recorder(&dr, || {
+            parse_prometheus_metrics(s, tags.as_ref(), None);
+        });
 
         snapshotter.snapshot().into_hashmap()
     }
@@ -412,7 +413,7 @@ mod tests {
 
         let dr = metrics_util::debugging::DebuggingRecorder::new();
         let snapshotter = dr.snapshotter();
-        dr.install().expect("failed to install recorder");
+        let _guard = metrics::set_default_local_recorder(&dr);
 
         experiment_started_broadcaster.signal();
 


### PR DESCRIPTION
### What does this PR do?

Switches over to using "local" recorders for the Prometheus "target metrics" unit tests, which avoids the common pitfall of concurrent tests trying to install a global recorder.

### Motivation

Hit "recorder already installed" errors when trying to run `cargo test`.

### Related issues

N/A

### Additional Notes

N/A
