### PR TITLE
Remove smaps.locked.by_pathname metric across repo

### DIFF
--- a/lading/src/observer/linux/procfs.rs
+++ b/lading/src/observer/linux/procfs.rs
@@ -291,9 +291,7 @@ impl Sampler {
                         if let Some(m) = measures.file_pmd_mapped {
                             gauge!("smaps.file_pmd_mapped.by_pathname", &labels).set(m as f64);
                         }
-                        if let Some(m) = measures.locked {
-                            gauge!("smaps.locked.by_pathname", &labels).set(m as f64);
-                        }
+                        
                         if let Some(m) = measures.swap_pss {
                             gauge!("smaps.swap_pss.by_pathname", &labels).set(m as f64);
                         }


### PR DESCRIPTION
<!-- dd-meta {"pullId":"a5a0495f-660a-428c-8754-4775f9b83a8a","source":"chat","resourceId":"9baeedcd-2e60-4906-bfa5-419e07223e8d","workflowId":"e7dd54e8-d60b-4a55-a020-d773558a3df4","codeChangeId":"e7dd54e8-d60b-4a55-a020-d773558a3df4","sourceType":"action_platform_workflows"} -->
PR by [Bits](https://app.datadoghq.com/code?session_id=a5a0495f-660a-428c-8754-4775f9b83a8a) for chat [9baeedcd-2e60-4906-bfa5-419e07223e8d](https://app.datadoghq.com/code/9baeedcd-2e60-4906-bfa5-419e07223e8d).

You can ask for changes by mentioning @Datadog in a comment.

Feedback (especially what can be better) welcome in [#code-gen-feedback](https://dd.enterprise.slack.com/archives/C07JA5N2D25)!

---

### What does this PR do?

Removes emission of the smaps.locked.by_pathname metric from lading/src/observer/linux/procfs.rs and ensures no references to single_machine_performance.regression_detector.capture.smaps.locked.by_pathname remain in the codebase.

### Motivation

This metric is deprecated and was causing CI checks to fail due to the presence of a disallowed metric. Removing its emission resolves the error and aligns the codebase with current metric requirements.

### Related issues

- N/A

### Additional Notes

- Changes are minimal and limited to removing the metric emission.
- No unrelated code was modified; no comments were added.
- Verified that no remaining references to the removed metric exist.