### PR TITLE
Bound OTel payloads overhead

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,6 +110,24 @@ jobs:
       - run: ci/kani ${{ matrix.crate }}
         timeout-minutes: 30
 
+  fuzz-check:
+    name: Check Fuzz Targets
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions-rust-lang/setup-rust-toolchain@fb51252c7ba57d633bc668f941da052e410add48 # v1.10
+        with:
+          toolchain: nightly
+          components: rust-src
+      - name: Install Protobuf
+        uses: ./.github/actions/install-protobuf
+      - name: Install FUSE
+        uses: ./.github/actions/install-fuse
+      - name: Install cargo-fuzz
+        run: cargo install cargo-fuzz
+      - run: ci/fuzz --check lading_payload
+        timeout-minutes: 10
+
   buf:
     runs-on: ubuntu-latest
     steps:

--- a/.gitlab/fuzz.yml
+++ b/.gitlab/fuzz.yml
@@ -2,46 +2,6 @@ variables:
   # Update this base image by clicking on the `ci-container-image` job in gitlab (pick the latest pipeline on main)
   BASE_CI_IMAGE: registry.ddbuild.io/images/ci/lading-fuzz:2025-08-14-b39a488a@sha256:2d7d6d9a445e2048f454a3e5d4175e7600700cac54ba1fc47801376803109bd1
 
-# Check that all fuzz targets build correctly
-check-fuzz-targets:
-  stage: fuzz
-  tags: ["arch:amd64"]
-  image: $BASE_CI_IMAGE
-  timeout: 10m
-  rules:
-    # Run on merge requests
-    - if: '$CI_PIPELINE_SOURCE == "merge_request_event"'
-    # Run on main branch
-    - if: '$CI_COMMIT_REF_NAME == "main" && $CI_PIPELINE_SOURCE == "push"'
-  script: |
-    echo "Checking all fuzz targets build..."
-    cd lading_payload
-    # List all targets and check each one builds
-    for target in $(cargo +nightly fuzz list); do
-      echo "Checking fuzz target: $target"
-      cargo +nightly fuzz check $target
-    done
-    echo "All fuzz targets build successfully!"
-
-# Run short fuzz tests on PRs
-run-fuzzing-pr:
-  stage: fuzz
-  tags: ["arch:amd64"]
-  image: $BASE_CI_IMAGE
-  timeout: 15m
-  rules:
-    # Run on merge requests
-    - if: '$CI_PIPELINE_SOURCE == "merge_request_event"'
-  script: |
-    echo "Running short fuzz tests for PR..."
-    cd lading_payload
-    # Run each fuzz target for 30 seconds
-    for target in $(cargo +nightly fuzz list); do
-      echo "Running fuzz target: $target for 30 seconds"
-      cargo +nightly fuzz run --jobs 2 --build-std --release "$target" -- -max_total_time=30 || true
-    done
-    echo "PR fuzz tests completed!"
-
 # Full fuzzing run for main branch and scheduled pipelines
 run-fuzzing:
   stage: fuzz

--- a/.gitlab/fuzz.yml
+++ b/.gitlab/fuzz.yml
@@ -2,6 +2,47 @@ variables:
   # Update this base image by clicking on the `ci-container-image` job in gitlab (pick the latest pipeline on main)
   BASE_CI_IMAGE: registry.ddbuild.io/images/ci/lading-fuzz:2025-08-14-b39a488a@sha256:2d7d6d9a445e2048f454a3e5d4175e7600700cac54ba1fc47801376803109bd1
 
