### PR TITLE
Release lading 0.28.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.28.0]
 ## Added
 - Added configuration surface area to the OTel logs payload generator, in a
   manner similar to OTel metrics.
@@ -23,7 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   distribution derived number of points.
 ## Removed
 - Removed `prefix_metric_names` configuration from DogStatsD generator.
-- Removed JSON support from trace-agent payload 
+- Removed JSON support from trace-agent payload
 
 ## [0.27.0]
 ## Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1825,7 +1825,7 @@ dependencies = [
 
 [[package]]
 name = "lading"
-version = "0.27.0"
+version = "0.28.0"
 dependencies = [
  "async-compression",
  "async-pidfd",

--- a/lading/Cargo.toml
+++ b/lading/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lading"
-version = "0.27.0"
+version = "0.28.0"
 authors = [
   "Brian L. Troutwine <brian.troutwine@datadoghq.com>",
   "George Hahn <george.hahn@datadoghq.com>",


### PR DESCRIPTION
### What does this PR do?

This release contains non-trivial memory consumption improvements to the dogstatsd payload, improvements to the modeling fidelity of OpenTelemetry metrics payload and adds a new kubernetes load generator to the project. Full notes in the CHANGELOG.md.

