### PR TITLE
Convert remaining generators to new `Handle` block approach

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   of Kubernetes resources.
 ## Changed
 - Lading toolchain is now 1.89.0
+- Generators now use a handle based mechanism to address their block cache,
+  reducing memory consumption for generators with parallel connection support.
 ## Fixed
 - Fixed a bug in OTel payload generation where templates would not be used if
   context cap number of templates were not pre-generated. This had a knock-on
@@ -23,7 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   distribution derived number of points.
 ## Removed
 - Removed `prefix_metric_names` configuration from DogStatsD generator.
-- Removed JSON support from trace-agent payload 
+- Removed JSON support from trace-agent payload
 
 ## [0.27.0]
 ## Added

--- a/lading/src/common.rs
+++ b/lading/src/common.rs
@@ -1,7 +1,6 @@
 use std::{fmt, fs, path::PathBuf, process::Stdio, str};
 
 use serde::Deserialize;
-use tokio::sync::mpsc;
 
 #[derive(Debug, Deserialize, PartialEq, Eq)]
 #[serde(deny_unknown_fields)]
@@ -64,35 +63,5 @@ pub(crate) fn stdio(behavior: &Behavior) -> Stdio {
             });
             Stdio::from(fp)
         }
-    }
-}
-
-#[derive(Debug)]
-pub(crate) struct PeekableReceiver<T> {
-    receiver: mpsc::Receiver<T>,
-    buffer: Option<T>,
-}
-
-impl<T> PeekableReceiver<T> {
-    pub(crate) fn new(receiver: mpsc::Receiver<T>) -> Self {
-        Self {
-            receiver,
-            buffer: None,
-        }
-    }
-
-    #[inline]
-    pub(crate) async fn next(&mut self) -> Option<T> {
-        match self.buffer.take() {
-            Some(t) => Some(t),
-            None => self.receiver.recv().await,
-        }
-    }
-
-    pub(crate) async fn peek(&mut self) -> Option<&T> {
-        if self.buffer.is_none() {
-            self.buffer = self.receiver.recv().await;
-        }
-        self.buffer.as_ref()
     }
 }

