### PR TITLE
Fix cargo-machete CI warning

### DIFF
--- a/lading/Cargo.toml
+++ b/lading/Cargo.toml
@@ -14,6 +14,9 @@ keywords = ["random_test", "generator"]
 categories = ["development-tools::profiling"]
 description = "A tool for load testing daemons."
 
+[package.metadata.cargo-machete]
+ignored = ["prost"]
+
 [dependencies]
 lading-capture = { version = "0.2", path = "../lading_capture" }
 lading-payload = { version = "0.1", path = "../lading_payload" }


### PR DESCRIPTION
### What does this PR do?

Cargo-machete is raising an error on the top level Cargo.toml.

### Motivation

Fix CI.

### Related issues

#1534 