+# Check that all fuzz targets build correctly
+check-fuzz-targets:
+  stage: fuzz
+  tags: ["arch:amd64"]
+  image: $BASE_CI_IMAGE
+  timeout: 10m
+  rules:
+    # Run on merge requests
+    - if: '$CI_PIPELINE_SOURCE == "merge_request_event"'
+    # Run on main branch
+    - if: '$CI_COMMIT_REF_NAME == "main" && $CI_PIPELINE_SOURCE == "push"'
+  script: |
+    echo "Checking all fuzz targets build..."
+    cd lading_payload
+    # List all targets and check each one builds
+    for target in $(cargo +nightly fuzz list); do
+      echo "Checking fuzz target: $target"
+      cargo +nightly fuzz check $target
+    done
+    echo "All fuzz targets build successfully!"
+
+# Run short fuzz tests on PRs
+run-fuzzing-pr:
+  stage: fuzz
+  tags: ["arch:amd64"]
+  image: $BASE_CI_IMAGE
+  timeout: 15m
+  rules:
+    # Run on merge requests
+    - if: '$CI_PIPELINE_SOURCE == "merge_request_event"'
+  script: |
+    echo "Running short fuzz tests for PR..."
+    cd lading_payload
+    # Run each fuzz target for 30 seconds
+    for target in $(cargo +nightly fuzz list); do
+      echo "Running fuzz target: $target for 30 seconds"
+      cargo +nightly fuzz run --jobs 2 --build-std --release "$target" -- -max_total_time=30 || true
+    done
+    echo "PR fuzz tests completed!"
+
+# Full fuzzing run for main branch and scheduled pipelines
 run-fuzzing:
   stage: fuzz
   tags: ["arch:amd64"]

--- a/ci/fuzz
+++ b/ci/fuzz
@@ -3,20 +3,49 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-# Check if both crate and target arguments were provided
-if [ $# -lt 2 ]; then
-    echo "Usage: $0 <crate> <target>"
+# Default values
+MODE="run"
+CRATE=""
+TARGET=""
+
+# Parse arguments
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --check)
+            MODE="check"
+            shift
+            ;;
+        --list)
+            MODE="list"
+            shift
+            ;;
+        *)
+            if [ -z "$CRATE" ]; then
+                CRATE="$1"
+            elif [ -z "$TARGET" ]; then
+                TARGET="$1"
+            else
+                echo "Error: Unexpected argument '$1'"
+                exit 1
+            fi
+            shift
+            ;;
+    esac
+done
+
+# Validate crate argument
+if [ -z "$CRATE" ]; then
+    echo "Usage: $0 [--check|--list] <crate> [target]"
     echo "Valid crates: lading_payload"
     echo ""
-    echo "To see available targets, run:"
-    echo "  cd <crate> && cargo fuzz list"
+    echo "Examples:"
+    echo "  $0 --check lading_payload       # Check all fuzz targets build"
+    echo "  $0 --list lading_payload        # List available fuzz targets"
+    echo "  $0 lading_payload <target>      # Run specific fuzz target"
     exit 1
 fi
 
-CRATE="$1"
-TARGET="$2"
-
-# Validate the crate argument
+# Validate the crate
 case "$CRATE" in
     lading_payload)
         # Valid crate
@@ -34,5 +63,31 @@ if ! command -v cargo-fuzz &> /dev/null; then
     cargo install cargo-fuzz
 fi
 
-echo "Running fuzz test: ${CRATE}/${TARGET}..."
-(cd "${CRATE}" && rustup run nightly cargo fuzz run --jobs 8 --build-std --release "${TARGET}")
+# Execute based on mode
+case "$MODE" in
+    check)
+        echo "Checking all fuzz targets in ${CRATE} build correctly..."
+        cd "${CRATE}"
+        # List all targets and check each one builds
+        for target in $(rustup run nightly cargo fuzz list); do
+            echo "Checking fuzz target: $target"
+            rustup run nightly cargo fuzz check "$target"
+        done
+        echo "All fuzz targets build successfully!"
+        ;;
+    list)
+        echo "Available fuzz targets in ${CRATE}:"
+        cd "${CRATE}"
+        rustup run nightly cargo fuzz list
+        ;;
+    run)
+        if [ -z "$TARGET" ]; then
+            echo "Error: Target required for run mode"
+            echo "Usage: $0 <crate> <target>"
+            exit 1
+        fi
+        echo "Running fuzz test: ${CRATE}/${TARGET}..."
+        cd "${CRATE}"
+        rustup run nightly cargo fuzz run --jobs 8 --build-std --release "${TARGET}"
+        ;;
+esac

