### PR TITLE
Purge metric smaps.file_pmd_mapped.by_pathname from lading

### DIFF
--- a/lading/src/observer/linux/procfs.rs
+++ b/lading/src/observer/linux/procfs.rs
@@ -288,9 +288,7 @@ impl Sampler {
                         if let Some(m) = measures.private_hugetlb {
                             gauge!("smaps.private_hugetlb.by_pathname", &labels).set(m as f64);
                         }
-                        if let Some(m) = measures.file_pmd_mapped {
-                            gauge!("smaps.file_pmd_mapped.by_pathname", &labels).set(m as f64);
-                        }
+                        
                         if let Some(m) = measures.locked {
                             gauge!("smaps.locked.by_pathname", &labels).set(m as f64);
                         }


### PR DESCRIPTION
<!-- dd-meta {"pullId":"dc12dd57-5a5c-4d4e-9698-b765a0d76243","source":"chat","resourceId":"fb5d06b2-2eff-444a-9465-4e0d4906002f","workflowId":"387aa326-e12d-44d7-81a8-6ea6cd2a8e7f","codeChangeId":"387aa326-e12d-44d7-81a8-6ea6cd2a8e7f","sourceType":"action_platform_workflows"} -->
PR by [Bits](https://app.datadoghq.com/code?session_id=dc12dd57-5a5c-4d4e-9698-b765a0d76243) for chat [fb5d06b2-2eff-444a-9465-4e0d4906002f](https://app.datadoghq.com/code/fb5d06b2-2eff-444a-9465-4e0d4906002f).

You can ask for changes by mentioning @Datadog in a comment.

Feedback (especially what can be better) welcome in [#code-gen-feedback](https://dd.enterprise.slack.com/archives/C07JA5N2D25)!

---

### What does this PR do?

Removes the smaps.file_pmd_mapped.by_pathname metric emission from lading/src/observer/linux/procfs.rs and ensures no references to single_machine_performance.regression_detector.capture.smaps.file_pmd_mapped.by_pathname remain in the codebase.

### Motivation

This metric is deprecated and its presence was causing monitoring/validation errors in downstream systems. Removing it eliminates the faulty/unsupported metric and aligns with the request to fully drop it.

### Related issues

- N/A

### Additional Notes

- No other metrics or logic were modified.
- Verified via repository-wide search that no references to the metric remain.