### PR TITLE
Introduce fuzz target for OpentelemetryMetrics::to_bytes

### DIFF
--- a/ci/fuzz
+++ b/ci/fuzz
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+set -o errexit
+set -o nounset
+set -o pipefail
+
+# Check if both crate and target arguments were provided
+if [ $# -lt 2 ]; then
+    echo "Usage: $0 <crate> <target>"
+    echo "Valid crates: lading_payload"
+    echo ""
+    echo "To see available targets, run:"
+    echo "  cd <crate> && cargo fuzz list"
+    exit 1
+fi
+
+CRATE="$1"
+TARGET="$2"
+
+# Validate the crate argument
+case "$CRATE" in
+    lading_payload)
+        # Valid crate
+        ;;
+    *)
+        echo "Error: Invalid crate '$CRATE'"
+        echo "Valid crates: lading_payload"
+        exit 1
+        ;;
+esac
+
+# Check if cargo fuzz is installed
+if ! command -v cargo-fuzz &> /dev/null; then
+    echo "cargo-fuzz not installed. Installing it now..."
+    cargo install cargo-fuzz
+fi
+
+echo "Running fuzz test: ${CRATE}/${TARGET}..."
+(cd "${CRATE}" && rustup run nightly cargo fuzz run --jobs 8 --build-std --release "${TARGET}")

--- a/lading_payload/fuzz/Cargo.toml
+++ b/lading_payload/fuzz/Cargo.toml
@@ -74,3 +74,9 @@ name = "fixed_cache_opentelemetry_metrics"
 path = "fuzz_targets/fixed_cache_opentelemetry_metrics.rs"
 test = false
 doc = false
+
+[[bin]]
+name = "fixed_cache_opentelemetry_metrics_fixed_config"
+path = "fuzz_targets/fixed_cache_opentelemetry_metrics_fixed_config.rs"
+test = false
+doc = false

--- a/lading_payload/fuzz/Cargo.toml
+++ b/lading_payload/fuzz/Cargo.toml
@@ -68,3 +68,9 @@ name = "fixed_cache_creation_json"
 path = "fuzz_targets/fixed_cache_creation_json.rs"
 test = false
 doc = false
+
+[[bin]]
+name = "fixed_cache_opentelemetry_metrics"
+path = "fuzz_targets/fixed_cache_opentelemetry_metrics.rs"
+test = false
+doc = false

--- a/lading_payload/fuzz/fuzz_targets/fixed_cache_opentelemetry_metrics.rs
+++ b/lading_payload/fuzz/fuzz_targets/fixed_cache_opentelemetry_metrics.rs
@@ -16,7 +16,7 @@ struct Input {
 }
 
 const MAX_CONTEXTS: u32 = 5_000;
