### PR TITLE
feat(otlp-metrics): added support for histogram, exp. histogram, and summary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated dependencies
 
 ## Added
+- Added support for `Histogram`, `ExponentialHistogram`, and `Summary` metric
+  types to the OpenTelemetry metrics payload generator. Each type is generated
+  with valid structure (bucket invariants, quantile ordering, three-way count
+  partitioning) and re-randomized per tick so successive payloads carry varied
+  data. Histogram supports optional `min`/`max` fields; `ExponentialHistogram`
+  varies `zero_threshold`; `Summary` randomises across five common quantile
+  configurations.
 - Added new `!concat` generator to the `templated_json` payload generator.
 - Use `mise` for tooling management
 - Added new `StaticTimestamped` payload generator that parses timestamps from a

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1930,7 +1930,7 @@ dependencies = [
  "proptest",
  "prost",
  "prost-build",
- "rand 0.9.2",
+ "rand 0.9.3",
  "regex",
  "reqwest",
  "rustc-hash",
@@ -1977,7 +1977,7 @@ dependencies = [
  "parquet",
  "proptest",
  "protobuf",
- "rand 0.9.2",
+ "rand 0.9.3",
  "rustc-hash",
  "serde",
  "serde_json",
@@ -2014,7 +2014,7 @@ dependencies = [
  "proptest",
  "proptest-derive",
  "prost",
- "rand 0.9.2",
+ "rand 0.9.3",
  "rmp-serde",
  "rustc-hash",
  "serde",
@@ -2245,7 +2245,7 @@ dependencies = [
  "ordered-float 5.3.0",
  "quanta",
  "radix_trie",
- "rand 0.9.2",
+ "rand 0.9.3",
  "rand_xoshiro",
  "sketches-ddsketch",
 ]
@@ -2522,7 +2522,7 @@ dependencies = [
  "futures-util",
  "opentelemetry",
  "percent-encoding",
- "rand 0.9.2",
+ "rand 0.9.3",
  "thiserror 2.0.18",
 ]
 
@@ -2857,7 +2857,7 @@ dependencies = [
  "bit-vec",
  "bitflags",
  "num-traits",
- "rand 0.9.2",
+ "rand 0.9.3",
  "rand_chacha 0.9.0",
  "rand_xorshift",
  "regex-syntax",
@@ -3082,9 +3082,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
  "libc",
  "rand_chacha 0.3.1",
@@ -3093,9 +3093,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "7ec095654a25171c2124e9e3393a930bddbffdc939556c914957a4c3e0a87166"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.5",
@@ -3361,7 +3361,7 @@ dependencies = [
  "borsh",
  "bytes",
  "num-traits",
- "rand 0.8.5",
+ "rand 0.8.6",
  "rkyv",
  "serde",
  "serde_json",
@@ -3447,9 +3447,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.12"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "ring",
  "rustls-pki-types",

--- a/ci/fingerprints/otel_metrics/fingerprint.txt
+++ b/ci/fingerprints/otel_metrics/fingerprint.txt
@@ -1,1 +1,1 @@
-otel_metrics_grpc: 1a99c0f4baf2470e547d0038dcaa6e7f134a1a31ae9dea50460e21f5e4e3a562 entropy=6.7343
+otel_metrics_grpc: 24764e37bb7072b5058324826a44b7feb33d71b7516eda2c11ccf578f29f1f0a entropy=6.8989

--- a/ci/fingerprints/otel_metrics/fingerprint.txt
+++ b/ci/fingerprints/otel_metrics/fingerprint.txt
@@ -1,1 +1,1 @@
-otel_metrics_grpc: 7e6b0255a600290b03aef0cafe1714af8a7e4ed8149630df53cdd54aae43d47f entropy=6.9980
+otel_metrics_grpc: 6c0ab386cf4998ef372056a76ccaa8bb8e67bb8e81f7efbfb6b517d627d185f7 entropy=6.8468

--- a/ci/fingerprints/otel_metrics/fingerprint.txt
+++ b/ci/fingerprints/otel_metrics/fingerprint.txt
@@ -1,1 +1,1 @@
-otel_metrics_grpc: d00db7a2a20316eebd8dc499ca177564be15e1fb5ad80a9e02ce2f1b55b17fe3 entropy=6.9978
+otel_metrics_grpc: 7e6b0255a600290b03aef0cafe1714af8a7e4ed8149630df53cdd54aae43d47f entropy=6.9980

--- a/ci/fingerprints/otel_metrics/fingerprint.txt
+++ b/ci/fingerprints/otel_metrics/fingerprint.txt
@@ -1,1 +1,1 @@
-otel_metrics_grpc: 7f5a723e8e4416e0e405358da75e1dc361ecea53a2b8b074d95013e62a68ddab entropy=6.9234
+otel_metrics_grpc: caac15e2dc5c4f3530a672e22e433fed57f7577d36dce863afac0aa8ba202d3b entropy=6.8426

--- a/ci/fingerprints/otel_metrics/fingerprint.txt
+++ b/ci/fingerprints/otel_metrics/fingerprint.txt
@@ -1,1 +1,1 @@
-otel_metrics_grpc: 027ba01347a05ddbf6a23b54ecbc472be588d9ea58e7b77d9235f2ad8c638e67 entropy=6.9981
+otel_metrics_grpc: d00db7a2a20316eebd8dc499ca177564be15e1fb5ad80a9e02ce2f1b55b17fe3 entropy=6.9978

--- a/ci/fingerprints/otel_metrics/fingerprint.txt
+++ b/ci/fingerprints/otel_metrics/fingerprint.txt
@@ -1,1 +1,1 @@
-otel_metrics_grpc: 6c0ab386cf4998ef372056a76ccaa8bb8e67bb8e81f7efbfb6b517d627d185f7 entropy=6.8468
+otel_metrics_grpc: 7f5a723e8e4416e0e405358da75e1dc361ecea53a2b8b074d95013e62a68ddab entropy=6.9234

--- a/ci/fingerprints/otel_metrics/fingerprint.txt
+++ b/ci/fingerprints/otel_metrics/fingerprint.txt
@@ -1,1 +1,1 @@
-otel_metrics_grpc: ff2f793ceb9940f8132bf4313d7431aeb4cdc0a279e7fa7bbe16bd79e13bc1a7 entropy=6.9414
+otel_metrics_grpc: 027ba01347a05ddbf6a23b54ecbc472be588d9ea58e7b77d9235f2ad8c638e67 entropy=6.9981

--- a/ci/fingerprints/otel_metrics/fingerprint.txt
+++ b/ci/fingerprints/otel_metrics/fingerprint.txt
@@ -1,1 +1,1 @@
-otel_metrics_grpc: 24764e37bb7072b5058324826a44b7feb33d71b7516eda2c11ccf578f29f1f0a entropy=6.8989
+otel_metrics_grpc: ff2f793ceb9940f8132bf4313d7431aeb4cdc0a279e7fa7bbe16bd79e13bc1a7 entropy=6.9414

--- a/examples/lading-otel-metrics.yaml
+++ b/examples/lading-otel-metrics.yaml
@@ -11,12 +11,15 @@ generator:
         post:
           maximum_prebuild_cache_size_bytes: "1 GiB"
           variant:
-            # all numbers arbitraray
             opentelemetry_metrics:
+              # Relative weights; values do not need to sum to 100.
               metric_weights:
                 gauge: 50
                 sum_delta: 25
                 sum_cumulative: 25
+                histogram: 15
+                exponential_histogram: 3
+                summary: 2
               contexts:
                 total_contexts:
                   constant: 10000

--- a/lading_payload/benches/opentelemetry_metric.rs
+++ b/lading_payload/benches/opentelemetry_metric.rs
@@ -20,6 +20,9 @@ fn opentelemetry_metric_setup(c: &mut Criterion) {
                     gauge: 50,
                     sum_delta: 25,
                     sum_cumulative: 25,
+                    histogram: 15,
+                    exponential_histogram: 3,
+                    summary: 2,
                 },
                 contexts: Contexts {
                     total_contexts: ConfRange::Constant(100),
@@ -49,6 +52,9 @@ fn opentelemetry_metric_throughput(c: &mut Criterion) {
                             gauge: 50,
                             sum_delta: 25,
                             sum_cumulative: 25,
+                            histogram: 15,
+                            exponential_histogram: 3,
+                            summary: 2,
                         },
                         contexts: Contexts {
                             total_contexts: ConfRange::Constant(100),

--- a/lading_payload/src/opentelemetry/common/templates.rs
+++ b/lading_payload/src/opentelemetry/common/templates.rs
@@ -96,6 +96,7 @@ where
 
     /// Check if any template in the pool can fit within the given budget.
     /// Returns true if at least one template fits, false otherwise.
+    #[cfg(test)]
     pub(crate) fn template_fits(&self, budget: usize) -> bool {
         // Check if any existing template in the pool fits
         self.by_size.range(..=budget).next().is_some()

--- a/lading_payload/src/opentelemetry/metric.rs
+++ b/lading_payload/src/opentelemetry/metric.rs
@@ -41,6 +41,8 @@
 pub(crate) mod templates;
 pub(crate) mod unit;
 
+use std::collections::BTreeMap;
+use std::hash::{DefaultHasher, Hash, Hasher};
 use std::rc::Rc;
 use std::{cell::RefCell, io::Write};
 
@@ -49,7 +51,11 @@ use crate::opentelemetry::common::templates::PoolError;
 use crate::{Error, common::config::ConfRange, common::strings};
 use bytes::BytesMut;
 use opentelemetry_proto::tonic::collector::metrics::v1::ExportMetricsServiceRequest;
-use opentelemetry_proto::tonic::metrics::v1::{ResourceMetrics, metric::Data, number_data_point};
+use opentelemetry_proto::tonic::common::v1::{KeyValue, any_value};
+use opentelemetry_proto::tonic::metrics::v1::{
+    Exemplar, Metric, ResourceMetrics, exemplar, exponential_histogram_data_point, metric::Data,
+    number_data_point,
+};
 use prost::Message;
 use serde::Deserialize;
 use templates::{Pool, ResourceTemplateGenerator};
@@ -60,8 +66,496 @@ use unit::UnitGenerator;
 /// `smallest_protobuf` test.
 pub const SMALLEST_PROTOBUF: usize = 31;
 
-/// Increment timestamps by 100 milliseconds (in nanoseconds) per tick
-const TIME_INCREMENT_NANOS: u64 = 1_000_000;
+/// Advance collection timestamps by 100 milliseconds per synthetic tick.
+const TIME_INCREMENT_NANOS: u64 = 100_000_000;
+const BASE_TIME_UNIX_NANOS: u64 = 1_700_000_000_000_000_000;
+const DELTA_TEMPORALITY: i32 = 1;
+const CUMULATIVE_TEMPORALITY: i32 = 2;
+const SUMMARY_RESERVOIR_CAP: usize = 512;
+
+#[derive(Clone, Debug)]
+struct SeriesClock {
+    stream_start_time_unix_nano: u64,
+    last_time_unix_nano: u64,
+    emissions: u64,
+}
+
+impl SeriesClock {
+    fn new(current_time_unix_nano: u64, previous_time_unix_nano: u64) -> Self {
+        Self {
+            stream_start_time_unix_nano: current_time_unix_nano,
+            last_time_unix_nano: previous_time_unix_nano,
+            emissions: 0,
+        }
+    }
+
+    fn start_time_for_temporality(&self, temporality: i32) -> u64 {
+        if temporality == DELTA_TEMPORALITY {
+            self.last_time_unix_nano
+        } else {
+            self.stream_start_time_unix_nano
+        }
+    }
+
+    fn note_emission(&mut self, current_time_unix_nano: u64) {
+        self.last_time_unix_nano = current_time_unix_nano;
+        self.emissions += 1;
+    }
+}
+
+#[derive(Clone, Debug)]
+struct HistogramPointState {
+    clock: SeriesClock,
+    cumulative_bucket_counts: Vec<u64>,
+    cumulative_count: u64,
+    cumulative_sum: f64,
+    cumulative_min: Option<f64>,
+    cumulative_max: Option<f64>,
+}
+
+impl HistogramPointState {
+    fn new(current_time_unix_nano: u64, previous_time_unix_nano: u64, bucket_count: usize) -> Self {
+        Self {
+            clock: SeriesClock::new(current_time_unix_nano, previous_time_unix_nano),
+            cumulative_bucket_counts: vec![0; bucket_count],
+            cumulative_count: 0,
+            cumulative_sum: 0.0,
+            cumulative_min: None,
+            cumulative_max: None,
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+struct SummaryPointState {
+    clock: SeriesClock,
+    cumulative_count: u64,
+    cumulative_sum: f64,
+    retained_observations: Vec<f64>,
+}
+
+impl SummaryPointState {
+    fn new(current_time_unix_nano: u64, previous_time_unix_nano: u64) -> Self {
+        Self {
+            clock: SeriesClock::new(current_time_unix_nano, previous_time_unix_nano),
+            cumulative_count: 0,
+            cumulative_sum: 0.0,
+            retained_observations: Vec::new(),
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+struct ExponentialHistogramPointState {
+    clock: SeriesClock,
+    cumulative_positive: BTreeMap<i32, u64>,
+    cumulative_negative: BTreeMap<i32, u64>,
+    cumulative_zero_count: u64,
+    cumulative_count: u64,
+    cumulative_sum: f64,
+    cumulative_min: Option<f64>,
+    cumulative_max: Option<f64>,
+}
+
+impl ExponentialHistogramPointState {
+    fn new(current_time_unix_nano: u64, previous_time_unix_nano: u64) -> Self {
+        Self {
+            clock: SeriesClock::new(current_time_unix_nano, previous_time_unix_nano),
+            cumulative_positive: BTreeMap::new(),
+            cumulative_negative: BTreeMap::new(),
+            cumulative_zero_count: 0,
+            cumulative_count: 0,
+            cumulative_sum: 0.0,
+            cumulative_min: None,
+            cumulative_max: None,
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+struct PopulationStats {
+    observations: Vec<f64>,
+    count: u64,
+    sum: f64,
+    min: Option<f64>,
+    max: Option<f64>,
+}
+
+fn tick_time_unix_nano(tick: u64) -> u64 {
+    BASE_TIME_UNIX_NANOS + tick.saturating_mul(TIME_INCREMENT_NANOS)
+}
+
+fn hash_any_value(value: &any_value::Value, hasher: &mut DefaultHasher) {
+    match value {
+        any_value::Value::StringValue(v) => {
+            "string".hash(hasher);
+            v.hash(hasher);
+        }
+        any_value::Value::BoolValue(v) => {
+            "bool".hash(hasher);
+            v.hash(hasher);
+        }
+        any_value::Value::IntValue(v) => {
+            "int".hash(hasher);
+            v.hash(hasher);
+        }
+        any_value::Value::DoubleValue(v) => {
+            "double".hash(hasher);
+            v.to_bits().hash(hasher);
+        }
+        // ArrayValue / KvlistValue / BytesValue are never produced by this
+        // generator; hashing the discriminant keeps identity stable if that
+        // ever changes.
+        other => std::mem::discriminant(other).hash(hasher),
+    }
+}
+
+fn hash_key_values(values: &[KeyValue], hasher: &mut DefaultHasher) {
+    for value in values {
+        value.key.hash(hasher);
+        if let Some(any_value) = &value.value
+            && let Some(inner) = &any_value.value
+        {
+            hash_any_value(inner, hasher);
+        }
+    }
+}
+
+fn metric_identity_hash(
+    resource_attributes: Option<&[KeyValue]>,
+    scope_attributes: Option<&[KeyValue]>,
+    metric: &Metric,
+) -> u64 {
+    let mut hasher = DefaultHasher::new();
+    if let Some(resource_attributes) = resource_attributes {
+        hash_key_values(resource_attributes, &mut hasher);
+    }
+    if let Some(scope_attributes) = scope_attributes {
+        hash_key_values(scope_attributes, &mut hasher);
+    }
+    metric.name.hash(&mut hasher);
+    metric.description.hash(&mut hasher);
+    metric.unit.hash(&mut hasher);
+    hash_key_values(&metric.metadata, &mut hasher);
+
+    if let Some(data) = &metric.data {
+        match data {
+            Data::Gauge(_) => "gauge".hash(&mut hasher),
+            Data::Sum(sum) => {
+                "sum".hash(&mut hasher);
+                sum.aggregation_temporality.hash(&mut hasher);
+                sum.is_monotonic.hash(&mut hasher);
+            }
+            Data::Histogram(histogram) => {
+                "histogram".hash(&mut hasher);
+                histogram.aggregation_temporality.hash(&mut hasher);
+            }
+            Data::ExponentialHistogram(histogram) => {
+                "exponential_histogram".hash(&mut hasher);
+                histogram.aggregation_temporality.hash(&mut hasher);
+            }
+            Data::Summary(_) => "summary".hash(&mut hasher),
+        }
+    }
+
+    hasher.finish()
+}
+
+fn point_series_id(metric_identity: u64, point_index: usize, attributes: &[KeyValue]) -> u64 {
+    let mut hasher = DefaultHasher::new();
+    metric_identity.hash(&mut hasher);
+    point_index.hash(&mut hasher);
+    hash_key_values(attributes, &mut hasher);
+    hasher.finish()
+}
+
+fn update_min(current: Option<f64>, candidate: Option<f64>) -> Option<f64> {
+    match (current, candidate) {
+        (Some(current), Some(candidate)) => Some(current.min(candidate)),
+        (None, Some(candidate)) => Some(candidate),
+        (Some(current), None) => Some(current),
+        (None, None) => None,
+    }
+}
+
+fn update_max(current: Option<f64>, candidate: Option<f64>) -> Option<f64> {
+    match (current, candidate) {
+        (Some(current), Some(candidate)) => Some(current.max(candidate)),
+        (None, Some(candidate)) => Some(candidate),
+        (Some(current), None) => Some(current),
+        (None, None) => None,
+    }
+}
+
+fn population_stats(observations: Vec<f64>) -> PopulationStats {
+    let mut sum = 0.0;
+    let mut min = None;
+    let mut max = None;
+
+    for observation in &observations {
+        sum += observation;
+        min = update_min(min, Some(*observation));
+        max = update_max(max, Some(*observation));
+    }
+
+    PopulationStats {
+        count: observations.len() as u64,
+        sum,
+        min,
+        max,
+        observations,
+    }
+}
+
+fn random_exemplars<R>(
+    current_time_unix_nano: u64,
+    min: Option<f64>,
+    max: Option<f64>,
+    rng: &mut R,
+) -> Vec<Exemplar>
+where
+    R: rand::Rng + ?Sized,
+{
+    let min = min.unwrap_or(0.0);
+    let max = max.unwrap_or(min).max(min);
+    let exemplar_count = rng.random_range(2_usize..=4);
+    let mut exemplars = Vec::with_capacity(exemplar_count);
+
+    for _ in 0..exemplar_count {
+        let trace_id: [u8; 16] = rng.random();
+        let span_id: [u8; 8] = rng.random();
+        exemplars.push(Exemplar {
+            filtered_attributes: Vec::new(),
+            time_unix_nano: current_time_unix_nano,
+            span_id: span_id.to_vec(),
+            trace_id: trace_id.to_vec(),
+            value: Some(exemplar::Value::AsDouble(rng.random_range(min..=max))),
+        });
+    }
+
+    exemplars
+}
+
+fn non_negative_population<R>(
+    profile: templates::PointProfile,
+    emissions: u64,
+    rng: &mut R,
+) -> PopulationStats
+where
+    R: rand::Rng + ?Sized,
+{
+    let count = rng.random_range(8_usize..=48);
+    let center = profile.sample + profile.jitter * emissions as f64;
+    let spread = profile.spread.max(1.0);
+    let mut observations = Vec::with_capacity(count);
+
+    for index in 0..count {
+        let deterministic_offset = ((index as f64 + 1.0) / count as f64) * spread;
+        let lower = (center - spread).max(0.0);
+        let upper = center + deterministic_offset + profile.jitter;
+        observations.push(rng.random_range(lower..=upper.max(lower)));
+    }
+
+    population_stats(observations)
+}
+
+fn signed_population<R>(
+    profile: templates::PointProfile,
+    zero_threshold: f64,
+    emissions: u64,
+    rng: &mut R,
+) -> PopulationStats
+where
+    R: rand::Rng + ?Sized,
+{
+    let count = rng.random_range(12_usize..=64);
+    let spread = (profile.spread / 4.0).max(1.0);
+    let drift = profile.jitter * emissions as f64 / 8.0;
+    let magnitude_base = (profile.sample / 16.0).max(1.0) + drift;
+    let mut observations = Vec::with_capacity(count);
+
+    for index in 0..count {
+        let value = match rng.random_range(0_u8..=9) {
+            0 => rng.random_range(-zero_threshold..=zero_threshold),
+            1..=4 => magnitude_base + rng.random_range(0.0..=spread) + index as f64 * 0.25,
+            _ => -(magnitude_base + rng.random_range(0.0..=spread) + index as f64 * 0.25),
+        };
+        observations.push(value);
+    }
+
+    population_stats(observations)
+}
+
+fn histogram_bucket_counts(observations: &[f64], explicit_bounds: &[f64]) -> Vec<u64> {
+    let mut bucket_counts = vec![0; explicit_bounds.len() + 1];
+    for observation in observations {
+        let bucket_index = explicit_bounds.partition_point(|bound| *bound < *observation);
+        if let Some(bucket_count) = bucket_counts.get_mut(bucket_index) {
+            *bucket_count += 1;
+        }
+    }
+    bucket_counts
+}
+
+fn merge_bucket_counts(target: &mut [u64], update: &[u64]) {
+    for (target, update) in target.iter_mut().zip(update.iter().copied()) {
+        *target += update;
+    }
+}
+
+// OTLP defines bucket indices as sint32; the truncating cast is intentional.
+#[allow(clippy::cast_possible_truncation)]
+fn exponential_histogram_bucket_index(value: f64, scale: i32) -> i32 {
+    if value <= 0.0 {
+        return 0;
+    }
+
+    let scale_factor = 2_f64.powi(scale);
+    (value.log2() * scale_factor).floor() as i32
+}
+
+/// Bucket `observations` into positive/negative/zero maps under the given
+/// scale and `zero_threshold`. Returns `(zero_count, positive, negative)`.
+fn exponential_histogram_buckets(
+    observations: &[f64],
+    scale: i32,
+    zero_threshold: f64,
+) -> (u64, BTreeMap<i32, u64>, BTreeMap<i32, u64>) {
+    let mut zero_count = 0_u64;
+    let mut positive = BTreeMap::new();
+    let mut negative = BTreeMap::new();
+
+    for observation in observations {
+        if observation.abs() <= zero_threshold {
+            zero_count += 1;
+            continue;
+        }
+
+        let bucket_index = exponential_histogram_bucket_index(observation.abs(), scale);
+        if *observation > 0.0 {
+            *positive.entry(bucket_index).or_insert(0) += 1;
+        } else {
+            *negative.entry(bucket_index).or_insert(0) += 1;
+        }
+    }
+
+    (zero_count, positive, negative)
+}
+
+// first_index/last_index come from an ordered BTreeMap and bucket_index is
+// always >= first_index, so the differences are non-negative.
+#[allow(clippy::cast_sign_loss)]
+fn dense_exponential_buckets(
+    counts: &BTreeMap<i32, u64>,
+) -> exponential_histogram_data_point::Buckets {
+    let (Some(first_index), Some(last_index)) = (counts.keys().next(), counts.keys().next_back())
+    else {
+        return exponential_histogram_data_point::Buckets {
+            offset: 0,
+            bucket_counts: Vec::new(),
+        };
+    };
+
+    let mut bucket_counts = vec![0; (*last_index - *first_index + 1) as usize];
+    for (bucket_index, count) in counts {
+        let dense_index = (*bucket_index - *first_index) as usize;
+        if let Some(bucket_count) = bucket_counts.get_mut(dense_index) {
+            *bucket_count = *count;
+        }
+    }
+
+    exponential_histogram_data_point::Buckets {
+        offset: *first_index,
+        bucket_counts,
+    }
+}
+
+fn extend_summary_reservoir(reservoir: &mut Vec<f64>, observations: &[f64]) {
+    reservoir.extend_from_slice(observations);
+    if reservoir.len() > SUMMARY_RESERVOIR_CAP {
+        let overflow = reservoir.len() - SUMMARY_RESERVOIR_CAP;
+        reservoir.drain(0..overflow);
+    }
+}
+
+// quantile is clamped to [0, 1] and the result lies in [0, len-1] as a
+// non-negative finite float, so the usize cast is safe.
+#[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+fn quantile_value(sorted_observations: &[f64], quantile: f64) -> f64 {
+    if sorted_observations.is_empty() {
+        return 0.0;
+    }
+
+    let quantile = quantile.clamp(0.0, 1.0);
+    let index = ((sorted_observations.len() - 1) as f64 * quantile).round() as usize;
+    sorted_observations[index]
+}
+
+fn metric_data_points_total(metric: &Metric) -> usize {
+    match &metric.data {
+        Some(Data::Gauge(gauge)) => gauge.data_points.len(),
+        Some(Data::Sum(sum)) => sum.data_points.len(),
+        Some(Data::Histogram(histogram)) => histogram.data_points.len(),
+        Some(Data::ExponentialHistogram(histogram)) => histogram.data_points.len(),
+        Some(Data::Summary(summary)) => summary.data_points.len(),
+        None => 0,
+    }
+}
+
+fn trim_one_data_point(resource_metrics: &mut ResourceMetrics) -> bool {
+    for scope_idx in (0..resource_metrics.scope_metrics.len()).rev() {
+        let mut trimmed = false;
+        let mut remove_metric_idx = None;
+        let remove_scope;
+
+        {
+            let scope_metrics = &mut resource_metrics.scope_metrics[scope_idx];
+            for metric_idx in (0..scope_metrics.metrics.len()).rev() {
+                let metric = &mut scope_metrics.metrics[metric_idx];
+                let did_trim = match &mut metric.data {
+                    Some(Data::Gauge(gauge)) => gauge.data_points.pop().is_some(),
+                    Some(Data::Sum(sum)) => sum.data_points.pop().is_some(),
+                    Some(Data::Histogram(histogram)) => histogram.data_points.pop().is_some(),
+                    Some(Data::ExponentialHistogram(histogram)) => {
+                        histogram.data_points.pop().is_some()
+                    }
+                    Some(Data::Summary(summary)) => summary.data_points.pop().is_some(),
+                    None => false,
+                };
+                if did_trim {
+                    trimmed = true;
+                    if metric_data_points_total(metric) == 0 {
+                        remove_metric_idx = Some(metric_idx);
+                    }
+                    break;
+                }
+            }
+            if let Some(metric_idx) = remove_metric_idx {
+                scope_metrics.metrics.remove(metric_idx);
+            }
+            remove_scope = scope_metrics.metrics.is_empty();
+        }
+
+        if trimmed {
+            if remove_scope {
+                resource_metrics.scope_metrics.remove(scope_idx);
+            }
+            return true;
+        }
+    }
+
+    false
+}
+
+fn total_data_points(resource_metrics: &ResourceMetrics) -> u64 {
+    let mut total = 0_u64;
+    for scope_metrics in &resource_metrics.scope_metrics {
+        for metric in &scope_metrics.metrics {
+            total += metric_data_points_total(metric) as u64;
+        }
+    }
+    total
+}
 
 /// Configure the OpenTelemetry metric payload.
 #[derive(Debug, Deserialize, serde::Serialize, Clone, PartialEq, Copy)]
@@ -109,14 +603,23 @@ pub struct MetricWeights {
     pub sum_delta: u8,
     /// The relative probability of generating a sum cumulative metric.
     pub sum_cumulative: u8,
+    /// The relative probability of generating a histogram metric.
+    pub histogram: u8,
+    /// The relative probability of generating an exponential histogram metric.
+    pub exponential_histogram: u8,
+    /// The relative probability of generating a summary metric.
+    pub summary: u8,
 }
 
 impl Default for MetricWeights {
     fn default() -> Self {
         Self {
-            gauge: 50,          // 50%
-            sum_delta: 25,      // 25%
-            sum_cumulative: 25, // 25%
+            gauge: 40,                // 40%
+            sum_delta: 25,            // 20%
+            sum_cumulative: 25,       // 20%
+            histogram: 15,            //15%
+            exponential_histogram: 3, // 3%
+            summary: 2,               //2%
         }
     }
 }
@@ -144,6 +647,9 @@ impl Config {
         if self.metric_weights.gauge == 0
             || self.metric_weights.sum_delta == 0
             || self.metric_weights.sum_cumulative == 0
+            || self.metric_weights.summary == 0
+            || self.metric_weights.histogram == 0
+            || self.metric_weights.exponential_histogram == 0
         {
             return Err("Metric weights cannot be 0".to_string());
         }
@@ -293,10 +799,20 @@ pub struct OpentelemetryMetrics {
     scratch: RefCell<BytesMut>,
     /// Current tick count for monotonic timing (starts at 0)
     tick: u64,
+    /// Most recent collection timestamp emitted by this generator.
+    last_collection_time_unix_nano: u64,
     /// Accumulating sum increment, floating point
     incr_f: f64,
     /// Accumulating sum increment, integer
     incr_i: i64,
+    /// Per-series time tracking for sums.
+    sum_clocks: BTreeMap<u64, SeriesClock>,
+    /// Per-series state for explicit histograms.
+    histogram_series: BTreeMap<u64, HistogramPointState>,
+    /// Per-series state for exponential histograms.
+    exponential_histogram_series: BTreeMap<u64, ExponentialHistogramPointState>,
+    /// Per-series state for summaries.
+    summary_series: BTreeMap<u64, SummaryPointState>,
     /// Number of data points in the most recent `ResourceMetrics` (set by
     /// `generate`).
     data_points_per_resource: u64,
@@ -323,8 +839,13 @@ impl OpentelemetryMetrics {
             pool: Pool::new(context_cap, max_overhead_bytes, rt_gen),
             scratch: RefCell::new(BytesMut::with_capacity(4096)),
             tick: 0,
+            last_collection_time_unix_nano: BASE_TIME_UNIX_NANOS,
             incr_f: 0.0,
             incr_i: 0,
+            sum_clocks: BTreeMap::new(),
+            histogram_series: BTreeMap::new(),
+            exponential_histogram_series: BTreeMap::new(),
+            summary_series: BTreeMap::new(),
             data_points_per_resource: 0,
             data_points_per_block: 0,
         })
@@ -340,8 +861,9 @@ impl<'a> SizedGenerator<'a> for OpentelemetryMetrics {
     /// * Monotonic sums are truly monotonic, incrementing by a random amount
     ///   each tick
     /// * Timestamps advance monotonically based on internal tick counter
-    ///   starting at epoch
+    ///   starting from a fixed non-zero base timestamp
     /// * Each call advances the tick counter by a random amount (1-60)
+    #[allow(clippy::too_many_lines)]
     fn generate<R>(&'a mut self, rng: &mut R, budget: &mut usize) -> Result<Self::Output, Error>
     where
         R: rand::Rng + ?Sized,
@@ -349,7 +871,10 @@ impl<'a> SizedGenerator<'a> for OpentelemetryMetrics {
         self.tick += rng.random_range(1..=60);
         self.incr_f += rng.random_range(1.0..=100.0);
         self.incr_i += rng.random_range(1_i64..=100_i64);
+        let current_time_unix_nano = tick_time_unix_nano(self.tick);
+        let previous_time_unix_nano = self.last_collection_time_unix_nano;
 
+        let budget_before_fetch = *budget;
         let mut tpl: ResourceMetrics = match self.pool.fetch(rng, budget) {
             Ok(t) => t.to_owned(),
             Err(PoolError::EmptyChoice) => {
@@ -359,19 +884,29 @@ impl<'a> SizedGenerator<'a> for OpentelemetryMetrics {
             Err(e) => Err(e)?,
         };
 
-        // Update data points in each metric. For gauges we use random values,
-        // for accumulating sums we increment by a fixed amount per tick.
-        // All timestamps are updated based on the current tick.
-        let mut data_points_count = 0;
+        let resource_attributes = tpl
+            .resource
+            .as_ref()
+            .map(|resource| resource.attributes.as_slice());
 
+        // Update data points in each metric using per-series state so identity
+        // attributes, timestamps, and cumulative aggregates stay coherent
+        // across repeated emissions of the same template.
         for scope_metrics in &mut tpl.scope_metrics {
+            let scope_attributes = scope_metrics
+                .scope
+                .as_ref()
+                .map(|scope| scope.attributes.as_slice());
+
             for metric in &mut scope_metrics.metrics {
+                let metric_identity =
+                    metric_identity_hash(resource_attributes, scope_attributes, metric);
+
                 if let Some(data) = &mut metric.data {
                     match data {
                         Data::Gauge(gauge) => {
-                            data_points_count += gauge.data_points.len() as u64;
                             for point in &mut gauge.data_points {
-                                point.time_unix_nano = self.tick * TIME_INCREMENT_NANOS;
+                                point.time_unix_nano = current_time_unix_nano;
                                 if let Some(value) = &mut point.value {
                                     match value {
                                         number_data_point::Value::AsDouble(v) => {
@@ -385,13 +920,27 @@ impl<'a> SizedGenerator<'a> for OpentelemetryMetrics {
                             }
                         }
                         Data::Sum(sum) => {
-                            data_points_count += sum.data_points.len() as u64;
                             let is_accumulating = sum.is_monotonic;
-                            for point in &mut sum.data_points {
-                                point.time_unix_nano = self.tick * TIME_INCREMENT_NANOS;
+                            let aggregation_temporality = sum.aggregation_temporality;
+
+                            for (point_index, point) in sum.data_points.iter_mut().enumerate() {
+                                let series_id = point_series_id(
+                                    metric_identity,
+                                    point_index,
+                                    &point.attributes,
+                                );
+                                let clock = self.sum_clocks.entry(series_id).or_insert_with(|| {
+                                    SeriesClock::new(
+                                        current_time_unix_nano,
+                                        previous_time_unix_nano,
+                                    )
+                                });
+
+                                point.start_time_unix_nano =
+                                    clock.start_time_for_temporality(aggregation_temporality);
+                                point.time_unix_nano = current_time_unix_nano;
+
                                 if is_accumulating {
-                                    // For accumulating sums, monotonically
-                                    // increase by some factor of `tick_diff`
                                     if let Some(value) = &mut point.value {
                                         match value {
                                             number_data_point::Value::AsDouble(v) => {
@@ -403,29 +952,243 @@ impl<'a> SizedGenerator<'a> for OpentelemetryMetrics {
                                             }
                                         }
                                     }
-                                } else {
-                                    // For non-accumulating sums, use random
-                                    // values
-                                    if let Some(value) = &mut point.value {
-                                        match value {
-                                            number_data_point::Value::AsDouble(v) => {
-                                                *v = rng.random();
-                                            }
-                                            number_data_point::Value::AsInt(v) => {
-                                                *v = rng.random();
-                                            }
+                                } else if let Some(value) = &mut point.value {
+                                    match value {
+                                        number_data_point::Value::AsDouble(v) => {
+                                            *v = rng.random();
+                                        }
+                                        number_data_point::Value::AsInt(v) => {
+                                            *v = rng.random();
                                         }
                                     }
                                 }
+
+                                clock.note_emission(current_time_unix_nano);
                             }
                         }
-                        _ => unimplemented!(),
+                        Data::Histogram(histogram) => {
+                            let aggregation_temporality = histogram.aggregation_temporality;
+
+                            for (point_index, point) in histogram.data_points.iter_mut().enumerate()
+                            {
+                                let series_id = point_series_id(
+                                    metric_identity,
+                                    point_index,
+                                    &point.attributes,
+                                );
+                                let bucket_count = point.explicit_bounds.len() + 1;
+                                let profile = templates::point_profile(series_id);
+
+                                let state =
+                                    self.histogram_series.entry(series_id).or_insert_with(|| {
+                                        HistogramPointState::new(
+                                            current_time_unix_nano,
+                                            previous_time_unix_nano,
+                                            bucket_count,
+                                        )
+                                    });
+
+                                let interval_population =
+                                    non_negative_population(profile, state.clock.emissions, rng);
+                                let interval_bucket_counts = histogram_bucket_counts(
+                                    &interval_population.observations,
+                                    &point.explicit_bounds,
+                                );
+
+                                point.start_time_unix_nano = state
+                                    .clock
+                                    .start_time_for_temporality(aggregation_temporality);
+                                point.time_unix_nano = current_time_unix_nano;
+
+                                if aggregation_temporality == CUMULATIVE_TEMPORALITY {
+                                    merge_bucket_counts(
+                                        &mut state.cumulative_bucket_counts,
+                                        &interval_bucket_counts,
+                                    );
+                                    state.cumulative_count += interval_population.count;
+                                    state.cumulative_sum += interval_population.sum;
+                                    state.cumulative_min =
+                                        update_min(state.cumulative_min, interval_population.min);
+                                    state.cumulative_max =
+                                        update_max(state.cumulative_max, interval_population.max);
+
+                                    point
+                                        .bucket_counts
+                                        .clone_from(&state.cumulative_bucket_counts);
+                                    point.count = state.cumulative_count;
+                                    point.sum = Some(state.cumulative_sum);
+                                    point.min = state.cumulative_min;
+                                    point.max = state.cumulative_max;
+                                } else {
+                                    point.bucket_counts = interval_bucket_counts;
+                                    point.count = interval_population.count;
+                                    point.sum = Some(interval_population.sum);
+                                    point.min = interval_population.min;
+                                    point.max = interval_population.max;
+                                }
+                                point.exemplars = random_exemplars(
+                                    current_time_unix_nano,
+                                    point.min,
+                                    point.max,
+                                    rng,
+                                );
+
+                                state.clock.note_emission(current_time_unix_nano);
+                            }
+                        }
+                        Data::ExponentialHistogram(histogram) => {
+                            let aggregation_temporality = histogram.aggregation_temporality;
+
+                            for (point_index, point) in histogram.data_points.iter_mut().enumerate()
+                            {
+                                let series_id = point_series_id(
+                                    metric_identity,
+                                    point_index,
+                                    &point.attributes,
+                                );
+                                let profile = templates::point_profile(series_id);
+                                let state = self
+                                    .exponential_histogram_series
+                                    .entry(series_id)
+                                    .or_insert_with(|| {
+                                        ExponentialHistogramPointState::new(
+                                            current_time_unix_nano,
+                                            previous_time_unix_nano,
+                                        )
+                                    });
+                                let interval_population = signed_population(
+                                    profile,
+                                    point.zero_threshold,
+                                    state.clock.emissions,
+                                    rng,
+                                );
+                                let (interval_zero_count, interval_positive, interval_negative) =
+                                    exponential_histogram_buckets(
+                                        &interval_population.observations,
+                                        point.scale,
+                                        point.zero_threshold,
+                                    );
+
+                                point.start_time_unix_nano = state
+                                    .clock
+                                    .start_time_for_temporality(aggregation_temporality);
+                                point.time_unix_nano = current_time_unix_nano;
+
+                                if aggregation_temporality == CUMULATIVE_TEMPORALITY {
+                                    for (bucket_index, count) in &interval_positive {
+                                        *state
+                                            .cumulative_positive
+                                            .entry(*bucket_index)
+                                            .or_insert(0) += *count;
+                                    }
+                                    for (bucket_index, count) in &interval_negative {
+                                        *state
+                                            .cumulative_negative
+                                            .entry(*bucket_index)
+                                            .or_insert(0) += *count;
+                                    }
+                                    state.cumulative_zero_count += interval_zero_count;
+                                    state.cumulative_count += interval_population.count;
+                                    state.cumulative_sum += interval_population.sum;
+                                    state.cumulative_min =
+                                        update_min(state.cumulative_min, interval_population.min);
+                                    state.cumulative_max =
+                                        update_max(state.cumulative_max, interval_population.max);
+
+                                    point.positive =
+                                        Some(dense_exponential_buckets(&state.cumulative_positive));
+                                    point.negative =
+                                        Some(dense_exponential_buckets(&state.cumulative_negative));
+                                    point.zero_count = state.cumulative_zero_count;
+                                    point.count = state.cumulative_count;
+                                    point.sum = Some(state.cumulative_sum);
+                                    point.min = state.cumulative_min;
+                                    point.max = state.cumulative_max;
+                                } else {
+                                    point.positive =
+                                        Some(dense_exponential_buckets(&interval_positive));
+                                    point.negative =
+                                        Some(dense_exponential_buckets(&interval_negative));
+                                    point.zero_count = interval_zero_count;
+                                    point.count = interval_population.count;
+                                    point.sum = Some(interval_population.sum);
+                                    point.min = interval_population.min;
+                                    point.max = interval_population.max;
+                                }
+                                point.exemplars = random_exemplars(
+                                    current_time_unix_nano,
+                                    point.min,
+                                    point.max,
+                                    rng,
+                                );
+
+                                state.clock.note_emission(current_time_unix_nano);
+                            }
+                        }
+                        Data::Summary(summary) => {
+                            for (point_index, point) in summary.data_points.iter_mut().enumerate() {
+                                let series_id = point_series_id(
+                                    metric_identity,
+                                    point_index,
+                                    &point.attributes,
+                                );
+                                let state =
+                                    self.summary_series.entry(series_id).or_insert_with(|| {
+                                        SummaryPointState::new(
+                                            current_time_unix_nano,
+                                            previous_time_unix_nano,
+                                        )
+                                    });
+                                let profile = templates::point_profile(series_id);
+                                let interval_population =
+                                    non_negative_population(profile, state.clock.emissions, rng);
+
+                                point.start_time_unix_nano =
+                                    state.clock.stream_start_time_unix_nano;
+                                point.time_unix_nano = current_time_unix_nano;
+                                state.cumulative_count += interval_population.count;
+                                state.cumulative_sum += interval_population.sum;
+                                extend_summary_reservoir(
+                                    &mut state.retained_observations,
+                                    &interval_population.observations,
+                                );
+
+                                let mut sorted_observations = state.retained_observations.clone();
+                                sorted_observations.sort_by(f64::total_cmp);
+                                for quantile in &mut point.quantile_values {
+                                    quantile.value =
+                                        quantile_value(&sorted_observations, quantile.quantile);
+                                }
+
+                                point.count = state.cumulative_count;
+                                point.sum = state.cumulative_sum;
+                                state.clock.note_emission(current_time_unix_nano);
+                            }
+                        }
                     }
                 }
             }
         }
 
-        self.data_points_per_resource = data_points_count;
+        while tpl.encoded_len() > budget_before_fetch {
+            if !trim_one_data_point(&mut tpl) {
+                debug!(
+                    budget_before_fetch,
+                    actual_size = tpl.encoded_len(),
+                    "metric payload could not be trimmed to fit budget"
+                );
+                Err(PoolError::EmptyChoice)?;
+            }
+        }
+
+        self.data_points_per_resource = total_data_points(&tpl);
+        self.last_collection_time_unix_nano = current_time_unix_nano;
+
+        // The pool deducted the template's stored encoded size from budget, but
+        // mutations (timestamp, values, bucket counts) may change varint sizes.
+        // Correct the budget so it reflects the actual bytes the caller will
+        // consume.
+        *budget = budget_before_fetch.saturating_sub(tpl.encoded_len());
 
         Ok(tpl)
     }
@@ -893,8 +1656,15 @@ mod test {
                             sum.aggregation_temporality.hash(&mut hasher);
                             sum.is_monotonic.hash(&mut hasher);
                         }
-                        // Add other metric types as needed
-                        _ => "unknown".hash(&mut hasher),
+                        Data::Histogram(h) => {
+                            "histogram".hash(&mut hasher);
+                            h.aggregation_temporality.hash(&mut hasher);
+                        }
+                        Data::ExponentialHistogram(eh) => {
+                            "exponential_histogram".hash(&mut hasher);
+                            eh.aggregation_temporality.hash(&mut hasher);
+                        }
+                        Data::Summary(_) => "summary".hash(&mut hasher),
                     }
                 }
             }
@@ -1006,7 +1776,30 @@ mod test {
                                                 .push(point.time_unix_nano);
                                         }
                                     },
-                                    _ => {},
+                                    Data::Histogram(histogram) => {
+                                        for point in &histogram.data_points {
+                                            timestamps_by_metric
+                                                .entry(id)
+                                                .or_default()
+                                                .push(point.time_unix_nano);
+                                        }
+                                    },
+                                    Data::ExponentialHistogram(eh) => {
+                                        for point in &eh.data_points {
+                                            timestamps_by_metric
+                                                .entry(id)
+                                                .or_default()
+                                                .push(point.time_unix_nano);
+                                        }
+                                    },
+                                    Data::Summary(summary) => {
+                                        for point in &summary.data_points {
+                                            timestamps_by_metric
+                                                .entry(id)
+                                                .or_default()
+                                                .push(point.time_unix_nano);
+                                        }
+                                    },
                                 }
                             }
                         }
@@ -1059,6 +1852,9 @@ mod test {
                     gauge: 0,   // Only generate sum metrics
                     sum_delta: 50,
                     sum_cumulative: 50,
+                    histogram: 0,
+                    exponential_histogram: 0,
+                    summary: 0,
                 },
             };
 
@@ -1099,6 +1895,9 @@ mod test {
                     gauge: 0,   // Only generate sum metrics
                     sum_delta: 50,
                     sum_cumulative: 50,
+                    histogram: 0,
+                    exponential_histogram: 0,
+                    summary: 0,
                 },
             };
 
@@ -1344,6 +2143,9 @@ mod test {
                 gauge: 0,
                 sum_delta: 25,
                 sum_cumulative: 25,
+                histogram: 15,
+                exponential_histogram: 3,
+                summary: 2,
             },
             ..valid_config
         };
@@ -1354,16 +2156,35 @@ mod test {
                 gauge: 50,
                 sum_delta: 0,
                 sum_cumulative: 0,
+                histogram: 15,
+                exponential_histogram: 3,
+                summary: 2,
             },
             ..valid_config
         };
         assert!(zero_sum_weight.valid().is_err());
+
+        let zero_sum_cumulative_weight = Config {
+            metric_weights: super::MetricWeights {
+                gauge: 50,
+                sum_delta: 25,
+                sum_cumulative: 0,
+                histogram: 15,
+                exponential_histogram: 3,
+                summary: 2,
+            },
+            ..valid_config
+        };
+        assert!(zero_sum_cumulative_weight.valid().is_err());
 
         let zero_weights = Config {
             metric_weights: super::MetricWeights {
                 gauge: 0,
                 sum_delta: 0,
                 sum_cumulative: 0,
+                histogram: 0,
+                exponential_histogram: 0,
+                summary: 0,
             },
             ..valid_config
         };

--- a/lading_payload/src/opentelemetry/metric.rs
+++ b/lading_payload/src/opentelemetry/metric.rs
@@ -30,7 +30,7 @@
 // * Sum -- `Gauge` with the addition of monotonic flag, aggregation metadata
 // * Histogram -- explicit-bound bucket counts, sums, min/max, and exemplars
 // * ExponentialHistogram -- scale-based positive, negative, and zero buckets
-// * Summary -- cumulative count/sum with configured quantile values
+// * Summary -- interval count/sum with configured quantile values
 //
 // The `NumberDataPoint` used by Gauge and Sum is a
 //
@@ -73,8 +73,6 @@ const TIME_INCREMENT_NANOS: u64 = 100_000_000;
 const BASE_TIME_UNIX_NANOS: u64 = 1_700_000_000_000_000_000;
 const DELTA_TEMPORALITY: i32 = 1;
 const CUMULATIVE_TEMPORALITY: i32 = 2;
-const SUMMARY_RESERVOIR_CAP: usize = 512;
-
 #[derive(Clone, Debug)]
 struct SeriesClock {
     stream_start_time_unix_nano: u64,
@@ -131,18 +129,12 @@ impl HistogramPointState {
 #[derive(Clone, Debug)]
 struct SummaryPointState {
     clock: SeriesClock,
-    cumulative_count: u64,
-    cumulative_sum: f64,
-    retained_observations: Vec<f64>,
 }
 
 impl SummaryPointState {
     fn new(current_time_unix_nano: u64, previous_time_unix_nano: u64) -> Self {
         Self {
             clock: SeriesClock::new(current_time_unix_nano, previous_time_unix_nano),
-            cumulative_count: 0,
-            cumulative_sum: 0.0,
-            retained_observations: Vec::new(),
         }
     }
 }
@@ -504,14 +496,6 @@ fn dense_exponential_buckets(
     exponential_histogram_data_point::Buckets {
         offset: *first_index,
         bucket_counts,
-    }
-}
-
-fn extend_summary_reservoir(reservoir: &mut Vec<f64>, observations: &[f64]) {
-    reservoir.extend_from_slice(observations);
-    if reservoir.len() > SUMMARY_RESERVOIR_CAP {
-        let overflow = reservoir.len() - SUMMARY_RESERVOIR_CAP;
-        reservoir.drain(0..overflow);
     }
 }
 
@@ -1199,25 +1183,18 @@ impl<'a> SizedGenerator<'a> for OpentelemetryMetrics {
                                 let interval_population =
                                     non_negative_population(profile, state.clock.emissions, rng);
 
-                                point.start_time_unix_nano =
-                                    state.clock.stream_start_time_unix_nano;
+                                point.start_time_unix_nano = state.clock.last_time_unix_nano;
                                 point.time_unix_nano = current_time_unix_nano;
-                                state.cumulative_count += interval_population.count;
-                                state.cumulative_sum += interval_population.sum;
-                                extend_summary_reservoir(
-                                    &mut state.retained_observations,
-                                    &interval_population.observations,
-                                );
 
-                                let mut sorted_observations = state.retained_observations.clone();
+                                let mut sorted_observations = interval_population.observations;
                                 sorted_observations.sort_by(f64::total_cmp);
                                 for quantile in &mut point.quantile_values {
                                     quantile.value =
                                         quantile_value(&sorted_observations, quantile.quantile);
                                 }
 
-                                point.count = state.cumulative_count;
-                                point.sum = state.cumulative_sum;
+                                point.count = interval_population.count;
+                                point.sum = interval_population.sum;
                                 state.clock.note_emission(current_time_unix_nano);
                             }
                         }

--- a/lading_payload/src/opentelemetry/metric.rs
+++ b/lading_payload/src/opentelemetry/metric.rs
@@ -224,6 +224,23 @@ fn metric_identity_hash(
     scope_attributes: Option<&[KeyValue]>,
     metric: &Metric,
 ) -> u64 {
+    metric_hash(resource_attributes, scope_attributes, metric, false)
+}
+
+fn metric_profile_hash(
+    resource_attributes: Option<&[KeyValue]>,
+    scope_attributes: Option<&[KeyValue]>,
+    metric: &Metric,
+) -> u64 {
+    metric_hash(resource_attributes, scope_attributes, metric, true)
+}
+
+fn metric_hash(
+    resource_attributes: Option<&[KeyValue]>,
+    scope_attributes: Option<&[KeyValue]>,
+    metric: &Metric,
+    include_metadata: bool,
+) -> u64 {
     let mut hasher = DefaultHasher::new();
     if let Some(resource_attributes) = resource_attributes {
         hash_key_values(resource_attributes, &mut hasher);
@@ -232,9 +249,14 @@ fn metric_identity_hash(
         hash_key_values(scope_attributes, &mut hasher);
     }
     metric.name.hash(&mut hasher);
-    metric.description.hash(&mut hasher);
     metric.unit.hash(&mut hasher);
-    hash_key_values(&metric.metadata, &mut hasher);
+    if include_metadata {
+        // Profile seeding uses the full template shape for value diversity.
+        // Cumulative state keys exclude these fields because the OTLP spec
+        // marks description and metadata as non-identifying.
+        metric.description.hash(&mut hasher);
+        hash_key_values(&metric.metadata, &mut hasher);
+    }
 
     if let Some(data) = &metric.data {
         match data {
@@ -266,6 +288,10 @@ fn point_series_hasher(
 ) -> DefaultHasher {
     let mut hasher = DefaultHasher::new();
     metric_identity.hash(&mut hasher);
+    // Hashing point_index as usize ensures distinct series for Sum points,
+    // whose attributes are empty. For Histogram/Summary/ExponentialHistogram
+    // points the `lading.point_index` string attribute also distinguishes
+    // them, so the usize is redundant there but harmless.
     point_index.hash(&mut hasher);
     hash_key_values(attributes, &mut hasher);
     hasher
@@ -431,6 +457,11 @@ fn histogram_bucket_counts(observations: &[f64], explicit_bounds: &[f64]) -> Vec
 }
 
 fn merge_bucket_counts(target: &mut [u64], update: &[u64]) {
+    debug_assert_eq!(
+        target.len(),
+        update.len(),
+        "bucket count mismatch — template bounds changed mid-stream"
+    );
     for (target, update) in target.iter_mut().zip(update.iter().copied()) {
         *target += update;
     }
@@ -483,6 +514,9 @@ fn dense_exponential_buckets(
 ) -> exponential_histogram_data_point::Buckets {
     let (Some(first_index), Some(last_index)) = (counts.keys().next(), counts.keys().next_back())
     else {
+        // Empty counts means all observations fell in the zero range; no
+        // positive/negative buckets to report. offset=0 with empty
+        // bucket_counts is the correct OTLP encoding for "no buckets".
         return exponential_histogram_data_point::Buckets {
             offset: 0,
             bucket_counts: Vec::new(),
@@ -932,6 +966,8 @@ impl<'a> SizedGenerator<'a> for OpentelemetryMetrics {
             for metric in &mut scope_metrics.metrics {
                 let metric_identity =
                     metric_identity_hash(resource_attributes, scope_attributes, metric);
+                let metric_profile_identity =
+                    metric_profile_hash(resource_attributes, scope_attributes, metric);
 
                 if let Some(data) = &mut metric.data {
                     match data {
@@ -1003,7 +1039,7 @@ impl<'a> SizedGenerator<'a> for OpentelemetryMetrics {
                             for (point_index, point) in histogram.data_points.iter_mut().enumerate()
                             {
                                 let point_id = point_series_id(
-                                    metric_identity,
+                                    metric_profile_identity,
                                     point_index,
                                     &point.attributes,
                                 );
@@ -1079,7 +1115,7 @@ impl<'a> SizedGenerator<'a> for OpentelemetryMetrics {
                             for (point_index, point) in histogram.data_points.iter_mut().enumerate()
                             {
                                 let point_id = point_series_id(
-                                    metric_identity,
+                                    metric_profile_identity,
                                     point_index,
                                     &point.attributes,
                                 );
@@ -1183,10 +1219,17 @@ impl<'a> SizedGenerator<'a> for OpentelemetryMetrics {
                                             previous_time_unix_nano,
                                         )
                                     });
-                                let profile = templates::point_profile(series_id);
+                                let profile_id = point_series_id(
+                                    metric_profile_identity,
+                                    point_index,
+                                    &point.attributes,
+                                );
+                                let profile = templates::point_profile(profile_id);
                                 let interval_population =
                                     non_negative_population(profile, state.clock.emissions, rng);
 
+                                // Summary has no aggregation_temporality field in the OTLP
+                                // proto; it is always semantically cumulative from stream start.
                                 point.start_time_unix_nano =
                                     state.clock.stream_start_time_unix_nano;
                                 point.time_unix_nano = current_time_unix_nano;

--- a/lading_payload/src/opentelemetry/metric.rs
+++ b/lading_payload/src/opentelemetry/metric.rs
@@ -678,13 +678,14 @@ pub struct MetricWeights {
 
 impl Default for MetricWeights {
     fn default() -> Self {
+        // These are relative weights and do not need to sum to 100.
         Self {
-            gauge: 40,                // 40%
-            sum_delta: 25,            // 20%
-            sum_cumulative: 25,       // 20%
-            histogram: 15,            //15%
-            exponential_histogram: 3, // 3%
-            summary: 2,               //2%
+            gauge: 40,
+            sum_delta: 25,
+            sum_cumulative: 25,
+            histogram: 15,
+            exponential_histogram: 3,
+            summary: 2,
         }
     }
 }

--- a/lading_payload/src/opentelemetry/metric.rs
+++ b/lading_payload/src/opentelemetry/metric.rs
@@ -49,7 +49,7 @@ use std::rc::Rc;
 use std::{cell::RefCell, io::Write};
 
 use crate::SizedGenerator;
-use crate::opentelemetry::common::templates::PoolError;
+use crate::opentelemetry::common::{overhead, templates::PoolError};
 use crate::{Error, common::config::ConfRange, common::strings};
 use bytes::BytesMut;
 use opentelemetry_proto::tonic::collector::metrics::v1::ExportMetricsServiceRequest;
@@ -263,11 +263,46 @@ fn metric_identity_hash(
     hasher.finish()
 }
 
-fn point_series_id(metric_identity: u64, point_index: usize, attributes: &[KeyValue]) -> u64 {
+fn point_series_hasher(
+    metric_identity: u64,
+    point_index: usize,
+    attributes: &[KeyValue],
+) -> DefaultHasher {
     let mut hasher = DefaultHasher::new();
     metric_identity.hash(&mut hasher);
     point_index.hash(&mut hasher);
     hash_key_values(attributes, &mut hasher);
+    hasher
+}
+
+fn point_series_id(metric_identity: u64, point_index: usize, attributes: &[KeyValue]) -> u64 {
+    let hasher = point_series_hasher(metric_identity, point_index, attributes);
+    hasher.finish()
+}
+
+fn histogram_point_series_id(
+    metric_identity: u64,
+    point_index: usize,
+    attributes: &[KeyValue],
+    explicit_bounds: &[f64],
+) -> u64 {
+    let mut hasher = point_series_hasher(metric_identity, point_index, attributes);
+    for bound in explicit_bounds {
+        bound.to_bits().hash(&mut hasher);
+    }
+    hasher.finish()
+}
+
+fn exponential_histogram_point_series_id(
+    metric_identity: u64,
+    point_index: usize,
+    attributes: &[KeyValue],
+    scale: i32,
+    zero_threshold: f64,
+) -> u64 {
+    let mut hasher = point_series_hasher(metric_identity, point_index, attributes);
+    scale.hash(&mut hasher);
+    zero_threshold.to_bits().hash(&mut hasher);
     hasher.finish()
 }
 
@@ -547,6 +582,12 @@ fn trim_one_data_point(resource_metrics: &mut ResourceMetrics) -> bool {
     }
 
     false
+}
+
+fn resource_metrics_budget(bytes_remaining: usize) -> Option<usize> {
+    (1..=bytes_remaining)
+        .rev()
+        .find(|budget| overhead(*budget) <= bytes_remaining)
 }
 
 fn total_data_points(resource_metrics: &ResourceMetrics) -> u64 {
@@ -973,13 +1014,19 @@ impl<'a> SizedGenerator<'a> for OpentelemetryMetrics {
 
                             for (point_index, point) in histogram.data_points.iter_mut().enumerate()
                             {
-                                let series_id = point_series_id(
+                                let point_id = point_series_id(
                                     metric_identity,
                                     point_index,
                                     &point.attributes,
                                 );
+                                let series_id = histogram_point_series_id(
+                                    metric_identity,
+                                    point_index,
+                                    &point.attributes,
+                                    &point.explicit_bounds,
+                                );
                                 let bucket_count = point.explicit_bounds.len() + 1;
-                                let profile = templates::point_profile(series_id);
+                                let profile = templates::point_profile(point_id);
 
                                 let state =
                                     self.histogram_series.entry(series_id).or_insert_with(|| {
@@ -1043,12 +1090,19 @@ impl<'a> SizedGenerator<'a> for OpentelemetryMetrics {
 
                             for (point_index, point) in histogram.data_points.iter_mut().enumerate()
                             {
-                                let series_id = point_series_id(
+                                let point_id = point_series_id(
                                     metric_identity,
                                     point_index,
                                     &point.attributes,
                                 );
-                                let profile = templates::point_profile(series_id);
+                                let series_id = exponential_histogram_point_series_id(
+                                    metric_identity,
+                                    point_index,
+                                    &point.attributes,
+                                    point.scale,
+                                    point.zero_threshold,
+                                );
+                                let profile = templates::point_profile(point_id);
                                 let state = self
                                     .exponential_histogram_series
                                     .entry(series_id)
@@ -1174,6 +1228,7 @@ impl<'a> SizedGenerator<'a> for OpentelemetryMetrics {
 
         while tpl.encoded_len() > budget_before_fetch {
             if !trim_one_data_point(&mut tpl) {
+                *budget = budget_before_fetch;
                 debug!(
                     budget_before_fetch,
                     actual_size = tpl.encoded_len(),
@@ -1183,7 +1238,18 @@ impl<'a> SizedGenerator<'a> for OpentelemetryMetrics {
             }
         }
 
-        self.data_points_per_resource = total_data_points(&tpl);
+        let data_points_per_resource = total_data_points(&tpl);
+        if data_points_per_resource == 0 {
+            *budget = budget_before_fetch;
+            debug!(
+                budget_before_fetch,
+                actual_size = tpl.encoded_len(),
+                "metric payload was trimmed to zero data points"
+            );
+            Err(PoolError::EmptyChoice)?;
+        }
+
+        self.data_points_per_resource = data_points_per_resource;
         self.last_collection_time_unix_nano = current_time_unix_nano;
 
         // The pool deducted the template's stored encoded size from budget, but
@@ -1213,33 +1279,8 @@ impl crate::Serialize for OpentelemetryMetrics {
         let mut total_data_points = 0;
         let loop_id: u32 = rng.random();
 
-        // Build up the request by adding ResourceMetrics one by one until we
-        // would exceed max_bytes.
-        //
-        // Example: max_bytes = 1000
-        //
-        // - Request with 0 ResourceMetrics: encoded size = 100 bytes
-        // - Add ResourceMetrics #1: encoded size = 400 bytes (still under 1000,
-        //   continue)
-        // - Add ResourceMetrics #2: encoded size = 700 bytes (still under 1000,
-        //   continue)
-        // - Add ResourceMetrics #3: encoded size = 1050 bytes (over 1000!)
-        // - Code detects overflow, pops #3, breaks the loop
-        // - Request now has #1 and #2, encoded size = 700 bytes
-        //
-        // When we call generate we pass bytes_remaining as the budget. After
-        // adding ResourceMetrics #2, we set bytes_remaining = 1000 - 700 =
-        // 300. So when generating #3, we tell it "you have 300 bytes to work
-        // with". The generate method might return something that encodes to 250
-        // bytes on its own.
-        //
-        // But, protobuf encoding isn't strictly additive. When we add that 250
-        // byte ResourceMetrics to a request that's already 700 bytes, the
-        // combined encoding might be > 1000 bytes (not 950) due to additional
-        // framing, length prefixes, field tags or whatever.  We handle this by
-        // checking after adding and removing the item if it exceeds the budget.
-        while bytes_remaining >= SMALLEST_PROTOBUF {
-            if let Ok(rm) = self.generate(&mut rng, &mut bytes_remaining) {
+        while let Some(mut resource_budget) = resource_metrics_budget(bytes_remaining) {
+            if let Ok(rm) = self.generate(&mut rng, &mut resource_budget) {
                 total_data_points += self.data_points_per_resource;
                 request.resource_metrics.push(rm);
 
@@ -1252,20 +1293,9 @@ impl crate::Serialize for OpentelemetryMetrics {
                     ?SMALLEST_PROTOBUF,
                     "to_bytes inner loop"
                 );
-                if required_bytes > max_bytes {
-                    total_data_points -= self.data_points_per_resource;
-                    drop(request.resource_metrics.pop());
-                    break;
-                }
+                debug_assert!(required_bytes <= max_bytes);
                 bytes_remaining = max_bytes.saturating_sub(required_bytes);
             } else {
-                // Belt with suspenders time: verify no templates could possibly
-                // fit. If we pass this assertion, break as no template will
-                // ever fit the requested max_bytes.
-                assert!(
-                    !self.pool.template_fits(bytes_remaining),
-                    "Pool claims template fits {bytes_remaining} bytes but generate() failed, indicative of a logic error",
-                );
                 break;
             }
         }

--- a/lading_payload/src/opentelemetry/metric.rs
+++ b/lading_payload/src/opentelemetry/metric.rs
@@ -53,7 +53,7 @@ use crate::opentelemetry::common::{overhead, templates::PoolError};
 use crate::{Error, common::config::ConfRange, common::strings};
 use bytes::BytesMut;
 use opentelemetry_proto::tonic::collector::metrics::v1::ExportMetricsServiceRequest;
-use opentelemetry_proto::tonic::common::v1::{KeyValue, any_value};
+use opentelemetry_proto::tonic::common::v1::{InstrumentationScope, KeyValue, any_value};
 use opentelemetry_proto::tonic::metrics::v1::{
     Exemplar, Metric, ResourceMetrics, exemplar, exponential_histogram_data_point, metric::Data,
     number_data_point,
@@ -219,23 +219,23 @@ fn hash_key_values(values: &[KeyValue], hasher: &mut DefaultHasher) {
 
 fn metric_identity_hash(
     resource_attributes: Option<&[KeyValue]>,
-    scope_attributes: Option<&[KeyValue]>,
+    scope: Option<&InstrumentationScope>,
     metric: &Metric,
 ) -> u64 {
-    metric_hash(resource_attributes, scope_attributes, metric, false)
+    metric_hash(resource_attributes, scope, metric, false)
 }
 
 fn metric_profile_hash(
     resource_attributes: Option<&[KeyValue]>,
-    scope_attributes: Option<&[KeyValue]>,
+    scope: Option<&InstrumentationScope>,
     metric: &Metric,
 ) -> u64 {
-    metric_hash(resource_attributes, scope_attributes, metric, true)
+    metric_hash(resource_attributes, scope, metric, true)
 }
 
 fn metric_hash(
     resource_attributes: Option<&[KeyValue]>,
-    scope_attributes: Option<&[KeyValue]>,
+    scope: Option<&InstrumentationScope>,
     metric: &Metric,
     include_metadata: bool,
 ) -> u64 {
@@ -243,8 +243,10 @@ fn metric_hash(
     if let Some(resource_attributes) = resource_attributes {
         hash_key_values(resource_attributes, &mut hasher);
     }
-    if let Some(scope_attributes) = scope_attributes {
-        hash_key_values(scope_attributes, &mut hasher);
+    if let Some(scope) = scope {
+        scope.name.hash(&mut hasher);
+        scope.version.hash(&mut hasher);
+        hash_key_values(&scope.attributes, &mut hasher);
     }
     metric.name.hash(&mut hasher);
     metric.unit.hash(&mut hasher);
@@ -956,16 +958,12 @@ impl<'a> SizedGenerator<'a> for OpentelemetryMetrics {
         // attributes, timestamps, and cumulative aggregates stay coherent
         // across repeated emissions of the same template.
         for scope_metrics in &mut tpl.scope_metrics {
-            let scope_attributes = scope_metrics
-                .scope
-                .as_ref()
-                .map(|scope| scope.attributes.as_slice());
+            let scope = scope_metrics.scope.as_ref();
 
             for metric in &mut scope_metrics.metrics {
-                let metric_identity =
-                    metric_identity_hash(resource_attributes, scope_attributes, metric);
+                let metric_identity = metric_identity_hash(resource_attributes, scope, metric);
                 let metric_profile_identity =
-                    metric_profile_hash(resource_attributes, scope_attributes, metric);
+                    metric_profile_hash(resource_attributes, scope, metric);
 
                 if let Some(data) = &mut metric.data {
                     match data {
@@ -1355,7 +1353,7 @@ impl crate::Serialize for OpentelemetryMetrics {
 mod test {
     use super::{Config, Contexts, OpentelemetryMetrics, ResourceMetrics, SMALLEST_PROTOBUF};
     use crate::{Serialize, SizedGenerator, common::config::ConfRange};
-    use opentelemetry_proto::tonic::common::v1::any_value;
+    use opentelemetry_proto::tonic::common::v1::InstrumentationScope;
     use opentelemetry_proto::tonic::metrics::v1::{
         Metric, NumberDataPoint, ScopeMetrics, metric::Data, number_data_point,
     };
@@ -1409,6 +1407,52 @@ mod test {
                 }
             }
         }
+    }
+
+    /// For all scopes a and b with equivalent attributes and distinct
+    /// name/version, metric state identity hashes differ.
+    #[test]
+    fn metric_identity_includes_scope_name_and_version() {
+        let metric = Metric {
+            name: "metric".to_string(),
+            description: String::new(),
+            unit: String::new(),
+            data: Some(Data::Gauge(Gauge {
+                data_points: Vec::new(),
+            })),
+            metadata: Vec::new(),
+        };
+        let base_scope = InstrumentationScope {
+            name: "scope-a".to_string(),
+            version: "1.0.0".to_string(),
+            attributes: Vec::new(),
+            dropped_attributes_count: 0,
+        };
+        let different_name = InstrumentationScope {
+            name: "scope-b".to_string(),
+            ..base_scope.clone()
+        };
+        let different_version = InstrumentationScope {
+            version: "2.0.0".to_string(),
+            ..base_scope.clone()
+        };
+
+        assert_ne!(
+            super::metric_identity_hash(None, Some(&base_scope), &metric),
+            super::metric_identity_hash(None, Some(&different_name), &metric)
+        );
+        assert_ne!(
+            super::metric_identity_hash(None, Some(&base_scope), &metric),
+            super::metric_identity_hash(None, Some(&different_version), &metric)
+        );
+        assert_ne!(
+            super::metric_profile_hash(None, Some(&base_scope), &metric),
+            super::metric_profile_hash(None, Some(&different_name), &metric)
+        );
+        assert_ne!(
+            super::metric_profile_hash(None, Some(&base_scope), &metric),
+            super::metric_profile_hash(None, Some(&different_version), &metric)
+        );
     }
 
     // Generation of metrics must be deterministic. In order to assert this
@@ -1660,35 +1704,23 @@ mod test {
     ///
     /// A context is defined by the unique combination of:
     /// - Resource attributes
-    /// - Scope attributes
+    /// - Scope name, version, and attributes
     /// - Metric name, attributes, data kind, and unit
     fn context_id(metric: &ResourceMetrics) -> u64 {
         let mut hasher = DefaultHasher::new();
 
         // Hash resource attributes
         if let Some(resource) = &metric.resource {
-            for attr in &resource.attributes {
-                attr.key.hash(&mut hasher);
-                if let Some(value) = &attr.value
-                    && let Some(any_value::Value::StringValue(s)) = &value.value
-                {
-                    s.hash(&mut hasher);
-                }
-            }
+            super::hash_key_values(&resource.attributes, &mut hasher);
         }
 
         // Hash each scope's context
         for scope_metrics in &metric.scope_metrics {
-            // Hash scope attributes
+            // Hash scope identity
             if let Some(scope) = &scope_metrics.scope {
-                for attr in &scope.attributes {
-                    attr.key.hash(&mut hasher);
-                    if let Some(value) = &attr.value
-                        && let Some(any_value::Value::StringValue(s)) = &value.value
-                    {
-                        s.hash(&mut hasher);
-                    }
-                }
+                scope.name.hash(&mut hasher);
+                scope.version.hash(&mut hasher);
+                super::hash_key_values(&scope.attributes, &mut hasher);
             }
 
             // Hash each metric's context
@@ -1697,14 +1729,7 @@ mod test {
                 metric.name.hash(&mut hasher);
 
                 // Hash metric attributes
-                for attr in &metric.metadata {
-                    attr.key.hash(&mut hasher);
-                    if let Some(value) = &attr.value
-                        && let Some(any_value::Value::StringValue(s)) = &value.value
-                    {
-                        s.hash(&mut hasher);
-                    }
-                }
+                super::hash_key_values(&metric.metadata, &mut hasher);
 
                 // Hash metric data kind and unit
                 metric.unit.hash(&mut hasher);

--- a/lading_payload/src/opentelemetry/metric.rs
+++ b/lading_payload/src/opentelemetry/metric.rs
@@ -150,7 +150,6 @@ struct ExponentialHistogramPointState {
     cumulative_negative: BTreeMap<i32, u64>,
     cumulative_zero_count: u64,
     cumulative_count: u64,
-    cumulative_sum: f64,
     cumulative_min: Option<f64>,
     cumulative_max: Option<f64>,
 }
@@ -163,7 +162,6 @@ impl ExponentialHistogramPointState {
             cumulative_negative: BTreeMap::new(),
             cumulative_zero_count: 0,
             cumulative_count: 0,
-            cumulative_sum: 0.0,
             cumulative_min: None,
             cumulative_max: None,
         }
@@ -1169,7 +1167,6 @@ impl<'a> SizedGenerator<'a> for OpentelemetryMetrics {
                                     }
                                     state.cumulative_zero_count += interval_zero_count;
                                     state.cumulative_count += interval_population.count;
-                                    state.cumulative_sum += interval_population.sum;
                                     state.cumulative_min =
                                         update_min(state.cumulative_min, interval_population.min);
                                     state.cumulative_max =
@@ -1181,7 +1178,9 @@ impl<'a> SizedGenerator<'a> for OpentelemetryMetrics {
                                         Some(dense_exponential_buckets(&state.cumulative_negative));
                                     point.zero_count = state.cumulative_zero_count;
                                     point.count = state.cumulative_count;
-                                    point.sum = Some(state.cumulative_sum);
+                                    // signed_population can produce negative measurements;
+                                    // OTLP proto says sum SHOULD NOT be set in that case.
+                                    point.sum = None;
                                     point.min = state.cumulative_min;
                                     point.max = state.cumulative_max;
                                 } else {
@@ -1191,7 +1190,9 @@ impl<'a> SizedGenerator<'a> for OpentelemetryMetrics {
                                         Some(dense_exponential_buckets(&interval_negative));
                                     point.zero_count = interval_zero_count;
                                     point.count = interval_population.count;
-                                    point.sum = Some(interval_population.sum);
+                                    // signed_population can produce negative measurements;
+                                    // OTLP proto says sum SHOULD NOT be set in that case.
+                                    point.sum = None;
                                     point.min = interval_population.min;
                                     point.max = interval_population.max;
                                 }

--- a/lading_payload/src/opentelemetry/metric.rs
+++ b/lading_payload/src/opentelemetry/metric.rs
@@ -460,7 +460,7 @@ fn merge_bucket_counts(target: &mut [u64], update: &[u64]) {
     debug_assert_eq!(
         target.len(),
         update.len(),
-        "bucket count mismatch — template bounds changed mid-stream"
+        "bucket count mismatch - template bounds changed mid-stream"
     );
     for (target, update) in target.iter_mut().zip(update.iter().copied()) {
         *target += update;

--- a/lading_payload/src/opentelemetry/metric.rs
+++ b/lading_payload/src/opentelemetry/metric.rs
@@ -28,9 +28,11 @@
 //
 // * Gauge -- a collection of `NumberDataPoint`, values sampled at specific times
 // * Sum -- `Gauge` with the addition of monotonic flag, aggregation metadata
+// * Histogram -- explicit-bound bucket counts, sums, min/max, and exemplars
+// * ExponentialHistogram -- scale-based positive, negative, and zero buckets
+// * Summary -- cumulative count/sum with configured quantile values
 //
-// We omit Histogram / ExponentialHistogram / Summary in this current version
-// but will introduce them in the near-term. The `NumberDataPoint` is a
+// The `NumberDataPoint` used by Gauge and Sum is a
 //
 // * attributes: Vec<KeyValue> -- tags
 // * start_time_unix_nano: u64 -- represents the first possible moment a measurement could be recorded, optional

--- a/lading_payload/src/opentelemetry/metric.rs
+++ b/lading_payload/src/opentelemetry/metric.rs
@@ -30,7 +30,7 @@
 // * Sum -- `Gauge` with the addition of monotonic flag, aggregation metadata
 // * Histogram -- explicit-bound bucket counts, sums, min/max, and exemplars
 // * ExponentialHistogram -- scale-based positive, negative, and zero buckets
-// * Summary -- interval count/sum with configured quantile values
+// * Summary -- cumulative count/sum with configured quantile values
 //
 // The `NumberDataPoint` used by Gauge and Sum is a
 //
@@ -129,12 +129,16 @@ impl HistogramPointState {
 #[derive(Clone, Debug)]
 struct SummaryPointState {
     clock: SeriesClock,
+    cumulative_count: u64,
+    cumulative_sum: f64,
 }
 
 impl SummaryPointState {
     fn new(current_time_unix_nano: u64, previous_time_unix_nano: u64) -> Self {
         Self {
             clock: SeriesClock::new(current_time_unix_nano, previous_time_unix_nano),
+            cumulative_count: 0,
+            cumulative_sum: 0.0,
         }
     }
 }
@@ -1183,8 +1187,11 @@ impl<'a> SizedGenerator<'a> for OpentelemetryMetrics {
                                 let interval_population =
                                     non_negative_population(profile, state.clock.emissions, rng);
 
-                                point.start_time_unix_nano = state.clock.last_time_unix_nano;
+                                point.start_time_unix_nano =
+                                    state.clock.stream_start_time_unix_nano;
                                 point.time_unix_nano = current_time_unix_nano;
+                                state.cumulative_count += interval_population.count;
+                                state.cumulative_sum += interval_population.sum;
 
                                 let mut sorted_observations = interval_population.observations;
                                 sorted_observations.sort_by(f64::total_cmp);
@@ -1193,8 +1200,8 @@ impl<'a> SizedGenerator<'a> for OpentelemetryMetrics {
                                         quantile_value(&sorted_observations, quantile.quantile);
                                 }
 
-                                point.count = interval_population.count;
-                                point.sum = interval_population.sum;
+                                point.count = state.cumulative_count;
+                                point.sum = state.cumulative_sum;
                                 state.clock.note_emission(current_time_unix_nano);
                             }
                         }

--- a/lading_payload/src/opentelemetry/metric/templates.rs
+++ b/lading_payload/src/opentelemetry/metric/templates.rs
@@ -1,11 +1,13 @@
 use std::{cmp, rc::Rc};
 
 use opentelemetry_proto::tonic::{
-    common::v1::InstrumentationScope,
+    common::v1::{InstrumentationScope, KeyValue},
     metrics::{
         self,
         v1::{
-            Metric, NumberDataPoint, ResourceMetrics, ScopeMetrics, metric::Data, number_data_point,
+            ExponentialHistogramDataPoint, HistogramDataPoint, Metric, NumberDataPoint,
+            ResourceMetrics, ScopeMetrics, SummaryDataPoint, exponential_histogram_data_point,
+            metric::Data, number_data_point, summary_data_point,
         },
     },
     resource,
@@ -22,6 +24,13 @@ use crate::opentelemetry::common::{GeneratorError, TagGenerator, UNIQUE_TAG_RATI
 use crate::{Error, Generator, common::config::ConfRange, common::strings};
 
 pub(crate) type Pool = templates::Pool<ResourceMetrics, ResourceTemplateGenerator>;
+
+#[derive(Clone, Copy, Debug)]
+pub(super) struct PointProfile {
+    pub sample: f64,
+    pub spread: f64,
+    pub jitter: f64,
+}
 
 /// Generate a random number between min and max (inclusive) with heavy bias
 /// toward min. Uses exponential decay: each doubling of the range has half the
@@ -51,6 +60,59 @@ fn exponential_weighted_range<R: Rng + ?Sized>(rng: &mut R, min: u32, max: u32) 
     max
 }
 
+pub(super) fn random_summary_quantiles<R: Rng + ?Sized>(
+    quantile_count: usize,
+    rng: &mut R,
+) -> Vec<f64> {
+    let mut quantiles: Vec<f64> = (0..quantile_count).map(|_| rng.random()).collect();
+    quantiles.sort_by(f64::total_cmp);
+    quantiles
+}
+
+pub(super) fn point_profile(seed: u64) -> PointProfile {
+    let sample = scaled_unit(seed, 0, 25.0, 1_000_000.0);
+    let spread = scaled_unit(seed, 21, 1.0, 100_000.0);
+    let jitter = scaled_unit(seed, 42, 0.0, 10_000.0);
+
+    PointProfile {
+        sample,
+        spread,
+        jitter,
+    }
+}
+
+fn histogram_bounds_from_profile(profile: PointProfile, n_bounds: usize) -> Vec<f64> {
+    if n_bounds == 0 {
+        return Vec::new();
+    }
+
+    let base_step = (profile.spread / 2.0).max(0.5);
+    let drift = (profile.jitter / 8.0).max(0.25);
+    let mut next = (profile.sample - base_step * n_bounds as f64).max(0.0);
+    let mut bounds = Vec::with_capacity(n_bounds);
+
+    for idx in 0..n_bounds {
+        next += base_step + drift + (idx as f64 * 0.25);
+        bounds.push(next);
+    }
+
+    bounds
+}
+
+pub(super) fn zero_threshold_from_profile(profile: PointProfile) -> f64 {
+    let candidate = (profile.spread / 512.0).max(profile.jitter / 1_024.0);
+    candidate.min(profile.spread / 4.0).max(0.0)
+}
+
+fn scaled_unit(seed: u64, shift: u32, min: f64, max: f64) -> f64 {
+    let value = ((seed.rotate_right(shift) & 0xFFFF) as f64) / 65_535.0;
+    min + value * (max - min)
+}
+
+fn point_attributes(metadata: &[KeyValue]) -> Vec<KeyValue> {
+    metadata.iter().take(2).cloned().collect()
+}
+
 struct Ndp(NumberDataPoint);
 impl Distribution<Ndp> for StandardUniform {
     fn sample<R>(&self, rng: &mut R) -> Ndp
@@ -67,8 +129,8 @@ impl Distribution<Ndp> for StandardUniform {
             // NOTE absent a reason to set attributes to not-empty, it's unclear
             // that we should.
             attributes: Vec::new(),
-            start_time_unix_nano: 0, // epoch instant
-            time_unix_nano: rng.random(),
+            start_time_unix_nano: 0,
+            time_unix_nano: 0,
             // Unclear that this needs to be set.
             exemplars: Vec::new(),
             // Equivalent to DoNotUse, the flag is ignored. This is discussed in
@@ -112,6 +174,9 @@ impl MetricTemplateGenerator {
                 u16::from(config.metric_weights.gauge),
                 u16::from(config.metric_weights.sum_delta),
                 u16::from(config.metric_weights.sum_cumulative),
+                u16::from(config.metric_weights.histogram),
+                u16::from(config.metric_weights.exponential_histogram),
+                u16::from(config.metric_weights.summary),
             ])?,
             unit_gen: UnitGenerator::new(),
             str_pool: Rc::clone(str_pool),
@@ -124,6 +189,7 @@ impl<'a> crate::SizedGenerator<'a> for MetricTemplateGenerator {
     type Output = Metric;
     type Error = GeneratorError;
 
+    #[allow(clippy::too_many_lines)]
     fn generate<R>(
         &'a mut self,
         rng: &mut R,
@@ -175,6 +241,14 @@ impl<'a> crate::SizedGenerator<'a> for MetricTemplateGenerator {
                 aggregation_temporality: 2,
                 is_monotonic: rng.random_bool(0.5),
             },
+            3 => Kind::Histogram {
+                aggregation_temporality: if rng.random_bool(0.5) { 1 } else { 2 },
+            },
+            4 => Kind::ExponentialHistogram {
+                aggregation_temporality: if rng.random_bool(0.5) { 1 } else { 2 },
+                scale: rng.random_range(-3_i32..=10),
+            },
+            5 => Kind::Summary,
             _ => unreachable!(),
         };
 
@@ -193,6 +267,101 @@ impl<'a> crate::SizedGenerator<'a> for MetricTemplateGenerator {
                 aggregation_temporality,
                 is_monotonic,
             }),
+            Kind::Summary => {
+                let data_points = (0..total_data_points)
+                    .map(|_| {
+                        let quantiles =
+                            random_summary_quantiles(rng.random_range(2_usize..=8), rng);
+                        let quantile_values = quantiles
+                            .into_iter()
+                            .map(|quantile| summary_data_point::ValueAtQuantile {
+                                quantile,
+                                value: 0.0,
+                            })
+                            .collect::<Vec<_>>();
+                        SummaryDataPoint {
+                            attributes: point_attributes(&metadata),
+                            start_time_unix_nano: 0,
+                            time_unix_nano: 0,
+                            count: 0,
+                            sum: 0.0,
+                            quantile_values,
+                            flags: 0,
+                        }
+                    })
+                    .collect();
+                Data::Summary(metrics::v1::Summary { data_points })
+            }
+            Kind::Histogram {
+                aggregation_temporality,
+            } => {
+                let data_points = (0..total_data_points as usize)
+                    .map(|_| {
+                        let attributes = point_attributes(&metadata);
+                        let profile = point_profile(rng.random());
+                        let n_bounds = rng.random_range(4_usize..=16);
+                        let bounds = histogram_bounds_from_profile(profile, n_bounds);
+                        let n_buckets = bounds.len() + 1;
+
+                        HistogramDataPoint {
+                            attributes,
+                            start_time_unix_nano: 0,
+                            time_unix_nano: 0,
+                            count: 0,
+                            sum: Some(0.0),
+                            explicit_bounds: bounds,
+                            bucket_counts: vec![0; n_buckets],
+                            exemplars: Vec::new(),
+                            flags: 0,
+                            min: None,
+                            max: None,
+                        }
+                    })
+                    .collect();
+                Data::Histogram(metrics::v1::Histogram {
+                    data_points,
+                    aggregation_temporality,
+                })
+            }
+            Kind::ExponentialHistogram {
+                aggregation_temporality,
+                scale,
+            } => {
+                let data_points = (0..total_data_points as usize)
+                    .map(|_| {
+                        let attributes = point_attributes(&metadata);
+                        let profile = point_profile(rng.random());
+
+                        ExponentialHistogramDataPoint {
+                            attributes,
+                            start_time_unix_nano: 0,
+                            time_unix_nano: 0,
+                            count: 0,
+                            sum: Some(0.0),
+                            scale,
+                            zero_count: 0,
+                            positive: Some(exponential_histogram_data_point::Buckets {
+                                offset: 0,
+                                bucket_counts: Vec::new(),
+                            }),
+                            negative: Some(exponential_histogram_data_point::Buckets {
+                                offset: 0,
+                                bucket_counts: Vec::new(),
+                            }),
+                            exemplars: Vec::new(),
+                            flags: 0,
+                            min: None,
+                            max: None,
+                            zero_threshold: zero_threshold_from_profile(profile),
+                        }
+                    })
+                    .collect();
+
+                Data::ExponentialHistogram(metrics::v1::ExponentialHistogram {
+                    data_points,
+                    aggregation_temporality,
+                })
+            }
         };
         let mut metric = Metric {
             name,
@@ -223,6 +392,46 @@ impl<'a> crate::SizedGenerator<'a> for MetricTemplateGenerator {
     }
 }
 
+#[cfg(test)]
+pub(super) fn random_partition<R: Rng + ?Sized>(
+    count: u64,
+    n_buckets: usize,
+    rng: &mut R,
+) -> Vec<u64> {
+    if n_buckets == 0 {
+        return Vec::new();
+    }
+
+    let mut result = vec![0; n_buckets];
+    if count == 0 {
+        return result;
+    }
+
+    let guaranteed_non_zero = n_buckets.min(usize::try_from(count).unwrap_or(usize::MAX));
+    for value in result.iter_mut().take(guaranteed_non_zero) {
+        *value = 1;
+    }
+
+    let mut remaining = count.saturating_sub(guaranteed_non_zero as u64);
+    while remaining > 0 {
+        let bucket_idx = rng.random_range(0..guaranteed_non_zero.max(1));
+        let chunk = if remaining == 1 {
+            1
+        } else {
+            rng.random_range(1..=remaining)
+        };
+        result[bucket_idx] += chunk;
+        remaining -= chunk;
+    }
+
+    for idx in (1..result.len()).rev() {
+        let swap_idx = rng.random_range(0..=idx);
+        result.swap(idx, swap_idx);
+    }
+
+    result
+}
+
 fn data_points_total(metric: &Metric) -> usize {
     let data = &metric.data;
     match data {
@@ -230,8 +439,12 @@ fn data_points_total(metric: &Metric) -> usize {
             Data::Gauge(metrics::v1::Gauge { data_points })
             | Data::Sum(metrics::v1::Sum { data_points, .. }),
         ) => data_points.len(),
+        Some(Data::Histogram(metrics::v1::Histogram { data_points, .. })) => data_points.len(),
+        Some(Data::ExponentialHistogram(metrics::v1::ExponentialHistogram {
+            data_points, ..
+        })) => data_points.len(),
+        Some(Data::Summary(metrics::v1::Summary { data_points })) => data_points.len(),
         None => 0,
-        _ => unimplemented!("only gauge/sum metrics supported"),
     }
 }
 
@@ -261,8 +474,36 @@ fn cut_data_points(metric: Metric) -> Metric {
                 is_monotonic,
             }))
         }
+        Some(Data::ExponentialHistogram(metrics::v1::ExponentialHistogram {
+            mut data_points,
+            aggregation_temporality,
+        })) => {
+            let new_len = data_points.len() / 2;
+            data_points.truncate(new_len);
+            Some(Data::ExponentialHistogram(
+                metrics::v1::ExponentialHistogram {
+                    data_points,
+                    aggregation_temporality,
+                },
+            ))
+        }
+        Some(Data::Histogram(metrics::v1::Histogram {
+            mut data_points,
+            aggregation_temporality,
+        })) => {
+            let new_len = data_points.len() / 2;
+            data_points.truncate(new_len);
+            Some(Data::Histogram(metrics::v1::Histogram {
+                data_points,
+                aggregation_temporality,
+            }))
+        }
+        Some(Data::Summary(metrics::v1::Summary { mut data_points })) => {
+            let new_len = data_points.len() / 2;
+            data_points.truncate(new_len);
+            Some(Data::Summary(metrics::v1::Summary { data_points }))
+        }
         None => None,
-        _ => unimplemented!("only gauge/sum metrics supported"),
     };
 
     Metric {
@@ -281,6 +522,14 @@ pub(crate) enum Kind {
         aggregation_temporality: i32,
         is_monotonic: bool,
     },
+    Histogram {
+        aggregation_temporality: i32,
+    },
+    ExponentialHistogram {
+        aggregation_temporality: i32,
+        scale: i32,
+    },
+    Summary,
 }
 
 #[derive(Clone, Debug)]
@@ -538,6 +787,9 @@ mod test {
             config.metric_weights.gauge = gauge;
             config.metric_weights.sum_delta = sum_delta;
             config.metric_weights.sum_cumulative = sum_cumulative;
+            config.metric_weights.histogram = 0;
+            config.metric_weights.exponential_histogram = 0;
+            config.metric_weights.summary = 0;
 
             let mut rng = SmallRng::seed_from_u64(seed);
 
@@ -563,8 +815,97 @@ mod test {
                             _ => panic!("invalid aggregation temporality"),
                         }
                     }
-                    _ => panic!("invalid metric data"),
+                    Data::Histogram(_) | Data::ExponentialHistogram(_) | Data::Summary(_) => {
+                        panic!("unexpected new metric type when weights are zero")
+                    }
                 }
+            }
+        }
+    }
+
+    proptest! {
+        #[test]
+        fn metric_template_generator_new_types_generate(
+            seed: u64,
+            histogram in 0..2_u8,
+            exponential_histogram in 0..2_u8,
+            summary in 0..2_u8,
+        ) {
+            if histogram == 0 && exponential_histogram == 0 && summary == 0 {
+                return Ok(());
+            }
+
+            let mut config = Config::default();
+            config.metric_weights.gauge = 0;
+            config.metric_weights.sum_delta = 0;
+            config.metric_weights.sum_cumulative = 0;
+            config.metric_weights.histogram = histogram;
+            config.metric_weights.exponential_histogram = exponential_histogram;
+            config.metric_weights.summary = summary;
+
+            let mut rng = SmallRng::seed_from_u64(seed);
+            let generator_result = MetricTemplateGenerator::new(
+                &config,
+                &Rc::new(strings::RandomStringPool::with_size(&mut rng, 1024)),
+                &mut rng,
+            );
+            assert!(generator_result.is_ok());
+            let mut generator = generator_result.unwrap();
+
+            for _ in 0..100 {
+                let result = generator.generate(&mut rng, &mut 1024);
+                assert!(result.is_ok());
+                let metric = result.unwrap();
+                assert!(metric.data.is_some());
+                match metric.data.unwrap() {
+                    Data::Histogram(_) => assert!(histogram >= 1),
+                    Data::ExponentialHistogram(_) => assert!(exponential_histogram >= 1),
+                    Data::Summary(_) => assert!(summary >= 1),
+                    Data::Gauge(_) | Data::Sum(_) => {
+                        panic!("unexpected gauge/sum when weights are zero")
+                    }
+                }
+            }
+        }
+    }
+
+    proptest! {
+        #[test]
+        fn random_partition_preserves_count_and_density(
+            seed: u64,
+            count in 0_u64..10_000,
+            n_buckets in 1_usize..128,
+        ) {
+            let mut rng = SmallRng::seed_from_u64(seed);
+            let partition = random_partition(count, n_buckets, &mut rng);
+
+            prop_assert_eq!(partition.len(), n_buckets);
+            prop_assert_eq!(partition.iter().sum::<u64>(), count);
+
+            if count >= n_buckets as u64 {
+                prop_assert!(
+                    partition.iter().all(|value| *value > 0),
+                    "count {count} should populate every bucket",
+                );
+            }
+        }
+    }
+
+    proptest! {
+        #[test]
+        fn random_summary_quantiles_are_sorted_and_bounded(
+            seed: u64,
+            quantile_count in 0_usize..32,
+        ) {
+            let mut rng = SmallRng::seed_from_u64(seed);
+            let quantiles = random_summary_quantiles(quantile_count, &mut rng);
+
+            prop_assert_eq!(quantiles.len(), quantile_count);
+            for quantile in &quantiles {
+                prop_assert!((0.0..=1.0).contains(quantile));
+            }
+            for pair in quantiles.windows(2) {
+                prop_assert!(pair[0] <= pair[1]);
             }
         }
     }

--- a/lading_payload/src/opentelemetry/metric/templates.rs
+++ b/lading_payload/src/opentelemetry/metric/templates.rs
@@ -53,7 +53,7 @@ fn exponential_weighted_range<R: Rng + ?Sized>(rng: &mut R, min: u32, max: u32) 
 
     while current < max {
         if rng.random_bool(0.5) {
-            return rng.random_range(current..=current.min(max));
+            return rng.random_range(current..=current.saturating_add(step - 1).min(max));
         }
         current = (current + step).min(max);
         step *= 2;

--- a/lading_payload/src/opentelemetry/metric/templates.rs
+++ b/lading_payload/src/opentelemetry/metric/templates.rs
@@ -1,7 +1,7 @@
 use std::{cmp, rc::Rc};
 
 use opentelemetry_proto::tonic::{
-    common::v1::{InstrumentationScope, KeyValue},
+    common::v1::{AnyValue, InstrumentationScope, KeyValue, any_value},
     metrics::{
         self,
         v1::{
@@ -24,6 +24,8 @@ use crate::opentelemetry::common::{GeneratorError, TagGenerator, UNIQUE_TAG_RATI
 use crate::{Error, Generator, common::config::ConfRange, common::strings};
 
 pub(crate) type Pool = templates::Pool<ResourceMetrics, ResourceTemplateGenerator>;
+
+const POINT_INDEX_ATTRIBUTE_KEY: &str = "lading.point_index";
 
 #[derive(Clone, Copy, Debug)]
 pub(super) struct PointProfile {
@@ -109,8 +111,16 @@ fn scaled_unit(seed: u64, shift: u32, min: f64, max: f64) -> f64 {
     min + value * (max - min)
 }
 
-fn point_attributes(metadata: &[KeyValue]) -> Vec<KeyValue> {
-    metadata.iter().take(2).cloned().collect()
+fn point_attributes(metadata: &[KeyValue], point_index: usize) -> Vec<KeyValue> {
+    let mut attributes = Vec::with_capacity(metadata.len().min(2) + 1);
+    attributes.extend(metadata.iter().take(2).cloned());
+    attributes.push(KeyValue {
+        key: POINT_INDEX_ATTRIBUTE_KEY.to_string(),
+        value: Some(AnyValue {
+            value: Some(any_value::Value::StringValue(point_index.to_string())),
+        }),
+    });
+    attributes
 }
 
 struct Ndp(NumberDataPoint);
@@ -268,8 +278,8 @@ impl<'a> crate::SizedGenerator<'a> for MetricTemplateGenerator {
                 is_monotonic,
             }),
             Kind::Summary => {
-                let data_points = (0..total_data_points)
-                    .map(|_| {
+                let data_points = (0..total_data_points as usize)
+                    .map(|point_index| {
                         let quantiles =
                             random_summary_quantiles(rng.random_range(2_usize..=8), rng);
                         let quantile_values = quantiles
@@ -280,7 +290,7 @@ impl<'a> crate::SizedGenerator<'a> for MetricTemplateGenerator {
                             })
                             .collect::<Vec<_>>();
                         SummaryDataPoint {
-                            attributes: point_attributes(&metadata),
+                            attributes: point_attributes(&metadata, point_index),
                             start_time_unix_nano: 0,
                             time_unix_nano: 0,
                             count: 0,
@@ -296,8 +306,8 @@ impl<'a> crate::SizedGenerator<'a> for MetricTemplateGenerator {
                 aggregation_temporality,
             } => {
                 let data_points = (0..total_data_points as usize)
-                    .map(|_| {
-                        let attributes = point_attributes(&metadata);
+                    .map(|point_index| {
+                        let attributes = point_attributes(&metadata, point_index);
                         let profile = point_profile(rng.random());
                         let n_bounds = rng.random_range(4_usize..=16);
                         let bounds = histogram_bounds_from_profile(profile, n_bounds);
@@ -328,8 +338,8 @@ impl<'a> crate::SizedGenerator<'a> for MetricTemplateGenerator {
                 scale,
             } => {
                 let data_points = (0..total_data_points as usize)
-                    .map(|_| {
-                        let attributes = point_attributes(&metadata);
+                    .map(|point_index| {
+                        let attributes = point_attributes(&metadata, point_index);
                         let profile = point_profile(rng.random());
 
                         ExponentialHistogramDataPoint {


### PR DESCRIPTION
…m, and summary metrics

### What does this PR do?

Adds support for the remaining OTLP metrics (Exponential Histogram, Histogram, and Summary) in the correctness tests. 

### Motivation

Will be used to test whether these metric types are being properly handled by ADP in the Saluki repo when compared to the Agent. 

**Supports:**
- #https://github.com/DataDog/saluki/pull/1319
### Related issues

A list of issues either fixed, containing architectural discussions, otherwise relevant
for this Pull Request.

### Additional Notes

Anything else we should know when reviewing?

Listed below is some additional information for the metrics added (how they are constructed and how they are expected to behave): 

- [Histogram](https://opentelemetry.io/docs/specs/otel/metrics/data-model/#histogram)
- [Exponential Histogram](https://opentelemetry.io/docs/specs/otel/metrics/data-model/#exponentialhistogram)
- [Summary](https://opentelemetry.io/docs/specs/otel/metrics/data-model/#summary-legacy)