--- a/lading_payload/fuzz/fuzz_targets/apache_common_cache_fixed_next_block.rs
+++ b/lading_payload/fuzz/fuzz_targets/apache_common_cache_fixed_next_block.rs
@@ -35,7 +35,7 @@ fuzz_target!(|input: Input| {
     let mut rng = SmallRng::from_seed(input.seed);
     let payload = lading_payload::Config::ApacheCommon;
     
-    let mut cache = match Cache::fixed_with_max_overhead(
+    let cache = match Cache::fixed_with_max_overhead(
         &mut rng,
         input.total_bytes,
         u128::from(input.max_block_size.get()),
@@ -46,8 +46,9 @@ fuzz_target!(|input: Input| {
         Err(_) => return,
     };
     
-    // Call next_block 10 times to exercise the cache rotation
+    // Call advance 10 times to exercise the cache rotation
+    let mut handle = cache.handle();
     for _ in 0..10 {
-        let _block = cache.next_block();
+        let _block = cache.advance(&mut handle);
     }
 });

--- a/lading_payload/fuzz/fuzz_targets/ascii_cache_fixed_next_block.rs
+++ b/lading_payload/fuzz/fuzz_targets/ascii_cache_fixed_next_block.rs
@@ -35,7 +35,7 @@ fuzz_target!(|input: Input| {
     let mut rng = SmallRng::from_seed(input.seed);
     let payload = lading_payload::Config::Ascii;
     
-    let mut cache = match Cache::fixed_with_max_overhead(
+    let cache = match Cache::fixed_with_max_overhead(
         &mut rng,
         input.total_bytes,
         u128::from(input.max_block_size.get()),
@@ -46,8 +46,9 @@ fuzz_target!(|input: Input| {
         Err(_) => return,
     };
     
-    // Call next_block 10 times to exercise the cache rotation
+    // Call advance 10 times to exercise the cache rotation
+    let mut handle = cache.handle();
     for _ in 0..10 {
-        let _block = cache.next_block();
+        let _block = cache.advance(&mut handle);
     }
 });

--- a/lading_payload/fuzz/fuzz_targets/datadog_log_cache_fixed_next_block.rs
+++ b/lading_payload/fuzz/fuzz_targets/datadog_log_cache_fixed_next_block.rs
@@ -35,7 +35,7 @@ fuzz_target!(|input: Input| {
     let mut rng = SmallRng::from_seed(input.seed);
     let payload = lading_payload::Config::DatadogLog;
     
-    let mut cache = match Cache::fixed_with_max_overhead(
+    let cache = match Cache::fixed_with_max_overhead(
         &mut rng,
         input.total_bytes,
         u128::from(input.max_block_size.get()),
@@ -46,8 +46,9 @@ fuzz_target!(|input: Input| {
         Err(_) => return,
     };
     
-    // Call next_block 10 times to exercise the cache rotation
+    // Call advance 10 times to exercise the cache rotation
+    let mut handle = cache.handle();
     for _ in 0..10 {
-        let _block = cache.next_block();
+        let _block = cache.advance(&mut handle);
     }
 });

--- a/lading_payload/fuzz/fuzz_targets/dogstatsd_cache_fixed_next_block.rs
+++ b/lading_payload/fuzz/fuzz_targets/dogstatsd_cache_fixed_next_block.rs
@@ -49,7 +49,7 @@ fuzz_target!(|input: Input| {
     let mut rng = SmallRng::from_seed(input.seed);
     let payload = lading_payload::Config::DogStatsD(input.config);
 
-    let mut cache = match Cache::fixed_with_max_overhead(
+    let cache = match Cache::fixed_with_max_overhead(
         &mut rng,
         input.total_bytes,
         u128::from(input.max_block_size.get()),
@@ -60,8 +60,9 @@ fuzz_target!(|input: Input| {
         Err(_) => return,
     };
 
-    // Call next_block 10 times to exercise the cache rotation
+    // Call advance 10 times to exercise the cache rotation
+    let mut handle = cache.handle();
     for _ in 0..10 {
-        let _block = cache.next_block();
+        let _block = cache.advance(&mut handle);
     }
 });

--- a/lading_payload/fuzz/fuzz_targets/fluent_cache_fixed_next_block.rs
+++ b/lading_payload/fuzz/fuzz_targets/fluent_cache_fixed_next_block.rs
@@ -35,7 +35,7 @@ fuzz_target!(|input: Input| {
     let mut rng = SmallRng::from_seed(input.seed);
     let payload = lading_payload::Config::Fluent;
     
-    let mut cache = match Cache::fixed_with_max_overhead(
+    let cache = match Cache::fixed_with_max_overhead(
         &mut rng,
         input.total_bytes,
         u128::from(input.max_block_size.get()),
@@ -46,8 +46,9 @@ fuzz_target!(|input: Input| {
         Err(_) => return,
     };
     
-    // Call next_block 10 times to exercise the cache rotation
+    // Call advance 10 times to exercise the cache rotation
+    let mut handle = cache.handle();
     for _ in 0..10 {
-        let _block = cache.next_block();
+        let _block = cache.advance(&mut handle);
     }
 });

--- a/lading_payload/fuzz/fuzz_targets/json_cache_fixed_next_block.rs
+++ b/lading_payload/fuzz/fuzz_targets/json_cache_fixed_next_block.rs
@@ -35,7 +35,7 @@ fuzz_target!(|input: Input| {
     let mut rng = SmallRng::from_seed(input.seed);
     let payload = lading_payload::Config::Json;
     
-    let mut cache = match Cache::fixed_with_max_overhead(
+    let cache = match Cache::fixed_with_max_overhead(
         &mut rng,
         input.total_bytes,
         u128::from(input.max_block_size.get()),
@@ -46,8 +46,9 @@ fuzz_target!(|input: Input| {
         Err(_) => return,
     };
     
-    // Call next_block 10 times to exercise the cache rotation
+    // Call advance 10 times to exercise the cache rotation
+    let mut handle = cache.handle();
     for _ in 0..10 {
-        let _block = cache.next_block();
+        let _block = cache.advance(&mut handle);
     }
 });

--- a/lading_payload/fuzz/fuzz_targets/opentelemetry_logs_cache_fixed_next_block.rs
+++ b/lading_payload/fuzz/fuzz_targets/opentelemetry_logs_cache_fixed_next_block.rs
@@ -58,7 +58,7 @@ fuzz_target!(|input: Input| {
     let mut rng = SmallRng::from_seed(input.seed);
     let payload = lading_payload::Config::OpentelemetryLogs(input.config);
     
-    let mut cache = match Cache::fixed_with_max_overhead(
+    let cache = match Cache::fixed_with_max_overhead(
         &mut rng,
         input.total_bytes,
         u128::from(input.max_block_size.get()),
@@ -69,8 +69,9 @@ fuzz_target!(|input: Input| {
         Err(_) => return,
     };
     
-    // Call next_block 10 times to exercise the cache rotation
+    // Call advance 10 times to exercise the cache rotation
+    let mut handle = cache.handle();
     for _ in 0..10 {
-        let _block = cache.next_block();
+        let _block = cache.advance(&mut handle);
     }
 });

--- a/lading_payload/fuzz/fuzz_targets/opentelemetry_metrics_cache_fixed_next_block.rs
+++ b/lading_payload/fuzz/fuzz_targets/opentelemetry_metrics_cache_fixed_next_block.rs
@@ -49,7 +49,7 @@ fuzz_target!(|input: Input| {
     let mut rng = SmallRng::from_seed(input.seed);
     let payload = lading_payload::Config::OpentelemetryMetrics(input.config);
 
-    let mut cache = match Cache::fixed_with_max_overhead(
+    let cache = match Cache::fixed_with_max_overhead(
         &mut rng,
         input.total_bytes,
         u128::from(input.max_block_size.get()),
@@ -60,8 +60,9 @@ fuzz_target!(|input: Input| {
         Err(_) => return,
     };
 
-    // Call next_block 10 times to exercise the cache rotation
+    // Call advance 10 times to exercise the cache rotation
+    let mut handle = cache.handle();
     for _ in 0..10 {
-        let _block = cache.next_block();
+        let _block = cache.advance(&mut handle);
     }
 });

--- a/lading_payload/fuzz/fuzz_targets/syslog5424_cache_fixed_next_block.rs
+++ b/lading_payload/fuzz/fuzz_targets/syslog5424_cache_fixed_next_block.rs
@@ -35,7 +35,7 @@ fuzz_target!(|input: Input| {
     let mut rng = SmallRng::from_seed(input.seed);
     let payload = lading_payload::Config::Syslog5424;
     
-    let mut cache = match Cache::fixed_with_max_overhead(
+    let cache = match Cache::fixed_with_max_overhead(
         &mut rng,
         input.total_bytes,
         u128::from(input.max_block_size.get()),
@@ -46,8 +46,9 @@ fuzz_target!(|input: Input| {
         Err(_) => return,
     };
     
-    // Call next_block 10 times to exercise the cache rotation
+    // Call advance 10 times to exercise the cache rotation
+    let mut handle = cache.handle();
     for _ in 0..10 {
-        let _block = cache.next_block();
+        let _block = cache.advance(&mut handle);
     }
 });

--- a/lading_payload/fuzz/fuzz_targets/trace_agent_cache_fixed_next_block.rs
+++ b/lading_payload/fuzz/fuzz_targets/trace_agent_cache_fixed_next_block.rs
@@ -35,7 +35,7 @@ fuzz_target!(|input: Input| {
     let mut rng = SmallRng::from_seed(input.seed);
     let payload = lading_payload::Config::TraceAgent;
     
-    let mut cache = match Cache::fixed_with_max_overhead(
+    let cache = match Cache::fixed_with_max_overhead(
         &mut rng,
         input.total_bytes,
         u128::from(input.max_block_size.get()),
@@ -46,8 +46,9 @@ fuzz_target!(|input: Input| {
         Err(_) => return,
     };
     
-    // Call next_block 10 times to exercise the cache rotation
+    // Call advance 10 times to exercise the cache rotation
+    let mut handle = cache.handle();
     for _ in 0..10 {
-        let _block = cache.next_block();
+        let _block = cache.advance(&mut handle);
     }
 });


### PR DESCRIPTION
### What does this PR do?

This commit removes the old peek interface for the block cache,
    converting all generators to use the new `Handle` based approach
    excepting logrotate_fs which retains is special-purpose read_at API in
    this commit.