--- a/lading/src/generator/file_gen/logrotate.rs
+++ b/lading/src/generator/file_gen/logrotate.rs
@@ -220,11 +220,20 @@ impl Server {
             let throttle = Throttle::new_with_config(throttle_config);
 
             let block_cache = match config.block_cache_method {
-                block::CacheMethod::Fixed => block::Cache::fixed(
+                block::CacheMethod::Fixed => block::Cache::fixed_with_max_overhead(
                     &mut rng,
                     maximum_prebuild_cache_size_bytes,
                     u128::from(maximum_block_size.get()),
                     &config.variant,
+                    // NOTE we bound payload generation to have overhead only
+                    // equivalent to the prebuild cache size,
+                    // `maximum_prebuild_cache_size_bytes`. This means on systems with plentiful
+                    // memory we're under generating entropy, on systems with
+                    // minimal memory we're over-generating.
+                    //
+                    // `lading::get_available_memory` suggests we can learn to
+                    // divvy this up in the future.
+                    maximum_prebuild_cache_size_bytes.get() as usize,
                 )?,
             };
 

--- a/lading/src/generator/file_gen/logrotate_fs.rs
+++ b/lading/src/generator/file_gen/logrotate_fs.rs
@@ -139,11 +139,20 @@ impl Server {
         let total_bytes =
             NonZeroU32::new(config.maximum_prebuild_cache_size_bytes.as_u128() as u32)
                 .ok_or(Error::Zero)?;
-        let block_cache = block::Cache::fixed(
+        let block_cache = block::Cache::fixed_with_max_overhead(
             &mut rng,
             total_bytes,
             config.maximum_block_size.as_u128(),
             &config.variant,
+            // NOTE we bound payload generation to have overhead only
+            // equivalent to the prebuild cache size,
+            // `total_bytes`. This means on systems with plentiful
+            // memory we're under generating entropy, on systems with
+            // minimal memory we're over-generating.
+            //
+            // `lading::get_available_memory` suggests we can learn to
+            // divvy this up in the future.
+            total_bytes.get() as usize,
         )?;
 
         let start_time = std::time::Instant::now();

--- a/lading/src/generator/file_gen/logrotate_fs/model.rs
+++ b/lading/src/generator/file_gen/logrotate_fs/model.rs
@@ -1032,7 +1032,7 @@ mod test {
                         load_profile,
                     )| {
                         let mut rng = StdRng::seed_from_u64(seed);
-                        let block_cache = block::Cache::fixed(
+                        let block_cache = block::Cache::fixed_with_max_overhead(
                             &mut rng,
                             NonZeroU32::new(1_000_000).expect("zero value"),
                             10_000,

--- a/lading/src/generator/file_gen/logrotate_fs/model.rs
+++ b/lading/src/generator/file_gen/logrotate_fs/model.rs
@@ -1037,6 +1037,7 @@ mod test {
                             NonZeroU32::new(1_000_000).expect("zero value"),
                             10_000,
                             &lading_payload::Config::Ascii,
+                            10_000,
                         )
                         .expect("block construction");
 

--- a/lading/src/generator/file_gen/traditional.rs
+++ b/lading/src/generator/file_gen/traditional.rs
@@ -188,11 +188,20 @@ impl Server {
             let throttle = Throttle::new_with_config(throttle_config);
 
             let block_cache = match config.block_cache_method {
-                block::CacheMethod::Fixed => block::Cache::fixed(
+                block::CacheMethod::Fixed => block::Cache::fixed_with_max_overhead(
                     &mut rng,
                     maximum_prebuild_cache_size_bytes,
                     maximum_block_size,
                     &config.variant,
+                    // NOTE we bound payload generation to have overhead only
+                    // equivalent to the prebuild cache size,
+                    // `maximum_prebuild_cache_size_bytes`. This means on systems with plentiful
+                    // memory we're under generating entropy, on systems with
+                    // minimal memory we're over-generating.
+                    //
+                    // `lading::get_available_memory` suggests we can learn to
+                    // divvy this up in the future.
+                    maximum_prebuild_cache_size_bytes.get() as usize,
                 )?,
             };
 

--- a/lading/src/generator/grpc.rs
+++ b/lading/src/generator/grpc.rs
@@ -205,11 +205,20 @@ impl Grpc {
             NonZeroU32::new(config.maximum_prebuild_cache_size_bytes.as_u128() as u32)
                 .ok_or(Error::Zero)?;
         let block_cache = match config.block_cache_method {
-            block::CacheMethod::Fixed => block::Cache::fixed(
+            block::CacheMethod::Fixed => block::Cache::fixed_with_max_overhead(
                 &mut rng,
                 maximum_prebuild_cache_size_bytes,
                 config.maximum_block_size.as_u128(),
                 &config.variant,
+                // NOTE we bound payload generation to have overhead only
+                // equivalent to the prebuild cache size,
+                // `maximum_prebuild_cache_size_bytes`. This means on systems with plentiful
+                // memory we're under generating entropy, on systems with
+                // minimal memory we're over-generating.
+                //
+                // `lading::get_available_memory` suggests we can learn to
+                // divvy this up in the future.
+                maximum_prebuild_cache_size_bytes.get() as usize,
             )?,
         };
 

--- a/lading/src/generator/passthru_file.rs
+++ b/lading/src/generator/passthru_file.rs
@@ -131,11 +131,20 @@ impl PassthruFile {
 
         let maximum_block_size = config.maximum_block_size.as_u128();
 
-        let block_cache = block::Cache::fixed(
+        let block_cache = block::Cache::fixed_with_max_overhead(
             &mut rng,
             maximum_prebuild_cache_size_bytes,
             maximum_block_size,
             &config.variant,
+            // NOTE we bound payload generation to have overhead only
+            // equivalent to the prebuild cache size,
+            // `maximum_prebuild_cache_size_bytes`. This means on systems with plentiful
+            // memory we're under generating entropy, on systems with
+            // minimal memory we're over-generating.
+            //
+            // `lading::get_available_memory` suggests we can learn to
+            // divvy this up in the future.
+            maximum_prebuild_cache_size_bytes.get() as usize,
         )?;
 
         let path = PathBuf::from(&config.path);

--- a/lading/src/generator/splunk_hec.rs
+++ b/lading/src/generator/splunk_hec.rs
@@ -223,11 +223,20 @@ impl SplunkHec {
             NonZeroU32::new(config.maximum_prebuild_cache_size_bytes.as_u128() as u32)
                 .ok_or(Error::Zero)?;
         let block_cache = match config.block_cache_method {
-            block::CacheMethod::Fixed => block::Cache::fixed(
+            block::CacheMethod::Fixed => block::Cache::fixed_with_max_overhead(
                 &mut rng,
                 total_bytes,
                 config.maximum_block_size.as_u128(),
                 &payload_config,
+                // NOTE we bound payload generation to have overhead only
+                // equivalent to the prebuild cache size,
+                // `total_bytes`. This means on systems with plentiful
+                // memory we're under generating entropy, on systems with
+                // minimal memory we're over-generating.
+                //
+                // `lading::get_available_memory` suggests we can learn to
+                // divvy this up in the future.
+                total_bytes.get() as usize,
             )?,
         };
 

--- a/lading/src/generator/tcp.rs
+++ b/lading/src/generator/tcp.rs
@@ -127,12 +127,23 @@ impl Tcp {
         };
         let throttle = Throttle::new_with_config(throttle_config);
 
-        let block_cache = block::Cache::fixed(
-            &mut rng,
+        let total_bytes =
             NonZeroU32::new(config.maximum_prebuild_cache_size_bytes.as_u128() as u32)
-                .ok_or(Error::Zero)?,
+                .ok_or(Error::Zero)?;
+        let block_cache = block::Cache::fixed_with_max_overhead(
+            &mut rng,
+            total_bytes,
             config.maximum_block_size.as_u128(),
             &config.variant,
+            // NOTE we bound payload generation to have overhead only
+            // equivalent to the prebuild cache size,
+            // `total_bytes`. This means on systems with plentiful
+            // memory we're under generating entropy, on systems with
+            // minimal memory we're over-generating.
+            //
+            // `lading::get_available_memory` suggests we can learn to
+            // divvy this up in the future.
+            total_bytes.get() as usize,
         )?;
 
         let addr = config

--- a/lading/src/generator/udp.rs
+++ b/lading/src/generator/udp.rs
@@ -134,12 +134,23 @@ impl Udp {
         };
         let throttle = Throttle::new_with_config(throttle_config);
 
-        let block_cache = block::Cache::fixed(
-            &mut rng,
+        let total_bytes =
             NonZeroU32::new(config.maximum_prebuild_cache_size_bytes.as_u128() as u32)
-                .ok_or(Error::Zero)?,
+                .ok_or(Error::Zero)?;
+        let block_cache = block::Cache::fixed_with_max_overhead(
+            &mut rng,
+            total_bytes,
             config.maximum_block_size.as_u128(),
             &config.variant,
+            // NOTE we bound payload generation to have overhead only
+            // equivalent to the prebuild cache size,
+            // `total_bytes`. This means on systems with plentiful
+            // memory we're under generating entropy, on systems with
+            // minimal memory we're over-generating.
+            //
+            // `lading::get_available_memory` suggests we can learn to
+            // divvy this up in the future.
+            total_bytes.get() as usize,
         )?;
 
         let addr = config

--- a/lading/src/generator/unix_datagram.rs
+++ b/lading/src/generator/unix_datagram.rs
@@ -165,11 +165,20 @@ impl UnixDatagram {
                 NonZeroU32::new(config.maximum_prebuild_cache_size_bytes.as_u128() as u32)
                     .ok_or(Error::Zero)?;
             let block_cache = match config.block_cache_method {
-                block::CacheMethod::Fixed => block::Cache::fixed(
+                block::CacheMethod::Fixed => block::Cache::fixed_with_max_overhead(
                     &mut rng,
                     total_bytes,
                     config.maximum_block_size.as_u128(),
                     &config.variant,
+                    // NOTE we bound payload generation to have overhead only
+                    // equivalent to the prebuild cache size,
+                    // `total_bytes`. This means on systems with plentiful
+                    // memory we're under generating entropy, on systems with
+                    // minimal memory we're over-generating.
+                    //
+                    // `lading::get_available_memory` suggests we can learn to
+                    // divvy this up in the future.
+                    total_bytes.get() as usize,
                 )?,
             };
 

--- a/lading/src/generator/unix_stream.rs
+++ b/lading/src/generator/unix_stream.rs
@@ -156,11 +156,20 @@ impl UnixStream {
                 NonZeroU32::new(config.maximum_prebuild_cache_size_bytes.as_u128() as u32)
                     .ok_or(Error::Zero)?;
             let block_cache = match config.block_cache_method {
-                block::CacheMethod::Fixed => block::Cache::fixed(
+                block::CacheMethod::Fixed => block::Cache::fixed_with_max_overhead(
                     &mut rng,
                     total_bytes,
                     config.maximum_block_size.as_u128(),
                     &config.variant,
+                    // NOTE we bound payload generation to have overhead only
+                    // equivalent to the prebuild cache size,
+                    // `total_bytes`. This means on systems with plentiful
+                    // memory we're under generating entropy, on systems with
+                    // minimal memory we're over-generating.
+                    //
+                    // `lading::get_available_memory` suggests we can learn to
+                    // divvy this up in the future.
+                    total_bytes.get() as usize,
                 )?,
             };
 

--- a/lading_payload/fuzz/fuzz_targets/apache_common_cache_fixed_next_block.rs
+++ b/lading_payload/fuzz/fuzz_targets/apache_common_cache_fixed_next_block.rs
@@ -35,11 +35,12 @@ fuzz_target!(|input: Input| {
     let mut rng = SmallRng::from_seed(input.seed);
     let payload = lading_payload::Config::ApacheCommon;
     
-    let mut cache = match Cache::fixed(
+    let mut cache = match Cache::fixed_with_max_overhead(
         &mut rng,
         input.total_bytes,
         u128::from(input.max_block_size.get()),
         &payload,
+        input.total_bytes.get() as usize,
     ) {
         Ok(c) => c,
         Err(_) => return,

--- a/lading_payload/fuzz/fuzz_targets/ascii_cache_fixed_next_block.rs
+++ b/lading_payload/fuzz/fuzz_targets/ascii_cache_fixed_next_block.rs
@@ -35,11 +35,12 @@ fuzz_target!(|input: Input| {
     let mut rng = SmallRng::from_seed(input.seed);
     let payload = lading_payload::Config::Ascii;
     
-    let mut cache = match Cache::fixed(
+    let mut cache = match Cache::fixed_with_max_overhead(
         &mut rng,
         input.total_bytes,
         u128::from(input.max_block_size.get()),
         &payload,
+        input.total_bytes.get() as usize,
     ) {
         Ok(c) => c,
         Err(_) => return,

--- a/lading_payload/fuzz/fuzz_targets/datadog_log_cache_fixed_next_block.rs
+++ b/lading_payload/fuzz/fuzz_targets/datadog_log_cache_fixed_next_block.rs
@@ -35,11 +35,12 @@ fuzz_target!(|input: Input| {
     let mut rng = SmallRng::from_seed(input.seed);
     let payload = lading_payload::Config::DatadogLog;
     
-    let mut cache = match Cache::fixed(
+    let mut cache = match Cache::fixed_with_max_overhead(
         &mut rng,
         input.total_bytes,
         u128::from(input.max_block_size.get()),
         &payload,
+        input.total_bytes.get() as usize,
     ) {
         Ok(c) => c,
         Err(_) => return,

--- a/lading_payload/fuzz/fuzz_targets/dogstatsd_cache_fixed_next_block.rs
+++ b/lading_payload/fuzz/fuzz_targets/dogstatsd_cache_fixed_next_block.rs
@@ -5,7 +5,7 @@ use libfuzzer_sys::fuzz_target;
 use rand::{SeedableRng, rngs::SmallRng};
 use std::num::NonZeroU32;
 
-use lading_payload::block::Cache;
+use lading_payload::{block::Cache, common::config::ConfRange};
 
 #[derive(arbitrary::Arbitrary, Debug)]
 struct Input {
@@ -15,21 +15,21 @@ struct Input {
     config: lading_payload::dogstatsd::Config,
 }
 
-const MAX_TOTAL_BYTES: u32 = 10 * 1024 * 1024;  // 10 MiB
-const MAX_BLOCK_SIZE: u32 = 1 * 1024 * 1024;    // 1 MiB
+const MAX_TOTAL_BYTES: u32 = 10 * 1024 * 1024; // 10 MiB
+const MAX_BLOCK_SIZE: u32 = 1 * 1024 * 1024; // 1 MiB
 const MAX_CONTEXTS: u32 = 1_000;
 
 fuzz_target!(|input: Input| {
     lading_fuzz::debug_input(&input);
-    
+
     if input.total_bytes.get() > MAX_TOTAL_BYTES {
         return;
     }
-    
+
     if input.max_block_size.get() > MAX_BLOCK_SIZE {
         return;
     }
-    
+
     if input.max_block_size.get() > input.total_bytes.get() {
         return;
     }
@@ -37,10 +37,10 @@ fuzz_target!(|input: Input| {
     if input.config.valid().is_err() {
         return;
     }
-    
+
     let max_contexts = match input.config.contexts {
-        lading_payload::common::config::ConfRange::Constant(n) => n,
-        lading_payload::common::config::ConfRange::Inclusive { max, .. } => max,
+        ConfRange::Constant(n) => n,
+        ConfRange::Inclusive { max, .. } => max,
     };
     if max_contexts > MAX_CONTEXTS {
         return;
@@ -48,17 +48,18 @@ fuzz_target!(|input: Input| {
 
     let mut rng = SmallRng::from_seed(input.seed);
     let payload = lading_payload::Config::DogStatsD(input.config);
-    
-    let mut cache = match Cache::fixed(
+
+    let mut cache = match Cache::fixed_with_max_overhead(
         &mut rng,
         input.total_bytes,
         u128::from(input.max_block_size.get()),
         &payload,
+        input.total_bytes.get() as usize,
     ) {
         Ok(c) => c,
         Err(_) => return,
     };
-    
+
     // Call next_block 10 times to exercise the cache rotation
     for _ in 0..10 {
         let _block = cache.next_block();

--- a/lading_payload/fuzz/fuzz_targets/fluent_cache_fixed_next_block.rs
+++ b/lading_payload/fuzz/fuzz_targets/fluent_cache_fixed_next_block.rs
@@ -35,11 +35,12 @@ fuzz_target!(|input: Input| {
     let mut rng = SmallRng::from_seed(input.seed);
     let payload = lading_payload::Config::Fluent;
     
-    let mut cache = match Cache::fixed(
+    let mut cache = match Cache::fixed_with_max_overhead(
         &mut rng,
         input.total_bytes,
         u128::from(input.max_block_size.get()),
         &payload,
+        input.total_bytes.get() as usize,
     ) {
         Ok(c) => c,
         Err(_) => return,

--- a/lading_payload/fuzz/fuzz_targets/json_cache_fixed_next_block.rs
+++ b/lading_payload/fuzz/fuzz_targets/json_cache_fixed_next_block.rs
@@ -35,11 +35,12 @@ fuzz_target!(|input: Input| {
     let mut rng = SmallRng::from_seed(input.seed);
     let payload = lading_payload::Config::Json;
     
-    let mut cache = match Cache::fixed(
+    let mut cache = match Cache::fixed_with_max_overhead(
         &mut rng,
         input.total_bytes,
         u128::from(input.max_block_size.get()),
         &payload,
+        input.total_bytes.get() as usize,
     ) {
         Ok(c) => c,
         Err(_) => return,

--- a/lading_payload/fuzz/fuzz_targets/opentelemetry_logs_cache_fixed_next_block.rs
+++ b/lading_payload/fuzz/fuzz_targets/opentelemetry_logs_cache_fixed_next_block.rs
@@ -58,11 +58,12 @@ fuzz_target!(|input: Input| {
     let mut rng = SmallRng::from_seed(input.seed);
     let payload = lading_payload::Config::OpentelemetryLogs(input.config);
     
-    let mut cache = match Cache::fixed(
+    let mut cache = match Cache::fixed_with_max_overhead(
         &mut rng,
         input.total_bytes,
         u128::from(input.max_block_size.get()),
         &payload,
+        input.total_bytes.get() as usize,
     ) {
         Ok(c) => c,
         Err(_) => return,

--- a/lading_payload/fuzz/fuzz_targets/opentelemetry_metrics_cache_fixed_next_block.rs
+++ b/lading_payload/fuzz/fuzz_targets/opentelemetry_metrics_cache_fixed_next_block.rs
@@ -5,7 +5,7 @@ use libfuzzer_sys::fuzz_target;
 use rand::{SeedableRng, rngs::SmallRng};
 use std::num::NonZeroU32;
 
-use lading_payload::block::Cache;
+use lading_payload::{block::Cache, common::config::ConfRange};
 
 #[derive(arbitrary::Arbitrary, Debug)]
 struct Input {
@@ -15,21 +15,21 @@ struct Input {
     config: lading_payload::opentelemetry::metric::Config,
 }
 
-const MAX_TOTAL_BYTES: u32 = 10 * 1024 * 1024;  // 10 MiB
-const MAX_BLOCK_SIZE: u32 = 1 * 1024 * 1024;    // 1 MiB
+const MAX_TOTAL_BYTES: u32 = 10 * 1024 * 1024; // 10 MiB
+const MAX_BLOCK_SIZE: u32 = 1 * 1024 * 1024; // 1 MiB
 const MAX_CONTEXTS: u32 = 5_000;
 
 fuzz_target!(|input: Input| {
     lading_fuzz::debug_input(&input);
-    
+
     if input.total_bytes.get() > MAX_TOTAL_BYTES {
         return;
     }
-    
+
     if input.max_block_size.get() > MAX_BLOCK_SIZE {
         return;
     }
-    
+
     if input.max_block_size.get() > input.total_bytes.get() {
         return;
     }
@@ -37,10 +37,10 @@ fuzz_target!(|input: Input| {
     if input.config.valid().is_err() {
         return;
     }
-    
+
     let max_contexts = match input.config.contexts.total_contexts {
-        lading_payload::common::config::ConfRange::Constant(n) => n,
-        lading_payload::common::config::ConfRange::Inclusive { max, .. } => max,
+        ConfRange::Constant(n) => n,
+        ConfRange::Inclusive { max, .. } => max,
     };
     if max_contexts > MAX_CONTEXTS {
         return;
@@ -48,17 +48,18 @@ fuzz_target!(|input: Input| {
 
     let mut rng = SmallRng::from_seed(input.seed);
     let payload = lading_payload::Config::OpentelemetryMetrics(input.config);
-    
-    let mut cache = match Cache::fixed(
+
+    let mut cache = match Cache::fixed_with_max_overhead(
         &mut rng,
         input.total_bytes,
         u128::from(input.max_block_size.get()),
         &payload,
+        input.total_bytes.get() as usize,
     ) {
         Ok(c) => c,
         Err(_) => return,
     };
-    
+
     // Call next_block 10 times to exercise the cache rotation
     for _ in 0..10 {
         let _block = cache.next_block();

--- a/lading_payload/fuzz/fuzz_targets/opentelemetry_metrics_serializer_to_bytes.rs
+++ b/lading_payload/fuzz/fuzz_targets/opentelemetry_metrics_serializer_to_bytes.rs
@@ -40,7 +40,7 @@ fuzz_target!(|input: Input| {
     let mut rng = SmallRng::from_seed(input.seed);
     let mut bytes = Vec::with_capacity(budget);
 
-    let mut serializer = match lading_payload::opentelemetry::metric::OpentelemetryMetrics::new(input.config, &mut rng) {
+    let mut serializer = match lading_payload::opentelemetry::metric::OpentelemetryMetrics::new(input.config, budget, &mut rng) {
         Ok(s) => s,
         Err(_) => return,
     };

--- a/lading_payload/fuzz/fuzz_targets/syslog5424_cache_fixed_next_block.rs
+++ b/lading_payload/fuzz/fuzz_targets/syslog5424_cache_fixed_next_block.rs
@@ -35,11 +35,12 @@ fuzz_target!(|input: Input| {
     let mut rng = SmallRng::from_seed(input.seed);
     let payload = lading_payload::Config::Syslog5424;
     
-    let mut cache = match Cache::fixed(
+    let mut cache = match Cache::fixed_with_max_overhead(
         &mut rng,
         input.total_bytes,
         u128::from(input.max_block_size.get()),
         &payload,
+        input.total_bytes.get() as usize,
     ) {
         Ok(c) => c,
         Err(_) => return,

--- a/lading_payload/fuzz/fuzz_targets/trace_agent_cache_fixed_next_block.rs
+++ b/lading_payload/fuzz/fuzz_targets/trace_agent_cache_fixed_next_block.rs
@@ -35,11 +35,12 @@ fuzz_target!(|input: Input| {
     let mut rng = SmallRng::from_seed(input.seed);
     let payload = lading_payload::Config::TraceAgent;
     
-    let mut cache = match Cache::fixed(
+    let mut cache = match Cache::fixed_with_max_overhead(
         &mut rng,
         input.total_bytes,
         u128::from(input.max_block_size.get()),
         &payload,
+        input.total_bytes.get() as usize,
     ) {
         Ok(c) => c,
         Err(_) => return,

--- a/lading_payload/proptest-regressions/opentelemetry/log.txt
+++ b/lading_payload/proptest-regressions/opentelemetry/log.txt
@@ -1,0 +1,7 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+cc 8ee584a001de4f7e45893569111c8192d410a82e17c534d1e87dc6b20701cbd7 # shrinks to min_body = 1, max_body = 1, min_trace = 0, max_trace = 0, min_attr_res = 127, max_attr_res = 0, min_attr_scope = 0, max_attr_scope = 0, min_attr_log = 0, max_attr_log = 0

--- a/lading_payload/src/opentelemetry/log.rs
+++ b/lading_payload/src/opentelemetry/log.rs
@@ -146,6 +146,7 @@ impl Config {
     ///
     /// # Errors
     /// Function will error if the configuration is invalid
+    #[allow(clippy::too_many_lines)]
     pub fn valid(&self) -> Result<(), String> {
         // Validate severity weights - at least one must be non-zero
         if self.severity_weights.trace == 0


### PR DESCRIPTION
### What does this PR do?

This commit alters the fixed block cache to allow for a fixed payload
    overhead. When payloads generate they need some internal allocation
    space temporarily to populate a block cache. The size of this space
    varies per payload but is, in the case of OTel, dependent on the
    number of contexts set by the end user. Users do not have enough
    information to know how much memory is required per context, that
    said, and so it's very likely that a user may configure lading to
    consume non-trivial memory, even if the actual amount of data they
    want to compute is relatively small, as determined by the prebuilt
    block cache size.

In this commit we alter the interface to the block cache, set the
    maximum overhead of the payloads to the size of the prebuild cache --
    downsides of this approach documented in-code -- and rig the OTel
    metrics pipeline appropriately.

## Motivation 

REF OTAGENT-479
