### PR TITLE
Repair compiler error with lading_fuzz intro

### DIFF
--- a/lading_fuzz/src/lib.rs
+++ b/lading_fuzz/src/lib.rs
@@ -3,7 +3,9 @@
 #![deny(clippy::all)]
 #![deny(clippy::pedantic)]
 #![deny(missing_docs)]
-#![deny(unused_crate_dependencies)]
+// Allow unused crate dependencies: cargo-fuzz --build-std adds std crates as
+// dependencies that we don't use, breaks the build.
+#![allow(unused_crate_dependencies)]
 #![deny(warnings)]
 #![allow(clippy::cast_possible_truncation)]
 #![allow(clippy::cast_precision_loss)]

--- a/lading_payload/fuzz/Cargo.lock
+++ b/lading_payload/fuzz/Cargo.lock
@@ -436,6 +436,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "lading-fuzz"
+version = "0.1.0"
+
+[[package]]
 name = "lading-payload"
 version = "0.1.0"
 dependencies = [
@@ -461,6 +465,7 @@ name = "lading-payload-fuzz"
 version = "0.0.0"
 dependencies = [
  "arbitrary",
+ "lading-fuzz",
  "lading-payload",
  "libfuzzer-sys",
  "rand",


### PR DESCRIPTION
### What does this PR do?

When we introduced lading_fuzz I didn't consider that our clippy lints would
    play badly with --build-std. This is now corrected.