-const MAX_BUDGET: usize = 8 * 1024 * 1024; // MiB
+const MAX_BUDGET: usize = 1 * 1024 * 1024; // MiB
 
 fuzz_target!(|input: Input| {
     // Validate inputs, skipping if too large to fit into memory or just plain invalid.

--- a/lading_payload/fuzz/fuzz_targets/fixed_cache_opentelemetry_metrics.rs
+++ b/lading_payload/fuzz/fuzz_targets/fixed_cache_opentelemetry_metrics.rs
@@ -1,0 +1,58 @@
+#![no_main]
+
+use arbitrary;
+use libfuzzer_sys::fuzz_target;
+use rand::{SeedableRng, rngs::SmallRng};
+use std::num::NonZeroU32;
+
+use lading_payload::Serialize;
+use lading_payload::opentelemetry::metric;
+
+#[derive(arbitrary::Arbitrary, Debug)]
+struct Input {
+    seed: [u8; 32],
+    budget_bytes: NonZeroU32,
+    config: metric::Config,
+}
+
+const MAX_CONTEXTS: u32 = 5_000;
+const MAX_BUDGET: usize = 32 * 1024 * 1024; // 32 MiB
+
+fuzz_target!(|input: Input| {
+    // Validate inputs, skipping if too large to fit into memory or just plain invalid.
+    if input.config.valid().is_err() {
+        return;
+    }
+    let total_contexts = match input.config.contexts.total_contexts {
+        lading_payload::common::config::ConfRange::Constant(n) => n,
+        lading_payload::common::config::ConfRange::Inclusive { max, .. } => max,
+    };
+    if total_contexts > MAX_CONTEXTS {
+        return;
+    }
+
+    let budget = input.budget_bytes.get() as usize;
+    if budget > MAX_BUDGET {
+        return;
+    }
+    if budget < metric::SMALLEST_PROTOBUF {
+        return;
+    }
+
+    // The actual fuzz bit. We make a new OpentelemetryMetrics instance then
+    // generate `budget` bytes into a vec. If the vec ends up being larger than
+    // the budget, failure.
+    let mut rng = SmallRng::from_seed(input.seed);
+    let mut metrics = metric::OpentelemetryMetrics::new(input.config, &mut rng)
+        .expect("failed to create metrics generator");
+
+    let mut bytes = Vec::with_capacity(budget);
+    metrics
+        .to_bytes(&mut rng, budget, &mut bytes)
+        .expect("failed to convert to bytes");
+    assert!(
+        bytes.len() <= budget,
+        "max len: {budget}, actual: {}",
+        bytes.len()
+    );
+});

--- a/lading_payload/src/opentelemetry/metric.rs
+++ b/lading_payload/src/opentelemetry/metric.rs
@@ -57,7 +57,7 @@ use tracing::{debug, error};
 use unit::UnitGenerator;
 
 /// Smallest useful protobuf, determined by experimentation and enforced in
-/// smallest_protobuf test.
+/// `smallest_protobuf` test.
 pub const SMALLEST_PROTOBUF: usize = 31;
 
 /// Increment timestamps by 100 milliseconds (in nanoseconds) per tick
@@ -134,6 +134,7 @@ impl Config {
     ///
     /// # Errors
     /// Function will error if the configuration is invalid
+    #[allow(clippy::too_many_lines)]
     pub fn valid(&self) -> Result<(), String> {
         // Validate metric weights - both types must have non-zero probability to ensure
         // we can generate a diverse set of metrics
@@ -190,30 +191,26 @@ impl Config {
         }
 
         // Validate attributes_per_resource range
-        if let ConfRange::Inclusive { min, max } = self.contexts.attributes_per_resource {
-            if min > max {
-                return Err(
-                    "attributes_per_resource minimum cannot be greater than maximum".to_string(),
-                );
-            }
+        if let ConfRange::Inclusive { min, max } = self.contexts.attributes_per_resource
+            && min > max
+        {
+            return Err(
+                "attributes_per_resource minimum cannot be greater than maximum".to_string(),
+            );
         }
 
         // Validate attributes_per_scope range
-        if let ConfRange::Inclusive { min, max } = self.contexts.attributes_per_scope {
-            if min > max {
-                return Err(
-                    "attributes_per_scope minimum cannot be greater than maximum".to_string(),
-                );
-            }
+        if let ConfRange::Inclusive { min, max } = self.contexts.attributes_per_scope
+            && min > max
+        {
+            return Err("attributes_per_scope minimum cannot be greater than maximum".to_string());
         }
 
         // Validate attributes_per_metric range
-        if let ConfRange::Inclusive { min, max } = self.contexts.attributes_per_metric {
-            if min > max {
-                return Err(
-                    "attributes_per_metric minimum cannot be greater than maximum".to_string(),
-                );
-            }
+        if let ConfRange::Inclusive { min, max } = self.contexts.attributes_per_metric
+            && min > max
+        {
+            return Err("attributes_per_metric minimum cannot be greater than maximum".to_string());
         }
 
         let min_contexts = match self.contexts.total_contexts {

--- a/lading_payload/src/opentelemetry/metric.rs
+++ b/lading_payload/src/opentelemetry/metric.rs
@@ -56,9 +56,9 @@ use templates::{Pool, ResourceTemplateGenerator};
 use tracing::{debug, error};
 use unit::UnitGenerator;
 
-// smallest useful protobuf, determined by experimentation and enforced in
-// smallest_protobuf test
-const SMALLEST_PROTOBUF: usize = 31;
+/// Smallest useful protobuf, determined by experimentation and enforced in
+/// smallest_protobuf test.
+pub const SMALLEST_PROTOBUF: usize = 31;
 
 /// Increment timestamps by 100 milliseconds (in nanoseconds) per tick
 const TIME_INCREMENT_NANOS: u64 = 1_000_000;
@@ -186,6 +186,33 @@ impl Config {
                         "metrics_per_scope minimum cannot be greater than maximum".to_string()
                     );
                 }
+            }
+        }
+
+        // Validate attributes_per_resource range
+        if let ConfRange::Inclusive { min, max } = self.contexts.attributes_per_resource {
+            if min > max {
+                return Err(
+                    "attributes_per_resource minimum cannot be greater than maximum".to_string(),
+                );
+            }
+        }
+
+        // Validate attributes_per_scope range
+        if let ConfRange::Inclusive { min, max } = self.contexts.attributes_per_scope {
+            if min > max {
+                return Err(
+                    "attributes_per_scope minimum cannot be greater than maximum".to_string(),
+                );
+            }
+        }
+
+        // Validate attributes_per_metric range
+        if let ConfRange::Inclusive { min, max } = self.contexts.attributes_per_metric {
+            if min > max {
+                return Err(
+                    "attributes_per_metric minimum cannot be greater than maximum".to_string(),
+                );
             }
         }
 
@@ -418,6 +445,31 @@ impl crate::Serialize for OpentelemetryMetrics {
         let mut total_data_points = 0;
         let loop_id: u32 = rng.random();
 
+        // Build up the request by adding ResourceMetrics one by one until we
+        // would exceed max_bytes.
+        //
+        // Example: max_bytes = 1000
+        //
+        // - Request with 0 ResourceMetrics: encoded size = 100 bytes
+        // - Add ResourceMetrics #1: encoded size = 400 bytes (still under 1000,
+        //   continue)
+        // - Add ResourceMetrics #2: encoded size = 700 bytes (still under 1000,
+        //   continue)
+        // - Add ResourceMetrics #3: encoded size = 1050 bytes (over 1000!)
+        // - Code detects overflow, pops #3, breaks the loop
+        // - Request now has #1 and #2, encoded size = 700 bytes
+        //
+        // When we call generate we pass bytes_remaining as the budget. After
+        // adding ResourceMetrics #2, we set bytes_remaining = 1000 - 700 =
+        // 300. So when generating #3, we tell it "you have 300 bytes to work
+        // with". The generate method might return something that encodes to 250
+        // bytes on its own.
+        //
+        // But, protobuf encoding isn't strictly additive. When we add that 250
+        // byte ResourceMetrics to a request that's already 700 bytes, the
+        // combined encoding might be > 1000 bytes (not 950) due to additional
+        // framing, length prefixes, field tags or whatever.  We handle this by
+        // checking after adding and removing the item if it exceeds the budget.
         while bytes_remaining >= SMALLEST_PROTOBUF {
             if let Ok(rm) = self.generate(&mut rng, &mut bytes_remaining) {
                 total_data_points += self.data_points_per_resource;


### PR DESCRIPTION
### What does this PR do?

This commit introduces a fuzz target whose goal is to find cases where
    to_bytes violates its set budget. My motivation is to add more backing
    material for PR #1447.
