### PR TITLE
Native Parquet capture when --capture-path ends .parquet

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,11 @@ once_cell = { version = "1.21" }
 proptest = { version = "1.7" }
 proptest-derive = { version = "0.6" }
 
+# Parquet/Arrow for capture writing
+parquet = { version = "54.2", features = ["arrow"] }
+arrow-array = { version = "54.2" }
+arrow-schema = { version = "54.2" }
+
 http = { version = "1.3" }
 http-body-util = { version = "0.1" }
 http-serde = { version = "2.1" }

--- a/lading/Cargo.toml
+++ b/lading/Cargo.toml
@@ -94,6 +94,11 @@ uuid = { workspace = true }
 quanta = { version = "0.12", default-features = false, features = [] }
 zstd = "0.13.3"
 
+# Parquet/Arrow for parquet capture sink
+parquet = { workspace = true }
+arrow-array = { workspace = true }
+arrow-schema = { workspace = true }
+
 [target.'cfg(target_os = "linux")'.dependencies]
 procfs = { version = "0.17", default-features = false, features = [] }
 async-pidfd = "0.1"

--- a/lading/src/captures.rs
+++ b/lading/src/captures.rs
@@ -165,7 +165,6 @@ impl ParquetSink {
     }
 
     fn write_lines(&mut self, lines: &[json::Line]) -> Result<(), Error> {
-        // Builders
         let cap = lines.len();
         let mut run_id_builder = StringBuilder::with_capacity(cap, 0);
         let mut time_builder = Int64Builder::with_capacity(cap);
@@ -269,16 +268,13 @@ impl CaptureManager {
             ),
         };
 
-        // Choose sink based on extension
         let sink = if capture_path
             .extension()
             .is_some_and(|ext| ext == OsStr::new("parquet"))
         {
-            // Safety: Any error from parquet creation is turned into io::Error here to satisfy signature
             match ParquetSink::new(fp) {
                 Ok(p) => CaptureSink::Parquet(p),
                 Err(e) => {
-                    // convert to io::Error with context
                     return Err(io::Error::new(io::ErrorKind::Other, e.to_string()));
                 }
             }
@@ -420,7 +416,6 @@ impl CaptureManager {
                 loop {
                     if self.shutdown.try_recv().expect("polled after signal") {
                         info!("shutdown signal received");
-                        // Finish sink before returning
                         if let Err(e) = self.sink.finish() {
                             warn!("failed to finish capture sink: {e}");
                         }

--- a/lading/src/captures.rs
+++ b/lading/src/captures.rs
@@ -7,13 +7,14 @@
 //! their [`metrics`] integration while [`CaptureManager`] need only hook into
 //! that same crate.
 
-use std::ffi::OsStr;
-use std::fs::File;
-use std::io::{self, BufWriter, Write};
-use std::path::PathBuf;
-use std::sync::atomic::Ordering;
-use std::sync::Arc;
-use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH, SystemTimeError};
+use std::{
+    ffi::OsStr,
+    fs::File,
+    io::{self, BufWriter, Write},
+    path::PathBuf,
+    sync::{atomic::Ordering, Arc},
+    time::{Duration, Instant, SystemTime, SystemTimeError, UNIX_EPOCH},
+};
 
 use lading_capture::json;
 use parquet::arrow::ArrowWriter;

--- a/lading/src/generator/file_gen/logrotate_fs.rs
+++ b/lading/src/generator/file_gen/logrotate_fs.rs
@@ -14,13 +14,15 @@ use metrics::counter;
 use nix::libc::{self, ENOENT};
 use rand::{SeedableRng, rngs::SmallRng};
 use serde::{Deserialize, Serialize};
-use std::ffi::OsStr;
-use std::collections::HashMap;
-use std::fs;
-use std::num::NonZeroU32;
-use std::path::PathBuf;
-use std::sync::{Arc, Mutex, MutexGuard};
-use std::time::Duration;
+use std::{
+    collections::HashMap,
+    ffi::OsStr,
+    fs,
+    num::NonZeroU32,
+    path::PathBuf,
+    sync::{Arc, Mutex, MutexGuard},
+    time::Duration,
+};
 use tokio::task::{self, JoinError};
 use tracing::{debug, error, info, warn};
 

--- a/lading/src/generator/file_gen/logrotate_fs.rs
+++ b/lading/src/generator/file_gen/logrotate_fs.rs
@@ -14,15 +14,13 @@ use metrics::counter;
 use nix::libc::{self, ENOENT};
 use rand::{SeedableRng, rngs::SmallRng};
 use serde::{Deserialize, Serialize};
-use std::{
-    collections::HashMap,
-    ffi::OsStr,
-    fs,
-    num::NonZeroU32,
-    path::PathBuf,
-    sync::{Arc, Mutex, MutexGuard},
-    time::Duration,
-};
+use std::ffi::OsStr;
+use std::collections::HashMap;
+use std::fs;
+use std::num::NonZeroU32;
+use std::path::PathBuf;
+use std::sync::{Arc, Mutex, MutexGuard};
+use std::time::Duration;
 use tokio::task::{self, JoinError};
 use tracing::{debug, error, info, warn};
 


### PR DESCRIPTION
<!-- dd-meta {"pullId":"a90d3930-6677-4061-99a7-2ed7f4274c76","source":"chat","resourceId":"a88e9c85-1048-4bae-b7ca-7cbd1ee52db4","workflowId":"feb7101c-76ed-43ea-bea3-2b08e0e85c4e","codeChangeId":"feb7101c-76ed-43ea-bea3-2b08e0e85c4e","sourceType":"chat"} -->
PR by [Bits](https://app.datadoghq.com/code?session_id=a90d3930-6677-4061-99a7-2ed7f4274c76) for chat [a88e9c85-1048-4bae-b7ca-7cbd1ee52db4](https://app.datadoghq.com/code/a88e9c85-1048-4bae-b7ca-7cbd1ee52db4).

You can ask for changes by mentioning @Datadog in a comment.

Feedback (especially what can be better) welcome in [#code-gen-feedback](https://dd.enterprise.slack.com/archives/C07JA5N2D25)!

---

### What does this PR do?

Adds a native Parquet capture sink alongside the existing JSON lines sink. When --capture-path ends with .parquet, captures are written as Parquet via ArrowWriter; otherwise behavior remains JSON lines. Introduces a CaptureSink abstraction (JsonSink and ParquetSink), writes batches directly from in-memory json::Line structures (no JSON->Parquet conversion), and ensures the sink is cleanly finalized on shutdown. New dependencies for parquet/arrow are added, and a ParquetWrite error variant is introduced.

### Motivation

Users requested capture files be written to Parquet when the capture path ends with .parquet, without converting from JSON lines. This enables more efficient storage and downstream analytical workflows while preserving the existing JSON default.

### Related issues

None

### Additional Notes

- Backward compatible: paths without .parquet continue to write JSONL.
- Parquet schema includes run_id, time_ms, fetch_index, metric_name, metric_kind, value_int (nullable), value_float (nullable), labels_json.
- time_ms (u128) and fetch_index (u64) are saturated to i64 for Arrow/Parquet compatibility.
- Labels are stored as a JSON string column.
- The JSON sink now flushes once per batch instead of per line.
- The Parquet writer is explicitly closed on shutdown to finalize the file.