### PR TITLE
Allow lading to detect its memory limit

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1851,6 +1851,7 @@ dependencies = [
  "serde_json",
  "serde_qs",
  "serde_yaml",
+ "sysinfo",
  "tempfile",
  "thiserror 2.0.16",
  "tokio",
@@ -2155,6 +2156,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ntapi"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8a3895c6391c39d7fe7ebc444a87eb2991b2a0bc718fdabd071eec617fc68e4"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "nu-ansi-term"
 version = "0.50.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2186,6 +2196,25 @@ checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
 dependencies = [
  "hermit-abi",
  "libc",
+]
+
+[[package]]
+name = "objc2-core-foundation"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c10c2894a6fed806ade6027bcd50662746363a9589d3ec9d9bef30a4e4bc166"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
+name = "objc2-io-kit"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71c1c64d6120e51cd86033f67176b1cb66780c2efe34dec55176f77befd93c0a"
+dependencies = [
+ "libc",
+ "objc2-core-foundation",
 ]
 
 [[package]]
@@ -3541,6 +3570,20 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.106",
+]
+
+[[package]]
+name = "sysinfo"
+version = "0.37.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07cec4dc2d2e357ca1e610cfb07de2fa7a10fc3e9fe89f72545f3d244ea87753"
+dependencies = [
+ "libc",
+ "memchr",
+ "ntapi",
+ "objc2-core-foundation",
+ "objc2-io-kit",
+ "windows",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,7 @@ http-body-util = { version = "0.1" }
 http-serde = { version = "2.1" }
 hyper = { version = "1.7", default-features = false }
 hyper-util = { version = "0.1", default-features = false }
-
+sysinfo = { version = "0.37", default-features = false }
 
 [profile.release]
 lto = true        # Optimize our binary at link stage.

--- a/lading/Cargo.toml
+++ b/lading/Cargo.toml
@@ -72,6 +72,7 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 serde_qs = { version = "0.15", default-features = false }
 serde_yaml = { version = "0.9" }
+sysinfo = { workspace = true, features = ["system"] }
 thiserror = { workspace = true }
 tokio = { workspace = true, features = [
   "rt",

--- a/lading/src/bin/lading.rs
+++ b/lading/src/bin/lading.rs
@@ -621,6 +621,12 @@ fn main() -> Result<(), Error> {
 
     let version = env!("CARGO_PKG_VERSION");
     info!("Starting lading {version} run.");
+    let memory_limit =
+        lading::get_available_memory().get_appropriate_unit(byte_unit::UnitType::Binary);
+    info!(
+        "Lading running with {limit} amount of memory.",
+        limit = memory_limit.to_string()
+    );
 
     // Two-parser fallback logic until CliFlatLegacy is removed
     let args = match CliWithSubcommands::try_parse() {


### PR DESCRIPTION
### What does this PR do?

This commit detect and reports via a log message lading's memory
    limit. No further actions are taken than this. The goal will be to
    feed this information into generators to avoid OOMs based on some user
    configurations.