### PR TITLE
New tcp based network workload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   static log file and groups each second's worth of lines into a single block.
   In conjunction with block-based throttling, this enables realistic load
   patterns that replay the original log file's timing.
+- Added new generator/blackhole pair for tcp request-response workload.
 
 ## [0.31.2]
 ## Changed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1911,6 +1911,7 @@ dependencies = [
  "serde_qs",
  "serde_yaml",
  "sha2",
+ "socket2",
  "sysinfo",
  "tempfile",
  "thiserror 2.0.17",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3451,9 +3451,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.12"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "ring",
  "rustls-pki-types",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1887,9 +1887,11 @@ dependencies = [
  "lading-payload",
  "lading-signal",
  "lading-throttle",
+ "libc",
  "metrics",
  "metrics-exporter-prometheus",
  "metrics-util",
+ "mio",
  "nix 0.30.1",
  "num-traits",
  "num_cpus",
@@ -2237,6 +2239,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
 dependencies = [
  "libc",
+ "log",
  "wasi",
  "windows-sys 0.61.2",
 ]

--- a/lading/Cargo.toml
+++ b/lading/Cargo.toml
@@ -51,7 +51,9 @@ kube-core = { version = "2.0.0" }
 k8s-openapi = { version = "0.26.0", default-features = false, features = [
   "latest",
 ] }
+libc = "0.2"
 metrics = { workspace = true }
+mio = { version = "1", features = ["os-poll", "net"] }
 metrics-exporter-prometheus = { workspace = true }
 metrics-util = { workspace = true }
 nix = { version = "0.30", features = ["fs", "signal"] }

--- a/lading/Cargo.toml
+++ b/lading/Cargo.toml
@@ -52,6 +52,7 @@ k8s-openapi = { version = "0.26.0", default-features = false, features = [
   "latest",
 ] }
 libc = "0.2"
+socket2 = "0.6"
 metrics = { workspace = true }
 mio = { version = "1", features = ["os-poll", "net"] }
 metrics-exporter-prometheus = { workspace = true }

--- a/lading/src/bin/lading.rs
+++ b/lading/src/bin/lading.rs
@@ -543,11 +543,9 @@ async fn inner_main(
     //
     // GENERATOR
     //
-    let sample_period = Duration::from_millis(config.sample_period_milliseconds);
     for cfg in config.generator {
         let tgt_rcv = tgt_snd.subscribe();
-        let generator_server =
-            generator::Server::new(cfg, shutdown_watcher.clone(), sample_period)?;
+        let generator_server = generator::Server::new(cfg, shutdown_watcher.clone())?;
         gsrv_joinset.spawn(generator_server.run(tgt_rcv));
     }
 
@@ -566,8 +564,7 @@ async fn inner_main(
     // BLACKHOLE
     //
     for cfg in config.blackhole {
-        let blackhole_server =
-            blackhole::Server::new(cfg, shutdown_watcher.clone(), sample_period)?;
+        let blackhole_server = blackhole::Server::new(cfg, shutdown_watcher.clone())?;
         let _bsrv = tokio::spawn(async {
             match blackhole_server.run().await {
                 Ok(()) => debug!("blackhole shut down successfully"),

--- a/lading/src/bin/lading.rs
+++ b/lading/src/bin/lading.rs
@@ -543,9 +543,11 @@ async fn inner_main(
     //
     // GENERATOR
     //
+    let sample_period = Duration::from_millis(config.sample_period_milliseconds);
     for cfg in config.generator {
         let tgt_rcv = tgt_snd.subscribe();
-        let generator_server = generator::Server::new(cfg, shutdown_watcher.clone())?;
+        let generator_server =
+            generator::Server::new(cfg, shutdown_watcher.clone(), sample_period)?;
         gsrv_joinset.spawn(generator_server.run(tgt_rcv));
     }
 
@@ -564,7 +566,8 @@ async fn inner_main(
     // BLACKHOLE
     //
     for cfg in config.blackhole {
-        let blackhole_server = blackhole::Server::new(cfg, shutdown_watcher.clone())?;
+        let blackhole_server =
+            blackhole::Server::new(cfg, shutdown_watcher.clone(), sample_period)?;
         let _bsrv = tokio::spawn(async {
             match blackhole_server.run().await {
                 Ok(()) => debug!("blackhole shut down successfully"),

--- a/lading/src/bin/payloadtool.rs
+++ b/lading/src/bin/payloadtool.rs
@@ -486,6 +486,12 @@ fn check_generator(config: &generator::Config, args: &Args) -> Result<Option<Fin
             }
             unimplemented!("Kubernetes not supported")
         }
+        generator::Inner::TcpRr(_) => {
+            if args.fingerprint {
+                return Ok(None);
+            }
+            unimplemented!("TcpRr not supported")
+        }
         generator::Inner::TraceAgent(g) => {
             let total_bytes =
                 generator::trace_agent::validate_cache_size(g.maximum_prebuild_cache_size_bytes)

--- a/lading/src/blackhole.rs
+++ b/lading/src/blackhole.rs
@@ -156,9 +156,12 @@ impl Server {
     ) -> Result<Self, Error> {
         let server = match config.inner {
             Inner::Tcp(conf) => Self::Tcp(tcp::Tcp::new(config.general, &conf, shutdown)),
-            Inner::TcpRr(conf) => {
-                Self::TcpRr(tcp_rr::TcpRr::new(config.general, &conf, shutdown, sample_period))
-            }
+            Inner::TcpRr(conf) => Self::TcpRr(tcp_rr::TcpRr::new(
+                config.general,
+                &conf,
+                shutdown,
+                sample_period,
+            )),
             Inner::Datadog(conf) => {
                 Self::Datadog(datadog::Datadog::new(config.general, conf, shutdown))
             }

--- a/lading/src/blackhole.rs
+++ b/lading/src/blackhole.rs
@@ -15,6 +15,7 @@ pub mod otlp;
 pub mod splunk_hec;
 pub mod sqs;
 pub mod tcp;
+pub mod tcp_rr;
 pub mod udp;
 pub mod unix_datagram;
 pub mod unix_stream;
@@ -25,6 +26,9 @@ pub enum Error {
     /// See [`crate::blackhole::tcp::Error`] for details.
     #[error(transparent)]
     Tcp(tcp::Error),
+    /// See [`crate::blackhole::tcp_rr::Error`] for details.
+    #[error(transparent)]
+    TcpRr(tcp_rr::Error),
     /// See [`crate::blackhole::datadog::Error`] for details.
     #[error(transparent)]
     Datadog(datadog::Error),
@@ -83,6 +87,8 @@ pub struct General {
 pub enum Inner {
     /// See [`crate::blackhole::tcp::Config`] for details.
     Tcp(tcp::Config),
+    /// See [`crate::blackhole::tcp_rr::Config`] for details.
+    TcpRr(tcp_rr::Config),
     /// See [`crate::blackhole::datadog::Config`] for details.
     Datadog(datadog::Config),
     /// See [`crate::blackhole::datadog_stateful_logs::Config`] for details.
@@ -111,6 +117,8 @@ pub enum Inner {
 pub enum Server {
     /// See [`crate::blackhole::tcp::Tcp`] for details.
     Tcp(tcp::Tcp),
+    /// See [`crate::blackhole::tcp_rr::TcpRr`] for details.
+    TcpRr(tcp_rr::TcpRr),
     /// See [`crate::blackhole::datadog::Datadog`] for details.
     Datadog(datadog::Datadog),
     /// See [`crate::blackhole::datadog_stateful_logs::DatadogStatefulLogs`] for details.
@@ -141,9 +149,16 @@ impl Server {
     ///
     /// Function will return an error if the underlying sub-server creation
     /// signals error.
-    pub fn new(config: Config, shutdown: lading_signal::Watcher) -> Result<Self, Error> {
+    pub fn new(
+        config: Config,
+        shutdown: lading_signal::Watcher,
+        sample_period: std::time::Duration,
+    ) -> Result<Self, Error> {
         let server = match config.inner {
             Inner::Tcp(conf) => Self::Tcp(tcp::Tcp::new(config.general, &conf, shutdown)),
+            Inner::TcpRr(conf) => {
+                Self::TcpRr(tcp_rr::TcpRr::new(config.general, &conf, shutdown, sample_period))
+            }
             Inner::Datadog(conf) => {
                 Self::Datadog(datadog::Datadog::new(config.general, conf, shutdown))
             }
@@ -185,6 +200,7 @@ impl Server {
     pub async fn run(self) -> Result<(), Error> {
         match self {
             Server::Tcp(inner) => inner.run().await.map_err(Error::Tcp),
+            Server::TcpRr(inner) => inner.run().await.map_err(Error::TcpRr),
             Server::Datadog(inner) => inner.run().await.map_err(Error::Datadog),
             Server::DatadogStatefulLogs(inner) => {
                 inner.run().await.map_err(Error::DatadogStatefulLogs)

--- a/lading/src/blackhole.rs
+++ b/lading/src/blackhole.rs
@@ -149,19 +149,10 @@ impl Server {
     ///
     /// Function will return an error if the underlying sub-server creation
     /// signals error.
-    pub fn new(
-        config: Config,
-        shutdown: lading_signal::Watcher,
-        sample_period: std::time::Duration,
-    ) -> Result<Self, Error> {
+    pub fn new(config: Config, shutdown: lading_signal::Watcher) -> Result<Self, Error> {
         let server = match config.inner {
             Inner::Tcp(conf) => Self::Tcp(tcp::Tcp::new(config.general, &conf, shutdown)),
-            Inner::TcpRr(conf) => Self::TcpRr(tcp_rr::TcpRr::new(
-                config.general,
-                &conf,
-                shutdown,
-                sample_period,
-            )),
+            Inner::TcpRr(conf) => Self::TcpRr(tcp_rr::TcpRr::new(config.general, &conf, shutdown)),
             Inner::Datadog(conf) => {
                 Self::Datadog(datadog::Datadog::new(config.general, conf, shutdown))
             }

--- a/lading/src/blackhole/tcp_rr.rs
+++ b/lading/src/blackhole/tcp_rr.rs
@@ -15,6 +15,7 @@
 
 use std::io::{Read, Write};
 use std::net::SocketAddr;
+use std::num::{NonZeroU16, NonZeroUsize};
 use std::os::fd::{AsRawFd, FromRawFd};
 use std::sync::atomic::Ordering::Relaxed;
 use std::sync::{Arc, Barrier};
@@ -31,12 +32,14 @@ use crate::neper::flow::{self, Action, Flow, FlowMap};
 use crate::neper::metrics::{self, ThreadMetrics};
 use crate::neper::thread;
 
-fn default_one() -> u16 {
-    1
+const fn default_nonzero_u16() -> NonZeroU16 {
+    // Safety: 1 != 0
+    unsafe { NonZeroU16::new_unchecked(1) }
 }
 
-fn default_one_usize() -> usize {
-    1
+const fn default_nonzero_usize() -> NonZeroUsize {
+    // Safety: 1 != 0
+    unsafe { NonZeroUsize::new_unchecked(1) }
 }
 
 fn default_control_port() -> u16 {
@@ -58,14 +61,14 @@ pub struct Config {
     pub control_port: u16,
     /// Number of OS server threads. Default 1. When > 1, uses `SO_REUSEPORT`
     /// with an eBPF program for load balancing
-    #[serde(default = "default_one")]
-    pub threads: u16,
+    #[serde(default = "default_nonzero_u16")]
+    pub threads: NonZeroU16,
     /// Bytes to read per request. Default 1.
-    #[serde(default = "default_one_usize")]
-    pub request_size: usize,
+    #[serde(default = "default_nonzero_usize")]
+    pub request_size: NonZeroUsize,
     /// Bytes to send per response. Default 1.
-    #[serde(default = "default_one_usize")]
-    pub response_size: usize,
+    #[serde(default = "default_nonzero_usize")]
+    pub response_size: NonZeroUsize,
     /// Whether to set `TCP_NODELAY` on accepted connections. Default true.
     #[serde(default = "default_true")]
     pub no_delay: bool,
@@ -144,7 +147,7 @@ impl TcpRr {
     /// Panics if the ready-barrier tokio task is cancelled.
     pub async fn run(self) -> Result<(), Error> {
         let shutdown_flag = thread::new_shutdown_flag();
-        let num_threads = self.config.threads;
+        let num_threads = self.config.threads.get();
 
         let thread_metrics = Arc::new(
             (0..num_threads)
@@ -178,8 +181,8 @@ impl TcpRr {
         let mut handles = Vec::with_capacity(num_threads as usize);
         for i in 0..num_threads {
             let binding_addr = self.config.binding_addr;
-            let request_size = self.config.request_size;
-            let response_size = self.config.response_size;
+            let request_size = self.config.request_size.get();
+            let response_size = self.config.response_size.get();
             let no_delay = self.config.no_delay;
             let flag = Arc::clone(&shutdown_flag);
             let tm = Arc::clone(&thread_metrics);

--- a/lading/src/blackhole/tcp_rr.rs
+++ b/lading/src/blackhole/tcp_rr.rs
@@ -17,8 +17,8 @@ use std::io::{Read, Write};
 use std::net::SocketAddr;
 use std::num::{NonZeroU16, NonZeroUsize};
 use std::os::fd::{AsRawFd, FromRawFd};
+use std::sync::Arc;
 use std::sync::atomic::Ordering::Relaxed;
-use std::sync::{Arc, Barrier};
 use std::time::Duration;
 
 use mio::net::TcpStream;
@@ -163,10 +163,13 @@ impl TcpRr {
             })
         };
 
-        // BPF barrier: thread 0 must bind first to attach BPF before other
-        // threads join the SO_REUSEPORT group.
-        let bpf_barrier = if num_threads > 1 {
-            Some(Arc::new(Barrier::new(num_threads as usize)))
+        // Pre-build thread 0's listener here so the BPF program is attached
+        // to the reuseport group before any other thread calls bind(). This
+        // removes the need for a cross-thread BPF barrier — if the bind fails
+        // or panics, it propagates as an error directly from this task.
+        let binding_addr = SocketAddr::new(self.config.addr, self.config.data_port);
+        let thread0_listener = if num_threads > 1 {
+            Some(create_listener(0, num_threads, binding_addr))
         } else {
             None
         };
@@ -178,26 +181,26 @@ impl TcpRr {
         let (ready_tx, mut ready_rx) = tokio::sync::mpsc::unbounded_channel::<()>();
 
         let mut handles = Vec::with_capacity(num_threads as usize);
+        let mut thread0_listener = thread0_listener;
         for i in 0..num_threads {
-            let binding_addr = SocketAddr::new(self.config.addr, self.config.data_port);
             let request_size = self.config.request_size.get();
             let response_size = self.config.response_size.get();
             let no_delay = self.config.no_delay;
             let flag = Arc::clone(&shutdown_flag);
             let tm = Arc::clone(&thread_metrics);
-            let bpf_barrier = bpf_barrier.clone();
+            let prebuilt = if i == 0 { thread0_listener.take() } else { None };
             let tx = ready_tx.clone();
             let handle = thread::spawn_named(&format!("tcp_rr-server-{i}"), move || {
                 server_thread_main(
                     i,
                     num_threads,
                     binding_addr,
+                    prebuilt,
                     request_size,
                     response_size,
                     no_delay,
                     &flag,
                     &tm[i as usize],
-                    bpf_barrier.as_deref(),
                     tx,
                 );
             });
@@ -382,30 +385,18 @@ fn server_thread_main(
     thread_index: u16,
     num_threads: u16,
     binding_addr: SocketAddr,
+    prebuilt_listener: Option<std::net::TcpListener>,
     request_size: usize,
     response_size: usize,
     no_delay: bool,
     shutdown_flag: &std::sync::atomic::AtomicBool,
     metrics: &ThreadMetrics,
-    bpf_barrier: Option<&Barrier>,
     ready_tx: tokio::sync::mpsc::UnboundedSender<()>,
 ) {
-    // Thread 0 must bind first (to attach BPF before others join the
-    // reuseport group). Non-zero threads wait at the BPF barrier first.
-    if let Some(barrier) = bpf_barrier
-        && thread_index != 0
-    {
-        barrier.wait();
-    }
-
-    let std_listener = create_listener(thread_index, num_threads, binding_addr);
-
-    // Thread 0 signals the BPF barrier after binding so others can proceed.
-    if let Some(barrier) = bpf_barrier
-        && thread_index == 0
-    {
-        barrier.wait();
-    }
+    // Thread 0 uses the pre-built listener (with BPF already attached);
+    // others bind their own sockets that join the existing reuseport group.
+    let std_listener = prebuilt_listener
+        .unwrap_or_else(|| create_listener(thread_index, num_threads, binding_addr));
 
     // Signal that this thread's listener is bound and ready. If this send
     // fails the receiver has gone away (blackhole is shutting down).

--- a/lading/src/blackhole/tcp_rr.rs
+++ b/lading/src/blackhole/tcp_rr.rs
@@ -16,7 +16,7 @@
 use std::io::{Read, Write};
 use std::net::SocketAddr;
 use std::num::{NonZeroU16, NonZeroUsize};
-use std::os::fd::{AsRawFd, FromRawFd};
+use std::os::fd::AsRawFd;
 use std::sync::Arc;
 use std::sync::atomic::Ordering::Relaxed;
 use std::time::Duration;
@@ -50,6 +50,10 @@ fn default_data_port() -> u16 {
     12867
 }
 
+fn default_backlog() -> i32 {
+    1024
+}
+
 const fn default_true() -> bool {
     true
 }
@@ -79,6 +83,10 @@ pub struct Config {
     /// Whether to set `TCP_NODELAY` on accepted connections. Default true.
     #[serde(default = "default_true")]
     pub no_delay: bool,
+    /// Listener backlog (pending-connection queue length) passed to `listen(2)`.
+    /// Default 1024.
+    #[serde(default = "default_backlog")]
+    pub backlog: i32,
 }
 
 #[derive(thiserror::Error, Debug)]
@@ -169,7 +177,7 @@ impl TcpRr {
         // or panics, it propagates as an error directly from this task.
         let binding_addr = SocketAddr::new(self.config.addr, self.config.data_port);
         let thread0_listener = if num_threads > 1 {
-            Some(create_listener(0, num_threads, binding_addr))
+            Some(create_listener(0, num_threads, binding_addr, self.config.backlog))
         } else {
             None
         };
@@ -186,6 +194,7 @@ impl TcpRr {
             let request_size = self.config.request_size.get();
             let response_size = self.config.response_size.get();
             let no_delay = self.config.no_delay;
+            let backlog = self.config.backlog;
             let flag = Arc::clone(&shutdown_flag);
             let tm = Arc::clone(&thread_metrics);
             let prebuilt = if i == 0 {
@@ -200,6 +209,7 @@ impl TcpRr {
                     num_threads,
                     binding_addr,
                     prebuilt,
+                    backlog,
                     request_size,
                     response_size,
                     no_delay,
@@ -284,37 +294,32 @@ impl TcpRr {
 
 /// Create a listener socket. When `num_threads` > 1, sets `SO_REUSEPORT`
 /// and (for thread 0) attaches the reuseport eBPF program.
-#[allow(clippy::cast_possible_truncation)]
 fn create_listener(
     thread_index: u16,
     num_threads: u16,
     binding_addr: SocketAddr,
+    backlog: i32,
 ) -> std::net::TcpListener {
-    // Create socket manually to set SO_REUSEPORT before bind.
     let domain = if binding_addr.is_ipv4() {
-        libc::AF_INET
+        socket2::Domain::IPV4
     } else {
-        libc::AF_INET6
+        socket2::Domain::IPV6
     };
-    let fd = unsafe { libc::socket(domain, libc::SOCK_STREAM, 0) };
-    assert!(fd >= 0, "failed to create socket");
-
-    // Set nonblocking (SOCK_NONBLOCK is Linux-only).
-    let flags = unsafe { libc::fcntl(fd, libc::F_GETFL) };
-    unsafe { libc::fcntl(fd, libc::F_SETFL, flags | libc::O_NONBLOCK) };
-
-    // Close-on-exec to prevent fd leaks to child processes.
-    unsafe { libc::fcntl(fd, libc::F_SETFD, libc::FD_CLOEXEC) };
-
-    set_sock_opt(fd, libc::SOL_SOCKET, libc::SO_REUSEADDR, 1);
+    let socket = socket2::Socket::new(domain, socket2::Type::STREAM, Some(socket2::Protocol::TCP))
+        .expect("failed to create socket");
+    socket.set_nonblocking(true).expect("failed to set nonblocking");
+    socket.set_cloexec(true).expect("failed to set close-on-exec");
+    socket.set_reuse_address(true).expect("failed to set SO_REUSEADDR");
 
     if num_threads > 1 {
-        set_sock_opt(fd, libc::SOL_SOCKET, libc::SO_REUSEPORT, 1);
+        socket
+            .set_reuse_port(true)
+            .expect("failed to set SO_REUSEPORT");
 
         if thread_index == 0 {
             match bpf::load_reuseport_ebpf(u32::from(num_threads)) {
                 Ok(prog) => {
-                    if let Err(e) = bpf::attach_reuseport_ebpf(fd, &prog) {
+                    if let Err(e) = bpf::attach_reuseport_ebpf(socket.as_raw_fd(), &prog) {
                         warn!("failed to attach reuseport eBPF: {e}, falling back to kernel hash");
                     }
                 }
@@ -325,63 +330,12 @@ fn create_listener(
         }
     }
 
-    let (sockaddr, socklen) = socket_addr_to_raw(&binding_addr);
-    let ret = unsafe { libc::bind(fd, (&raw const sockaddr).cast::<libc::sockaddr>(), socklen) };
-    assert!(
-        ret == 0,
-        "failed to bind to {binding_addr}: {}",
-        std::io::Error::last_os_error()
-    );
+    socket
+        .bind(&binding_addr.into())
+        .unwrap_or_else(|e| panic!("failed to bind to {binding_addr}: {e}"));
+    socket.listen(backlog).expect("failed to listen");
 
-    let ret = unsafe { libc::listen(fd, 1024) };
-    assert!(
-        ret == 0,
-        "failed to listen: {}",
-        std::io::Error::last_os_error()
-    );
-
-    unsafe { std::net::TcpListener::from_raw_fd(fd) }
-}
-
-#[allow(clippy::cast_possible_truncation)]
-fn set_sock_opt(fd: libc::c_int, level: libc::c_int, optname: libc::c_int, val: libc::c_int) {
-    unsafe {
-        libc::setsockopt(
-            fd,
-            level,
-            optname,
-            (&raw const val).cast::<libc::c_void>(),
-            std::mem::size_of::<libc::c_int>() as libc::socklen_t,
-        );
-    }
-}
-
-#[allow(clippy::cast_possible_truncation)]
-fn socket_addr_to_raw(addr: &SocketAddr) -> (libc::sockaddr_storage, libc::socklen_t) {
-    let mut storage: libc::sockaddr_storage = unsafe { std::mem::zeroed() };
-    let len = match addr {
-        SocketAddr::V4(a) => {
-            let sin = unsafe { &mut *(&raw mut storage).cast::<libc::sockaddr_in>() };
-            sin.sin_family = libc::AF_INET as libc::sa_family_t;
-            sin.sin_port = a.port().to_be();
-            sin.sin_addr = libc::in_addr {
-                s_addr: u32::from_ne_bytes(a.ip().octets()),
-            };
-            std::mem::size_of::<libc::sockaddr_in>() as libc::socklen_t
-        }
-        SocketAddr::V6(a) => {
-            let sin6 = unsafe { &mut *(&raw mut storage).cast::<libc::sockaddr_in6>() };
-            sin6.sin6_family = libc::AF_INET6 as libc::sa_family_t;
-            sin6.sin6_port = a.port().to_be();
-            sin6.sin6_addr = libc::in6_addr {
-                s6_addr: a.ip().octets(),
-            };
-            sin6.sin6_flowinfo = a.flowinfo();
-            sin6.sin6_scope_id = a.scope_id();
-            std::mem::size_of::<libc::sockaddr_in6>() as libc::socklen_t
-        }
-    };
-    (storage, len)
+    socket.into()
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -390,6 +344,7 @@ fn server_thread_main(
     num_threads: u16,
     binding_addr: SocketAddr,
     prebuilt_listener: Option<std::net::TcpListener>,
+    backlog: i32,
     request_size: usize,
     response_size: usize,
     no_delay: bool,
@@ -400,7 +355,7 @@ fn server_thread_main(
     // Thread 0 uses the pre-built listener (with BPF already attached);
     // others bind their own sockets that join the existing reuseport group.
     let std_listener = prebuilt_listener
-        .unwrap_or_else(|| create_listener(thread_index, num_threads, binding_addr));
+        .unwrap_or_else(|| create_listener(thread_index, num_threads, binding_addr, backlog));
 
     // Signal that this thread's listener is bound and ready. If this send
     // fails the receiver has gone away (blackhole is shutting down).
@@ -463,15 +418,12 @@ fn server_thread_main(
     }
 }
 
-/// Set `TCP_NODELAY` on a mio [`TcpStream`] using the raw fd.
+/// Set `TCP_NODELAY` on a mio [`TcpStream`] via a borrowed `socket2::SockRef`.
 fn set_nodelay_mio(stream: &TcpStream, no_delay: bool) {
-    let fd = stream.as_raw_fd();
-    set_sock_opt(
-        fd,
-        libc::IPPROTO_TCP,
-        libc::TCP_NODELAY,
-        i32::from(no_delay),
-    );
+    let sock = socket2::SockRef::from(stream);
+    if let Err(e) = sock.set_tcp_nodelay(no_delay) {
+        trace!("failed to set TCP_NODELAY: {e}");
+    }
 }
 
 fn handle_server_event(

--- a/lading/src/blackhole/tcp_rr.rs
+++ b/lading/src/blackhole/tcp_rr.rs
@@ -175,7 +175,12 @@ impl TcpRr {
         // or panics, it propagates as an error directly from this task.
         let binding_addr = SocketAddr::new(self.config.addr, self.config.data_port);
         let thread0_listener = if num_threads > 1 {
-            Some(create_listener(0, num_threads, binding_addr, self.config.backlog))
+            Some(create_listener(
+                0,
+                num_threads,
+                binding_addr,
+                self.config.backlog,
+            ))
         } else {
             None
         };
@@ -305,9 +310,15 @@ fn create_listener(
     };
     let socket = socket2::Socket::new(domain, socket2::Type::STREAM, Some(socket2::Protocol::TCP))
         .expect("failed to create socket");
-    socket.set_nonblocking(true).expect("failed to set nonblocking");
-    socket.set_cloexec(true).expect("failed to set close-on-exec");
-    socket.set_reuse_address(true).expect("failed to set SO_REUSEADDR");
+    socket
+        .set_nonblocking(true)
+        .expect("failed to set nonblocking");
+    socket
+        .set_cloexec(true)
+        .expect("failed to set close-on-exec");
+    socket
+        .set_reuse_address(true)
+        .expect("failed to set SO_REUSEADDR");
 
     if num_threads > 1 {
         socket

--- a/lading/src/blackhole/tcp_rr.rs
+++ b/lading/src/blackhole/tcp_rr.rs
@@ -32,14 +32,12 @@ use crate::neper::flow::{self, Action, Flow, FlowMap};
 use crate::neper::metrics::{self, ThreadMetrics};
 use crate::neper::thread;
 
-const fn default_nonzero_u16() -> NonZeroU16 {
-    // Safety: 1 != 0
-    unsafe { NonZeroU16::new_unchecked(1) }
+fn default_nonzero_u16() -> NonZeroU16 {
+    NonZeroU16::new(1).expect("1 is nonzero")
 }
 
-const fn default_nonzero_usize() -> NonZeroUsize {
-    // Safety: 1 != 0
-    unsafe { NonZeroUsize::new_unchecked(1) }
+fn default_nonzero_usize() -> NonZeroUsize {
+    NonZeroUsize::new(1).expect("1 is nonzero")
 }
 
 fn default_control_port() -> u16 {

--- a/lading/src/blackhole/tcp_rr.rs
+++ b/lading/src/blackhole/tcp_rr.rs
@@ -46,6 +46,10 @@ fn default_control_port() -> u16 {
     12866
 }
 
+fn default_data_port() -> u16 {
+    12867
+}
+
 const fn default_true() -> bool {
     true
 }
@@ -54,8 +58,11 @@ const fn default_true() -> bool {
 #[serde(deny_unknown_fields)]
 /// Configuration for the `tcp_rr` blackhole.
 pub struct Config {
-    /// Address to bind the listener on.
-    pub binding_addr: SocketAddr,
+    /// IP address to bind on.
+    pub addr: std::net::IpAddr,
+    /// Data port for flow connections. Default 12867.
+    #[serde(default = "default_data_port")]
+    pub data_port: u16,
     /// Control port for startup synchronization with the generator. Default 12866.
     #[serde(default = "default_control_port")]
     pub control_port: u16,
@@ -180,7 +187,7 @@ impl TcpRr {
 
         let mut handles = Vec::with_capacity(num_threads as usize);
         for i in 0..num_threads {
-            let binding_addr = self.config.binding_addr;
+            let binding_addr = SocketAddr::new(self.config.addr, self.config.data_port);
             let request_size = self.config.request_size.get();
             let response_size = self.config.response_size.get();
             let no_delay = self.config.no_delay;
@@ -212,7 +219,7 @@ impl TcpRr {
 
         // All data listeners are up. Open control port so the generator
         // can connect and know we're ready.
-        let control_addr = SocketAddr::new(self.config.binding_addr.ip(), self.config.control_port);
+        let control_addr = SocketAddr::new(self.config.addr, self.config.control_port);
         let control_listener = std::net::TcpListener::bind(control_addr)
             .map_err(|source| Error::Bind { addr: control_addr, source: Box::new(source) })?;
         info!("control port listening on {control_addr}, waiting for generator");

--- a/lading/src/blackhole/tcp_rr.rs
+++ b/lading/src/blackhole/tcp_rr.rs
@@ -13,15 +13,16 @@
 //! `bytes_received`: Request bytes read
 //! `bytes_written`: Response bytes sent
 
-use std::io::{Read, Write};
-use std::net::SocketAddr;
+use std::io::{ErrorKind, Read, Write};
+use std::net::{self, IpAddr, SocketAddr};
 use std::num::{NonZeroU16, NonZeroUsize};
 use std::os::fd::AsRawFd;
 use std::sync::Arc;
-use std::sync::atomic::Ordering::Relaxed;
+use std::sync::atomic::{AtomicBool, Ordering::Relaxed};
 use std::time::Duration;
 
-use mio::net::TcpStream;
+use mio::net::{TcpListener, TcpStream};
+use tokio::sync::mpsc;
 use mio::{Events, Interest, Poll, Token};
 use serde::{Deserialize, Serialize};
 use tracing::{info, trace, warn};
@@ -61,7 +62,7 @@ const fn default_true() -> bool {
 /// Configuration for the `tcp_rr` blackhole.
 pub struct Config {
     /// IP address to bind on.
-    pub addr: std::net::IpAddr,
+    pub addr: IpAddr,
     /// Data port for flow connections. Default 12867.
     #[serde(default = "default_data_port")]
     pub data_port: u16,
@@ -189,7 +190,7 @@ impl TcpRr {
         // If a thread panics before signaling, its sender drops; once all
         // senders are gone, recv() returns None and we detect the failure
         // instead of hanging forever.
-        let (ready_tx, mut ready_rx) = tokio::sync::mpsc::unbounded_channel::<()>();
+        let (ready_tx, mut ready_rx) = mpsc::unbounded_channel::<()>();
 
         let mut handles = Vec::with_capacity(num_threads as usize);
         let mut thread0_listener = thread0_listener;
@@ -240,7 +241,7 @@ impl TcpRr {
         // can connect and know we're ready.
         let control_addr = SocketAddr::new(self.config.addr, self.config.control_port);
         let control_listener =
-            std::net::TcpListener::bind(control_addr).map_err(|source| Error::Bind {
+            net::TcpListener::bind(control_addr).map_err(|source| Error::Bind {
                 addr: control_addr,
                 source: Box::new(source),
             })?;
@@ -270,7 +271,7 @@ impl TcpRr {
                     generator_connected = true;
                     break;
                 }
-                Err(ref e) if e.kind() == std::io::ErrorKind::WouldBlock => {
+                Err(ref e) if e.kind() == ErrorKind::WouldBlock => {
                     std::thread::sleep(Duration::from_millis(100));
                 }
                 Err(e) => {
@@ -302,7 +303,7 @@ fn create_listener(
     num_threads: u16,
     binding_addr: SocketAddr,
     backlog: i32,
-) -> std::net::TcpListener {
+) -> net::TcpListener {
     let domain = if binding_addr.is_ipv4() {
         socket2::Domain::IPV4
     } else {
@@ -352,14 +353,14 @@ fn server_thread_main(
     thread_index: u16,
     num_threads: u16,
     binding_addr: SocketAddr,
-    prebuilt_listener: Option<std::net::TcpListener>,
+    prebuilt_listener: Option<net::TcpListener>,
     backlog: i32,
     request_size: usize,
     response_size: usize,
     no_delay: bool,
-    shutdown_flag: &std::sync::atomic::AtomicBool,
+    shutdown_flag: &AtomicBool,
     metrics: &ThreadMetrics,
-    ready_tx: tokio::sync::mpsc::UnboundedSender<()>,
+    ready_tx: mpsc::UnboundedSender<()>,
 ) {
     // Thread 0 uses the pre-built listener (with BPF already attached);
     // others bind their own sockets that join the existing reuseport group.
@@ -371,7 +372,7 @@ fn server_thread_main(
     let _ = ready_tx.send(());
     drop(ready_tx);
 
-    let mut listener = mio::net::TcpListener::from_std(std_listener);
+    let mut listener = TcpListener::from_std(std_listener);
     let mut poll = Poll::new().expect("failed to create mio::Poll");
     let mut events = Events::with_capacity(256);
 
@@ -409,7 +410,7 @@ fn server_thread_main(
                             });
                             metrics.connections_accepted.add(1);
                         }
-                        Err(ref e) if e.kind() == std::io::ErrorKind::WouldBlock => break,
+                        Err(ref e) if e.kind() == ErrorKind::WouldBlock => break,
                         Err(e) => {
                             trace!("accept error: {e}");
                         }
@@ -458,7 +459,7 @@ fn handle_server_event(
                         Action::Continue
                     }
                 }
-                Err(e) if e.kind() == std::io::ErrorKind::WouldBlock => Action::Continue,
+                Err(e) if e.kind() == ErrorKind::WouldBlock => Action::Continue,
                 Err(e) => {
                     trace!("read error: {e}");
                     Action::Remove
@@ -480,7 +481,7 @@ fn handle_server_event(
                         Action::Continue
                     }
                 }
-                Err(e) if e.kind() == std::io::ErrorKind::WouldBlock => Action::Continue,
+                Err(e) if e.kind() == ErrorKind::WouldBlock => Action::Continue,
                 Err(e) => {
                     trace!("write error: {e}");
                     Action::Remove

--- a/lading/src/blackhole/tcp_rr.rs
+++ b/lading/src/blackhole/tcp_rr.rs
@@ -188,7 +188,11 @@ impl TcpRr {
             let no_delay = self.config.no_delay;
             let flag = Arc::clone(&shutdown_flag);
             let tm = Arc::clone(&thread_metrics);
-            let prebuilt = if i == 0 { thread0_listener.take() } else { None };
+            let prebuilt = if i == 0 {
+                thread0_listener.take()
+            } else {
+                None
+            };
             let tx = ready_tx.clone();
             let handle = thread::spawn_named(&format!("tcp_rr-server-{i}"), move || {
                 server_thread_main(

--- a/lading/src/blackhole/tcp_rr.rs
+++ b/lading/src/blackhole/tcp_rr.rs
@@ -150,6 +150,7 @@ impl TcpRr {
     /// # Panics
     ///
     /// Panics if the ready-barrier tokio task is cancelled.
+    #[allow(clippy::too_many_lines)]
     pub async fn run(self) -> Result<(), Error> {
         let shutdown_flag = thread::new_shutdown_flag();
         let num_threads = self.config.threads.get();

--- a/lading/src/blackhole/tcp_rr.rs
+++ b/lading/src/blackhole/tcp_rr.rs
@@ -117,8 +117,6 @@ enum ServerState {
 
 const LISTENER_TOKEN: Token = Token(0);
 
-
-
 impl TcpRr {
     /// Create a new [`TcpRr`] blackhole instance.
     #[must_use]
@@ -215,26 +213,63 @@ impl TcpRr {
         // Wait for all data threads to finish binding.
         // Use spawn_blocking so we don't block the tokio runtime.
         let rb = Arc::clone(&ready_barrier);
-        tokio::task::spawn_blocking(move || rb.wait()).await.expect("ready barrier join failed");
+        tokio::task::spawn_blocking(move || rb.wait())
+            .await
+            .expect("ready barrier join failed");
 
         // All data listeners are up. Open control port so the generator
         // can connect and know we're ready.
         let control_addr = SocketAddr::new(self.config.addr, self.config.control_port);
-        let control_listener = std::net::TcpListener::bind(control_addr)
-            .map_err(|source| Error::Bind { addr: control_addr, source: Box::new(source) })?;
+        let control_listener =
+            std::net::TcpListener::bind(control_addr).map_err(|source| Error::Bind {
+                addr: control_addr,
+                source: Box::new(source),
+            })?;
+        control_listener
+            .set_nonblocking(true)
+            .expect("failed to set control listener nonblocking");
         info!("control port listening on {control_addr}, waiting for generator");
-        let control_listener_clone = control_listener;
-        let (_conn, peer) = tokio::task::spawn_blocking(move || control_listener_clone.accept())
-            .await
-            .expect("control accept join failed")
-            .map_err(|source| Error::Bind { addr: control_addr, source: Box::new(source) })?;
-        info!("generator connected from {peer}, data threads running");
-
-        self.shutdown.recv().await;
-        info!("shutdown signal received");
-        shutdown_flag.store(true, Relaxed);
 
         handles.push(metrics_handle);
+
+        // Accept with shutdown awareness: poll accept in a loop.
+        let flag = Arc::clone(&shutdown_flag);
+        let shutdown_clone = self.shutdown.clone();
+        tokio::spawn(async move {
+            shutdown_clone.recv().await;
+            flag.store(true, Relaxed);
+        });
+        let mut generator_connected = false;
+        loop {
+            if shutdown_flag.load(Relaxed) {
+                info!("shutdown before generator connected");
+                break;
+            }
+            match control_listener.accept() {
+                Ok((_conn, peer)) => {
+                    info!("generator connected from {peer}, data threads running");
+                    generator_connected = true;
+                    break;
+                }
+                Err(ref e) if e.kind() == std::io::ErrorKind::WouldBlock => {
+                    std::thread::sleep(Duration::from_millis(100));
+                }
+                Err(e) => {
+                    return Err(Error::Bind {
+                        addr: control_addr,
+                        source: Box::new(e),
+                    });
+                }
+            }
+        }
+        drop(control_listener);
+
+        if generator_connected {
+            self.shutdown.recv().await;
+            info!("shutdown signal received");
+        }
+        shutdown_flag.store(true, Relaxed);
+
         thread::join_all(handles).map_err(|()| Error::ThreadPanicked)?;
 
         Ok(())

--- a/lading/src/blackhole/tcp_rr.rs
+++ b/lading/src/blackhole/tcp_rr.rs
@@ -272,7 +272,7 @@ impl TcpRr {
                     break;
                 }
                 Err(ref e) if e.kind() == ErrorKind::WouldBlock => {
-                    std::thread::sleep(Duration::from_millis(100));
+                    tokio::time::sleep(Duration::from_millis(100)).await;
                 }
                 Err(e) => {
                     return Err(Error::Bind {

--- a/lading/src/blackhole/tcp_rr.rs
+++ b/lading/src/blackhole/tcp_rr.rs
@@ -1,0 +1,442 @@
+//! TCP request/response (`tcp_rr`) blackhole — the server side.
+//!
+//! Listens for incoming connections and, for each flow, reads a fixed-size
+//! request then writes a fixed-size response, repeating until the flow closes
+//! or lading shuts down.
+//!
+//! ## Metrics
+//!
+//! `connections_accepted`: Incoming connections accepted
+//! `requests_received`: Completed request reads
+//! `responses_sent`: Completed response writes
+//! `bytes_received`: Request bytes read
+//! `bytes_written`: Response bytes sent
+
+use std::io::{Read, Write};
+use std::net::SocketAddr;
+use std::os::fd::{AsRawFd, FromRawFd};
+use std::sync::atomic::Ordering::Relaxed;
+use std::sync::{Arc, Barrier};
+use std::time::Duration;
+
+use mio::net::TcpStream;
+use mio::{Events, Interest, Poll, Token};
+use serde::{Deserialize, Serialize};
+use tracing::{info, trace, warn};
+
+use super::General;
+use crate::neper::bpf;
+use crate::neper::flow::{self, Action, Flow, FlowMap};
+use crate::neper::metrics::{self, ThreadMetrics};
+use crate::neper::thread;
+
+fn default_one() -> u16 {
+    1
+}
+
+fn default_one_usize() -> usize {
+    1
+}
+
+const fn default_true() -> bool {
+    true
+}
+
+#[derive(Debug, Deserialize, Serialize, Clone, Copy, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+/// Configuration for the `tcp_rr` blackhole.
+pub struct Config {
+    /// Address to bind the listener on.
+    pub binding_addr: SocketAddr,
+    /// Number of OS server threads. Default 1. When > 1, uses `SO_REUSEPORT`
+    /// with an eBPF program for load balancing
+    #[serde(default = "default_one")]
+    pub threads: u16,
+    /// Bytes to read per request. Default 1.
+    #[serde(default = "default_one_usize")]
+    pub request_size: usize,
+    /// Bytes to send per response. Default 1.
+    #[serde(default = "default_one_usize")]
+    pub response_size: usize,
+    /// Whether to set `TCP_NODELAY` on accepted connections. Default true.
+    #[serde(default = "default_true")]
+    pub no_delay: bool,
+}
+
+#[derive(thiserror::Error, Debug)]
+/// Errors produced by [`TcpRr`].
+pub enum Error {
+    /// IO error
+    #[error(transparent)]
+    Io(#[from] std::io::Error),
+    /// Error binding TCP listener
+    #[error("Failed to bind TCP listener to {addr}: {source}")]
+    Bind {
+        /// Binding address
+        addr: SocketAddr,
+        /// Underlying IO error
+        #[source]
+        source: Box<std::io::Error>,
+    },
+    /// Worker thread panicked
+    #[error("Worker thread panicked")]
+    ThreadPanicked,
+}
+
+#[derive(Debug)]
+/// The `tcp_rr` blackhole (server side).
+pub struct TcpRr {
+    config: Config,
+    metric_labels: Vec<(String, String)>,
+    shutdown: lading_signal::Watcher,
+    sample_period: Duration,
+}
+
+enum ServerState {
+    RecvRequest,
+    SendResponse,
+}
+
+const LISTENER_TOKEN: Token = Token(0);
+
+impl TcpRr {
+    /// Create a new [`TcpRr`] blackhole instance.
+    #[must_use]
+    pub fn new(
+        general: General,
+        config: &Config,
+        shutdown: lading_signal::Watcher,
+        sample_period: Duration,
+    ) -> Self {
+        let mut metric_labels = vec![
+            ("component".to_string(), "blackhole".to_string()),
+            ("component_name".to_string(), "tcp_rr".to_string()),
+        ];
+        if let Some(id) = general.id {
+            metric_labels.push(("id".to_string(), id));
+        }
+        Self {
+            config: *config,
+            metric_labels,
+            shutdown,
+            sample_period,
+        }
+    }
+
+    /// Run the blackhole to completion or until a shutdown signal is received.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if binding fails or a worker thread panics.
+    pub async fn run(self) -> Result<(), Error> {
+        let shutdown_flag = thread::new_shutdown_flag();
+        let num_threads = self.config.threads;
+
+        let thread_metrics = Arc::new(
+            (0..num_threads)
+                .map(|_| ThreadMetrics::new())
+                .collect::<Vec<_>>(),
+        );
+
+        let metrics_handle = {
+            let tm = Arc::clone(&thread_metrics);
+            let labels = self.metric_labels.clone();
+            let interval = self.sample_period;
+            let flag = Arc::clone(&shutdown_flag);
+            thread::spawn_named("tcp_rr-bh-metrics", move || {
+                metrics::run_metrics_thread(&tm, &labels, interval, &flag);
+            })
+        };
+
+        // When threads > 1, thread 0 must bind first to attach BPF before
+        // other threads join the SO_REUSEPORT group. The barrier ensures
+        // ordering: thread 0 binds + attaches, then signals the barrier,
+        // then all other threads proceed to bind.
+        let barrier = if num_threads > 1 {
+            Some(Arc::new(Barrier::new(num_threads as usize)))
+        } else {
+            None
+        };
+
+        let mut handles = Vec::with_capacity(num_threads as usize);
+        for i in 0..num_threads {
+            let binding_addr = self.config.binding_addr;
+            let request_size = self.config.request_size;
+            let response_size = self.config.response_size;
+            let no_delay = self.config.no_delay;
+            let flag = Arc::clone(&shutdown_flag);
+            let tm = Arc::clone(&thread_metrics);
+            let barrier = barrier.clone();
+            let handle = thread::spawn_named(&format!("tcp_rr-server-{i}"), move || {
+                server_thread_main(
+                    i,
+                    num_threads,
+                    binding_addr,
+                    request_size,
+                    response_size,
+                    no_delay,
+                    &flag,
+                    &tm[i as usize],
+                    barrier.as_deref(),
+                );
+            });
+            handles.push(handle);
+        }
+
+        self.shutdown.recv().await;
+        info!("shutdown signal received");
+        shutdown_flag.store(true, Relaxed);
+
+        handles.push(metrics_handle);
+        thread::join_all(handles).map_err(|()| Error::ThreadPanicked)?;
+
+        Ok(())
+    }
+}
+
+/// Create a listener socket. When `num_threads` > 1, sets `SO_REUSEPORT`
+/// and (for thread 0) attaches the reuseport eBPF program.
+#[allow(clippy::cast_possible_truncation)]
+fn create_listener(
+    thread_index: u16,
+    num_threads: u16,
+    binding_addr: SocketAddr,
+) -> std::net::TcpListener {
+    // Create socket manually to set SO_REUSEPORT before bind.
+    let domain = if binding_addr.is_ipv4() {
+        libc::AF_INET
+    } else {
+        libc::AF_INET6
+    };
+    let fd = unsafe { libc::socket(domain, libc::SOCK_STREAM | libc::SOCK_NONBLOCK, 0) };
+    assert!(fd >= 0, "failed to create socket");
+
+    set_sock_opt(fd, libc::SOL_SOCKET, libc::SO_REUSEADDR, 1);
+
+    if num_threads > 1 {
+        set_sock_opt(fd, libc::SOL_SOCKET, libc::SO_REUSEPORT, 1);
+
+        if thread_index == 0 {
+            match bpf::load_reuseport_ebpf(u32::from(num_threads)) {
+                Ok(prog) => {
+                    if let Err(e) = bpf::attach_reuseport_ebpf(fd, &prog) {
+                        warn!("failed to attach reuseport eBPF: {e}, falling back to kernel hash");
+                    }
+                }
+                Err(e) => {
+                    warn!("failed to load reuseport eBPF: {e}, falling back to kernel hash");
+                }
+            }
+        }
+    }
+
+    let (sockaddr, socklen) = socket_addr_to_raw(&binding_addr);
+    let ret = unsafe {
+        libc::bind(
+            fd,
+            (&raw const sockaddr).cast::<libc::sockaddr>(),
+            socklen,
+        )
+    };
+    assert!(
+        ret == 0,
+        "failed to bind to {binding_addr}: {}",
+        std::io::Error::last_os_error()
+    );
+
+    let ret = unsafe { libc::listen(fd, 1024) };
+    assert!(
+        ret == 0,
+        "failed to listen: {}",
+        std::io::Error::last_os_error()
+    );
+
+    unsafe { std::net::TcpListener::from_raw_fd(fd) }
+}
+
+#[allow(clippy::cast_possible_truncation)]
+fn set_sock_opt(fd: libc::c_int, level: libc::c_int, optname: libc::c_int, val: libc::c_int) {
+    unsafe {
+        libc::setsockopt(
+            fd,
+            level,
+            optname,
+            (&raw const val).cast::<libc::c_void>(),
+            std::mem::size_of::<libc::c_int>() as libc::socklen_t,
+        );
+    }
+}
+
+#[allow(clippy::cast_possible_truncation)]
+fn socket_addr_to_raw(addr: &SocketAddr) -> (libc::sockaddr_storage, libc::socklen_t) {
+    let mut storage: libc::sockaddr_storage = unsafe { std::mem::zeroed() };
+    let len = match addr {
+        SocketAddr::V4(a) => {
+            let sin = unsafe { &mut *(&raw mut storage).cast::<libc::sockaddr_in>() };
+            sin.sin_family = libc::AF_INET as libc::sa_family_t;
+            sin.sin_port = a.port().to_be();
+            sin.sin_addr = libc::in_addr {
+                s_addr: u32::from_ne_bytes(a.ip().octets()),
+            };
+            std::mem::size_of::<libc::sockaddr_in>() as libc::socklen_t
+        }
+        SocketAddr::V6(a) => {
+            let sin6 = unsafe { &mut *(&raw mut storage).cast::<libc::sockaddr_in6>() };
+            sin6.sin6_family = libc::AF_INET6 as libc::sa_family_t;
+            sin6.sin6_port = a.port().to_be();
+            sin6.sin6_addr = libc::in6_addr {
+                s6_addr: a.ip().octets(),
+            };
+            sin6.sin6_flowinfo = a.flowinfo();
+            sin6.sin6_scope_id = a.scope_id();
+            std::mem::size_of::<libc::sockaddr_in6>() as libc::socklen_t
+        }
+    };
+    (storage, len)
+}
+
+#[allow(clippy::too_many_arguments)]
+fn server_thread_main(
+    thread_index: u16,
+    num_threads: u16,
+    binding_addr: SocketAddr,
+    request_size: usize,
+    response_size: usize,
+    no_delay: bool,
+    shutdown_flag: &std::sync::atomic::AtomicBool,
+    metrics: &ThreadMetrics,
+    barrier: Option<&Barrier>,
+) {
+    // Thread 0 must bind first (to attach BPF before others join the
+    // reuseport group). Non-zero threads wait at the barrier first.
+    if let Some(barrier) = barrier
+        && thread_index != 0
+    {
+        barrier.wait();
+    }
+
+    let std_listener = create_listener(thread_index, num_threads, binding_addr);
+
+    // Thread 0 signals the barrier after binding so others can proceed.
+    if let Some(barrier) = barrier
+        && thread_index == 0
+    {
+        barrier.wait();
+    }
+
+    let mut listener = mio::net::TcpListener::from_std(std_listener);
+    let mut poll = Poll::new().expect("failed to create mio::Poll");
+    let mut events = Events::with_capacity(256);
+
+    poll.registry()
+        .register(&mut listener, LISTENER_TOKEN, Interest::READABLE)
+        .expect("failed to register listener");
+
+    let mut request_buf = vec![0u8; request_size];
+    let response_buf = vec![0u8; response_size];
+    let mut flows: FlowMap<ServerState> = FlowMap::new();
+    let mut next_token: usize = 1;
+
+    loop {
+        let _ = poll.poll(&mut events, Some(Duration::from_millis(100)));
+        if shutdown_flag.load(Relaxed) {
+            break;
+        }
+        for event in &events {
+            if event.token() == LISTENER_TOKEN {
+                loop {
+                    match listener.accept() {
+                        Ok((stream, _addr)) => {
+                            set_nodelay_mio(&stream, no_delay);
+                            let token = Token(next_token);
+                            next_token += 1;
+                            let mut mio_stream = stream;
+                            poll.registry()
+                                .register(&mut mio_stream, token, Interest::READABLE)
+                                .expect("failed to register flow");
+                            flows.insert(Flow {
+                                stream: mio_stream,
+                                token,
+                                state: ServerState::RecvRequest,
+                                xfer: request_size,
+                            });
+                            metrics.connections_accepted.add(1);
+                        }
+                        Err(ref e) if e.kind() == std::io::ErrorKind::WouldBlock => break,
+                        Err(e) => {
+                            trace!("accept error: {e}");
+                        }
+                    }
+                }
+            } else {
+                let token = event.token();
+                let Some(fl) = flows.get_mut(token) else {
+                    continue;
+                };
+                let action = handle_server_event(fl, &mut request_buf, &response_buf, metrics);
+                flow::apply_action(action, token, &mut flows, poll.registry());
+            }
+        }
+    }
+}
+
+/// Set `TCP_NODELAY` on a mio [`TcpStream`] using the raw fd.
+fn set_nodelay_mio(stream: &TcpStream, no_delay: bool) {
+    let fd = stream.as_raw_fd();
+    set_sock_opt(fd, libc::IPPROTO_TCP, libc::TCP_NODELAY, i32::from(no_delay));
+}
+
+fn handle_server_event(
+    flow: &mut Flow<ServerState>,
+    request_buf: &mut [u8],
+    response_buf: &[u8],
+    metrics: &ThreadMetrics,
+) -> Action {
+    match flow.state {
+        ServerState::RecvRequest => {
+            let offset = request_buf.len() - flow.xfer;
+            match flow.stream.read(&mut request_buf[offset..]) {
+                Ok(0) => Action::Remove,
+                Ok(n) => {
+                    flow.xfer -= n;
+                    if flow.xfer == 0 {
+                        flow.xfer = response_buf.len();
+                        flow.state = ServerState::SendResponse;
+                        metrics.requests_received_count.add(1);
+                        metrics.bytes_received.add(request_buf.len() as u64);
+                        Action::Reregister(Interest::WRITABLE)
+                    } else {
+                        Action::Continue
+                    }
+                }
+                Err(e) if e.kind() == std::io::ErrorKind::WouldBlock => Action::Continue,
+                Err(e) => {
+                    trace!("read error: {e}");
+                    Action::Remove
+                }
+            }
+        }
+        ServerState::SendResponse => {
+            let offset = response_buf.len() - flow.xfer;
+            match flow.stream.write(&response_buf[offset..]) {
+                Ok(n) => {
+                    flow.xfer -= n;
+                    if flow.xfer == 0 {
+                        flow.xfer = request_buf.len();
+                        flow.state = ServerState::RecvRequest;
+                        metrics.responses_sent.add(1);
+                        metrics.bytes_written.add(response_buf.len() as u64);
+                        Action::Reregister(Interest::READABLE)
+                    } else {
+                        Action::Continue
+                    }
+                }
+                Err(e) if e.kind() == std::io::ErrorKind::WouldBlock => Action::Continue,
+                Err(e) => {
+                    trace!("write error: {e}");
+                    Action::Remove
+                }
+            }
+        }
+    }
+}

--- a/lading/src/blackhole/tcp_rr.rs
+++ b/lading/src/blackhole/tcp_rr.rs
@@ -22,9 +22,9 @@ use std::sync::atomic::{AtomicBool, Ordering::Relaxed};
 use std::time::Duration;
 
 use mio::net::{TcpListener, TcpStream};
-use tokio::sync::mpsc;
 use mio::{Events, Interest, Poll, Token};
 use serde::{Deserialize, Serialize};
+use tokio::sync::mpsc;
 use tracing::{info, trace, warn};
 
 use super::General;

--- a/lading/src/blackhole/tcp_rr.rs
+++ b/lading/src/blackhole/tcp_rr.rs
@@ -1,4 +1,5 @@
 //! TCP request/response (`tcp_rr`) blackhole — the server side.
+//! Based on https://github.com/google/neper
 //!
 //! Listens for incoming connections and, for each flow, reads a fixed-size
 //! request then writes a fixed-size response, repeating until the flow closes

--- a/lading/src/blackhole/tcp_rr.rs
+++ b/lading/src/blackhole/tcp_rr.rs
@@ -231,13 +231,7 @@ fn create_listener(
     }
 
     let (sockaddr, socklen) = socket_addr_to_raw(&binding_addr);
-    let ret = unsafe {
-        libc::bind(
-            fd,
-            (&raw const sockaddr).cast::<libc::sockaddr>(),
-            socklen,
-        )
-    };
+    let ret = unsafe { libc::bind(fd, (&raw const sockaddr).cast::<libc::sockaddr>(), socklen) };
     assert!(
         ret == 0,
         "failed to bind to {binding_addr}: {}",
@@ -383,7 +377,12 @@ fn server_thread_main(
 /// Set `TCP_NODELAY` on a mio [`TcpStream`] using the raw fd.
 fn set_nodelay_mio(stream: &TcpStream, no_delay: bool) {
     let fd = stream.as_raw_fd();
-    set_sock_opt(fd, libc::IPPROTO_TCP, libc::TCP_NODELAY, i32::from(no_delay));
+    set_sock_opt(
+        fd,
+        libc::IPPROTO_TCP,
+        libc::TCP_NODELAY,
+        i32::from(no_delay),
+    );
 }
 
 fn handle_server_event(

--- a/lading/src/blackhole/tcp_rr.rs
+++ b/lading/src/blackhole/tcp_rr.rs
@@ -171,10 +171,11 @@ impl TcpRr {
             None
         };
 
-        // Ready barrier: all data threads + this async task wait here.
-        // Once all threads have bound their listeners, the async task
-        // opens the control port to signal readiness to the generator.
-        let ready_barrier = Arc::new(Barrier::new(num_threads as usize + 1));
+        // Each thread sends a ready signal via this channel after binding.
+        // If a thread panics before signaling, its sender drops; once all
+        // senders are gone, recv() returns None and we detect the failure
+        // instead of hanging forever.
+        let (ready_tx, mut ready_rx) = tokio::sync::mpsc::unbounded_channel::<()>();
 
         let mut handles = Vec::with_capacity(num_threads as usize);
         for i in 0..num_threads {
@@ -185,7 +186,7 @@ impl TcpRr {
             let flag = Arc::clone(&shutdown_flag);
             let tm = Arc::clone(&thread_metrics);
             let bpf_barrier = bpf_barrier.clone();
-            let ready_barrier = Arc::clone(&ready_barrier);
+            let tx = ready_tx.clone();
             let handle = thread::spawn_named(&format!("tcp_rr-server-{i}"), move || {
                 server_thread_main(
                     i,
@@ -197,18 +198,23 @@ impl TcpRr {
                     &flag,
                     &tm[i as usize],
                     bpf_barrier.as_deref(),
-                    &ready_barrier,
+                    tx,
                 );
             });
             handles.push(handle);
         }
+        // Drop our own copy so the channel closes when all worker threads exit.
+        drop(ready_tx);
 
-        // Wait for all data threads to finish binding.
-        // Use spawn_blocking so we don't block the tokio runtime.
-        let rb = Arc::clone(&ready_barrier);
-        tokio::task::spawn_blocking(move || rb.wait())
-            .await
-            .expect("ready barrier join failed");
+        // Wait for each thread to signal ready. If a sender drops without
+        // signaling (thread panicked), recv() eventually returns None.
+        for _ in 0..num_threads {
+            if ready_rx.recv().await.is_none() {
+                shutdown_flag.store(true, Relaxed);
+                thread::join_all(handles).map_err(|()| Error::ThreadPanicked)?;
+                return Err(Error::ThreadPanicked);
+            }
+        }
 
         // All data listeners are up. Open control port so the generator
         // can connect and know we're ready.
@@ -382,7 +388,7 @@ fn server_thread_main(
     shutdown_flag: &std::sync::atomic::AtomicBool,
     metrics: &ThreadMetrics,
     bpf_barrier: Option<&Barrier>,
-    ready_barrier: &Barrier,
+    ready_tx: tokio::sync::mpsc::UnboundedSender<()>,
 ) {
     // Thread 0 must bind first (to attach BPF before others join the
     // reuseport group). Non-zero threads wait at the BPF barrier first.
@@ -401,8 +407,10 @@ fn server_thread_main(
         barrier.wait();
     }
 
-    // Signal that this thread's listener is bound and ready.
-    ready_barrier.wait();
+    // Signal that this thread's listener is bound and ready. If this send
+    // fails the receiver has gone away (blackhole is shutting down).
+    let _ = ready_tx.send(());
+    drop(ready_tx);
 
     let mut listener = mio::net::TcpListener::from_std(std_listener);
     let mut poll = Poll::new().expect("failed to create mio::Poll");

--- a/lading/src/blackhole/tcp_rr.rs
+++ b/lading/src/blackhole/tcp_rr.rs
@@ -1,5 +1,5 @@
 //! TCP request/response (`tcp_rr`) blackhole — the server side.
-//! Based on https://github.com/google/neper
+//! Based on <https://github.com/google/neper>
 //!
 //! Listens for incoming connections and, for each flow, reads a fixed-size
 //! request then writes a fixed-size response, repeating until the flow closes
@@ -209,8 +209,12 @@ fn create_listener(
     } else {
         libc::AF_INET6
     };
-    let fd = unsafe { libc::socket(domain, libc::SOCK_STREAM | libc::SOCK_NONBLOCK, 0) };
+    let fd = unsafe { libc::socket(domain, libc::SOCK_STREAM, 0) };
     assert!(fd >= 0, "failed to create socket");
+
+    // Set nonblocking portably (SOCK_NONBLOCK is Linux-only).
+    let flags = unsafe { libc::fcntl(fd, libc::F_GETFL) };
+    unsafe { libc::fcntl(fd, libc::F_SETFL, flags | libc::O_NONBLOCK) };
 
     set_sock_opt(fd, libc::SOL_SOCKET, libc::SO_REUSEADDR, 1);
 

--- a/lading/src/blackhole/tcp_rr.rs
+++ b/lading/src/blackhole/tcp_rr.rs
@@ -390,6 +390,8 @@ fn server_thread_main(
         if shutdown_flag.load(Relaxed) {
             break;
         }
+
+        let mut attempts = 0;
         for event in &events {
             if event.token() == LISTENER_TOKEN {
                 loop {
@@ -412,7 +414,12 @@ fn server_thread_main(
                         }
                         Err(ref e) if e.kind() == ErrorKind::WouldBlock => break,
                         Err(e) => {
-                            trace!("accept error: {e}");
+                            if attempts > 2 {
+                                break;
+                            }
+                            warn!("accept error: {e}");
+                            attempts += 1;
+                            std::thread::sleep(Duration::from_millis(1000));
                         }
                     }
                 }

--- a/lading/src/blackhole/tcp_rr.rs
+++ b/lading/src/blackhole/tcp_rr.rs
@@ -39,6 +39,10 @@ fn default_one_usize() -> usize {
     1
 }
 
+fn default_control_port() -> u16 {
+    12866
+}
+
 const fn default_true() -> bool {
     true
 }
@@ -49,6 +53,9 @@ const fn default_true() -> bool {
 pub struct Config {
     /// Address to bind the listener on.
     pub binding_addr: SocketAddr,
+    /// Control port for startup synchronization with the generator. Default 12866.
+    #[serde(default = "default_control_port")]
+    pub control_port: u16,
     /// Number of OS server threads. Default 1. When > 1, uses `SO_REUSEPORT`
     /// with an eBPF program for load balancing
     #[serde(default = "default_one")]
@@ -100,6 +107,8 @@ enum ServerState {
 
 const LISTENER_TOKEN: Token = Token(0);
 
+
+
 impl TcpRr {
     /// Create a new [`TcpRr`] blackhole instance.
     #[must_use]
@@ -129,6 +138,10 @@ impl TcpRr {
     /// # Errors
     ///
     /// Returns an error if binding fails or a worker thread panics.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the ready-barrier tokio task is cancelled.
     pub async fn run(self) -> Result<(), Error> {
         let shutdown_flag = thread::new_shutdown_flag();
         let num_threads = self.config.threads;
@@ -149,15 +162,18 @@ impl TcpRr {
             })
         };
 
-        // When threads > 1, thread 0 must bind first to attach BPF before
-        // other threads join the SO_REUSEPORT group. The barrier ensures
-        // ordering: thread 0 binds + attaches, then signals the barrier,
-        // then all other threads proceed to bind.
-        let barrier = if num_threads > 1 {
+        // BPF barrier: thread 0 must bind first to attach BPF before other
+        // threads join the SO_REUSEPORT group.
+        let bpf_barrier = if num_threads > 1 {
             Some(Arc::new(Barrier::new(num_threads as usize)))
         } else {
             None
         };
+
+        // Ready barrier: all data threads + this async task wait here.
+        // Once all threads have bound their listeners, the async task
+        // opens the control port to signal readiness to the generator.
+        let ready_barrier = Arc::new(Barrier::new(num_threads as usize + 1));
 
         let mut handles = Vec::with_capacity(num_threads as usize);
         for i in 0..num_threads {
@@ -167,7 +183,8 @@ impl TcpRr {
             let no_delay = self.config.no_delay;
             let flag = Arc::clone(&shutdown_flag);
             let tm = Arc::clone(&thread_metrics);
-            let barrier = barrier.clone();
+            let bpf_barrier = bpf_barrier.clone();
+            let ready_barrier = Arc::clone(&ready_barrier);
             let handle = thread::spawn_named(&format!("tcp_rr-server-{i}"), move || {
                 server_thread_main(
                     i,
@@ -178,11 +195,30 @@ impl TcpRr {
                     no_delay,
                     &flag,
                     &tm[i as usize],
-                    barrier.as_deref(),
+                    bpf_barrier.as_deref(),
+                    &ready_barrier,
                 );
             });
             handles.push(handle);
         }
+
+        // Wait for all data threads to finish binding.
+        // Use spawn_blocking so we don't block the tokio runtime.
+        let rb = Arc::clone(&ready_barrier);
+        tokio::task::spawn_blocking(move || rb.wait()).await.expect("ready barrier join failed");
+
+        // All data listeners are up. Open control port so the generator
+        // can connect and know we're ready.
+        let control_addr = SocketAddr::new(self.config.binding_addr.ip(), self.config.control_port);
+        let control_listener = std::net::TcpListener::bind(control_addr)
+            .map_err(|source| Error::Bind { addr: control_addr, source: Box::new(source) })?;
+        info!("control port listening on {control_addr}, waiting for generator");
+        let control_listener_clone = control_listener;
+        let (_conn, peer) = tokio::task::spawn_blocking(move || control_listener_clone.accept())
+            .await
+            .expect("control accept join failed")
+            .map_err(|source| Error::Bind { addr: control_addr, source: Box::new(source) })?;
+        info!("generator connected from {peer}, data threads running");
 
         self.shutdown.recv().await;
         info!("shutdown signal received");
@@ -212,9 +248,12 @@ fn create_listener(
     let fd = unsafe { libc::socket(domain, libc::SOCK_STREAM, 0) };
     assert!(fd >= 0, "failed to create socket");
 
-    // Set nonblocking portably (SOCK_NONBLOCK is Linux-only).
+    // Set nonblocking (SOCK_NONBLOCK is Linux-only).
     let flags = unsafe { libc::fcntl(fd, libc::F_GETFL) };
     unsafe { libc::fcntl(fd, libc::F_SETFL, flags | libc::O_NONBLOCK) };
+
+    // Close-on-exec to prevent fd leaks to child processes.
+    unsafe { libc::fcntl(fd, libc::F_SETFD, libc::FD_CLOEXEC) };
 
     set_sock_opt(fd, libc::SOL_SOCKET, libc::SO_REUSEADDR, 1);
 
@@ -304,11 +343,12 @@ fn server_thread_main(
     no_delay: bool,
     shutdown_flag: &std::sync::atomic::AtomicBool,
     metrics: &ThreadMetrics,
-    barrier: Option<&Barrier>,
+    bpf_barrier: Option<&Barrier>,
+    ready_barrier: &Barrier,
 ) {
     // Thread 0 must bind first (to attach BPF before others join the
-    // reuseport group). Non-zero threads wait at the barrier first.
-    if let Some(barrier) = barrier
+    // reuseport group). Non-zero threads wait at the BPF barrier first.
+    if let Some(barrier) = bpf_barrier
         && thread_index != 0
     {
         barrier.wait();
@@ -316,12 +356,15 @@ fn server_thread_main(
 
     let std_listener = create_listener(thread_index, num_threads, binding_addr);
 
-    // Thread 0 signals the barrier after binding so others can proceed.
-    if let Some(barrier) = barrier
+    // Thread 0 signals the BPF barrier after binding so others can proceed.
+    if let Some(barrier) = bpf_barrier
         && thread_index == 0
     {
         barrier.wait();
     }
+
+    // Signal that this thread's listener is bound and ready.
+    ready_barrier.wait();
 
     let mut listener = mio::net::TcpListener::from_std(std_listener);
     let mut poll = Poll::new().expect("failed to create mio::Poll");

--- a/lading/src/blackhole/tcp_rr.rs
+++ b/lading/src/blackhole/tcp_rr.rs
@@ -107,7 +107,6 @@ pub struct TcpRr {
     config: Config,
     metric_labels: Vec<(String, String)>,
     shutdown: lading_signal::Watcher,
-    sample_period: Duration,
 }
 
 enum ServerState {
@@ -120,12 +119,7 @@ const LISTENER_TOKEN: Token = Token(0);
 impl TcpRr {
     /// Create a new [`TcpRr`] blackhole instance.
     #[must_use]
-    pub fn new(
-        general: General,
-        config: &Config,
-        shutdown: lading_signal::Watcher,
-        sample_period: Duration,
-    ) -> Self {
+    pub fn new(general: General, config: &Config, shutdown: lading_signal::Watcher) -> Self {
         let mut metric_labels = vec![
             ("component".to_string(), "blackhole".to_string()),
             ("component_name".to_string(), "tcp_rr".to_string()),
@@ -137,7 +131,6 @@ impl TcpRr {
             config: *config,
             metric_labels,
             shutdown,
-            sample_period,
         }
     }
 
@@ -164,10 +157,9 @@ impl TcpRr {
         let metrics_handle = {
             let tm = Arc::clone(&thread_metrics);
             let labels = self.metric_labels.clone();
-            let interval = self.sample_period;
             let flag = Arc::clone(&shutdown_flag);
             thread::spawn_named("tcp_rr-bh-metrics", move || {
-                metrics::run_metrics_thread(&tm, &labels, interval, &flag);
+                metrics::run_metrics_thread(&tm, &labels, &flag);
             })
         };
 

--- a/lading/src/blackhole/tcp_rr.rs
+++ b/lading/src/blackhole/tcp_rr.rs
@@ -459,7 +459,7 @@ fn handle_server_event(
                     if flow.xfer == 0 {
                         flow.xfer = response_buf.len();
                         flow.state = ServerState::SendResponse;
-                        metrics.requests_received_count.add(1);
+                        metrics.requests_received.add(1);
                         metrics.bytes_received.add(request_buf.len() as u64);
                         Action::Reregister(Interest::WRITABLE)
                     } else {

--- a/lading/src/generator.rs
+++ b/lading/src/generator.rs
@@ -27,6 +27,7 @@ pub mod process_tree;
 pub mod procfs;
 pub mod splunk_hec;
 pub mod tcp;
+pub mod tcp_rr;
 pub mod trace_agent;
 pub mod udp;
 pub mod unix_datagram;
@@ -38,6 +39,9 @@ pub enum Error {
     /// See [`crate::generator::tcp::Error`] for details.
     #[error(transparent)]
     Tcp(#[from] tcp::Error),
+    /// See [`crate::generator::tcp_rr::Error`] for details.
+    #[error(transparent)]
+    TcpRr(#[from] tcp_rr::Error),
     /// See [`crate::generator::udp::Error`] for details.
     #[error(transparent)]
     Udp(#[from] udp::Error),
@@ -111,6 +115,8 @@ pub struct General {
 pub enum Inner {
     /// See [`crate::generator::tcp::Config`] for details.
     Tcp(tcp::Config),
+    /// See [`crate::generator::tcp_rr::Config`] for details.
+    TcpRr(tcp_rr::Config),
     /// See [`crate::generator::udp::Config`] for details.
     Udp(udp::Config),
     /// See [`crate::generator::http::Config`] for details.
@@ -150,6 +156,8 @@ pub enum Inner {
 pub enum Server {
     /// See [`crate::generator::tcp::Tcp`] for details.
     Tcp(tcp::Tcp),
+    /// See [`crate::generator::tcp_rr::TcpRr`] for details.
+    TcpRr(tcp_rr::TcpRr),
     /// See [`crate::generator::udp::Udp`] for details.
     Udp(udp::Udp),
     /// See [`crate::generator::http::Http`] for details.
@@ -190,9 +198,16 @@ impl Server {
     ///
     /// Function will return an error if the underlying sub-server creation
     /// signals error.
-    pub fn new(config: Config, shutdown: lading_signal::Watcher) -> Result<Self, Error> {
+    pub fn new(
+        config: Config,
+        shutdown: lading_signal::Watcher,
+        sample_period: std::time::Duration,
+    ) -> Result<Self, Error> {
         let srv = match config.inner {
             Inner::Tcp(conf) => Self::Tcp(tcp::Tcp::new(config.general, &conf, shutdown)?),
+            Inner::TcpRr(conf) => {
+                Self::TcpRr(tcp_rr::TcpRr::new(config.general, &conf, shutdown, sample_period))
+            }
             Inner::Udp(conf) => Self::Udp(udp::Udp::new(config.general, &conf, shutdown)?),
             Inner::Http(conf) => Self::Http(http::Http::new(config.general, conf, shutdown)?),
             Inner::SplunkHec(conf) => {
@@ -267,6 +282,7 @@ impl Server {
 
         match self {
             Server::Tcp(inner) => inner.spin().await?,
+            Server::TcpRr(inner) => inner.spin().await?,
             Server::Udp(inner) => inner.spin().await?,
             Server::Http(inner) => inner.spin().await?,
             Server::SplunkHec(inner) => inner.spin().await?,

--- a/lading/src/generator.rs
+++ b/lading/src/generator.rs
@@ -205,9 +205,12 @@ impl Server {
     ) -> Result<Self, Error> {
         let srv = match config.inner {
             Inner::Tcp(conf) => Self::Tcp(tcp::Tcp::new(config.general, &conf, shutdown)?),
-            Inner::TcpRr(conf) => {
-                Self::TcpRr(tcp_rr::TcpRr::new(config.general, &conf, shutdown, sample_period))
-            }
+            Inner::TcpRr(conf) => Self::TcpRr(tcp_rr::TcpRr::new(
+                config.general,
+                &conf,
+                shutdown,
+                sample_period,
+            )),
             Inner::Udp(conf) => Self::Udp(udp::Udp::new(config.general, &conf, shutdown)?),
             Inner::Http(conf) => Self::Http(http::Http::new(config.general, conf, shutdown)?),
             Inner::SplunkHec(conf) => {

--- a/lading/src/generator.rs
+++ b/lading/src/generator.rs
@@ -198,19 +198,10 @@ impl Server {
     ///
     /// Function will return an error if the underlying sub-server creation
     /// signals error.
-    pub fn new(
-        config: Config,
-        shutdown: lading_signal::Watcher,
-        sample_period: std::time::Duration,
-    ) -> Result<Self, Error> {
+    pub fn new(config: Config, shutdown: lading_signal::Watcher) -> Result<Self, Error> {
         let srv = match config.inner {
             Inner::Tcp(conf) => Self::Tcp(tcp::Tcp::new(config.general, &conf, shutdown)?),
-            Inner::TcpRr(conf) => Self::TcpRr(tcp_rr::TcpRr::new(
-                config.general,
-                &conf,
-                shutdown,
-                sample_period,
-            )),
+            Inner::TcpRr(conf) => Self::TcpRr(tcp_rr::TcpRr::new(config.general, &conf, shutdown)),
             Inner::Udp(conf) => Self::Udp(udp::Udp::new(config.general, &conf, shutdown)?),
             Inner::Http(conf) => Self::Http(http::Http::new(config.general, conf, shutdown)?),
             Inner::SplunkHec(conf) => {

--- a/lading/src/generator/tcp_rr.rs
+++ b/lading/src/generator/tcp_rr.rs
@@ -1,4 +1,5 @@
 //! TCP request/response (`tcp_rr`) generator — the client side.
+//! Based on https://github.com/google/neper
 //!
 //! Implements neper's `tcp_rr` protocol: each flow sends a fixed-size request,
 //! waits for a fixed-size response, and repeats. Flows are distributed across

--- a/lading/src/generator/tcp_rr.rs
+++ b/lading/src/generator/tcp_rr.rs
@@ -143,11 +143,9 @@ impl TcpRr {
 
         // Wait for the blackhole to be ready by connecting to its control port.
         info!("waiting for blackhole control port at {control_addr}");
-        let deadline = std::time::Instant::now() + Duration::from_secs(300);
         {
             let flag = Arc::clone(&shutdown_flag);
             let shutdown = self.shutdown.clone();
-            // Bridge lading shutdown signal to the flag so the retry loop can check it.
             tokio::spawn(async move {
                 shutdown.recv().await;
                 flag.store(true, Relaxed);
@@ -167,15 +165,7 @@ impl TcpRr {
                     info!("blackhole ready, starting flows");
                     break;
                 }
-                Err(e) => {
-                    if std::time::Instant::now() >= deadline {
-                        return Err(Error::Io(std::io::Error::new(
-                            std::io::ErrorKind::TimedOut,
-                            format!(
-                                "blackhole control port {control_addr} not reachable after 5 minutes: {e}"
-                            ),
-                        )));
-                    }
+                Err(_) => {
                     std::thread::sleep(Duration::from_millis(100));
                 }
             }

--- a/lading/src/generator/tcp_rr.rs
+++ b/lading/src/generator/tcp_rr.rs
@@ -143,6 +143,7 @@ impl TcpRr {
 
         // Wait for the blackhole to be ready by connecting to its control port.
         info!("waiting for blackhole control port at {control_addr}");
+        let deadline = std::time::Instant::now() + Duration::from_secs(300);
         {
             let flag = Arc::clone(&shutdown_flag);
             let shutdown = self.shutdown.clone();
@@ -165,7 +166,15 @@ impl TcpRr {
                     info!("blackhole ready, starting flows");
                     break;
                 }
-                Err(_) => {
+                Err(e) => {
+                    if std::time::Instant::now() >= deadline {
+                        return Err(Error::Io(std::io::Error::new(
+                            std::io::ErrorKind::TimedOut,
+                            format!(
+                                "blackhole control port {control_addr} not reachable after 5 minutes: {e}"
+                            ),
+                        )));
+                    }
                     std::thread::sleep(Duration::from_millis(100));
                 }
             }

--- a/lading/src/generator/tcp_rr.rs
+++ b/lading/src/generator/tcp_rr.rs
@@ -42,12 +42,19 @@ const fn default_true() -> bool {
     true
 }
 
+fn default_control_port() -> u16 {
+    12866
+}
+
 #[derive(Debug, Deserialize, Serialize, PartialEq, Clone)]
 #[serde(deny_unknown_fields)]
 /// Configuration for the `tcp_rr` generator.
 pub struct Config {
     /// The address of the `tcp_rr` server to connect to.
     pub addr: String,
+    /// Control port for startup synchronization with the blackhole. Default 12866.
+    #[serde(default = "default_control_port")]
+    pub control_port: u16,
     /// Number of OS threads (neper -T). Default 1.
     #[serde(default = "default_one")]
     pub threads: u16,
@@ -90,6 +97,8 @@ enum ClientState {
     RecvResponse,
 }
 
+
+
 impl TcpRr {
     /// Create a new [`TcpRr`] generator instance.
     #[must_use]
@@ -127,6 +136,43 @@ impl TcpRr {
             .expect("no socket addr resolved");
 
         let shutdown_flag = thread::new_shutdown_flag();
+
+        // Wait for the blackhole to be ready by connecting to its control port.
+        let control_addr = SocketAddr::new(addr.ip(), self.config.control_port);
+        info!("waiting for blackhole control port at {control_addr}");
+        let deadline = std::time::Instant::now() + Duration::from_secs(300);
+        {
+            let flag = Arc::clone(&shutdown_flag);
+            let shutdown = self.shutdown.clone();
+            // Bridge lading shutdown signal to the flag so the retry loop can check it.
+            tokio::spawn(async move {
+                shutdown.recv().await;
+                flag.store(true, Relaxed);
+            });
+        }
+        loop {
+            if shutdown_flag.load(Relaxed) {
+                return Err(Error::Io(std::io::Error::new(
+                    std::io::ErrorKind::ConnectionRefused,
+                    format!("shutdown before blackhole control port {control_addr} became reachable"),
+                )));
+            }
+            match std::net::TcpStream::connect(control_addr) {
+                Ok(_conn) => {
+                    info!("blackhole ready, starting flows");
+                    break;
+                }
+                Err(e) => {
+                    if std::time::Instant::now() >= deadline {
+                        return Err(Error::Io(std::io::Error::new(
+                            std::io::ErrorKind::TimedOut,
+                            format!("blackhole control port {control_addr} not reachable after 5 minutes: {e}"),
+                        )));
+                    }
+                    std::thread::sleep(Duration::from_millis(100));
+                }
+            }
+        }
         let flow_dist = thread::distribute_flows(self.config.flows, self.config.threads);
 
         let thread_metrics = Arc::new(

--- a/lading/src/generator/tcp_rr.rs
+++ b/lading/src/generator/tcp_rr.rs
@@ -1,0 +1,288 @@
+//! TCP request/response (`tcp_rr`) generator — the client side.
+//!
+//! Implements neper's `tcp_rr` protocol: each flow sends a fixed-size request,
+//! waits for a fixed-size response, and repeats. Flows are distributed across
+//! OS threads and multiplexed via mio.
+//!
+//! ## Metrics
+//!
+//! `requests_sent`: Completed request writes
+//! `responses_received`: Completed response reads
+//! `bytes_written`: Request bytes sent
+//! `bytes_read`: Response bytes received
+//! `connections_failed`: Failed connection attempts
+
+use std::io::{Read, Write};
+use std::net::{SocketAddr, ToSocketAddrs};
+use std::sync::atomic::Ordering::Relaxed;
+use std::sync::Arc;
+use std::time::Duration;
+
+use mio::net::TcpStream;
+use mio::{Events, Interest, Poll, Token};
+use serde::{Deserialize, Serialize};
+use tracing::{info, trace};
+
+use super::General;
+use crate::generator::common::MetricsBuilder;
+use crate::neper::flow::{self, Action, Flow, FlowMap};
+use crate::neper::metrics::{self, ThreadMetrics};
+use crate::neper::thread;
+
+fn default_one() -> u16 {
+    1
+}
+
+fn default_one_usize() -> usize {
+    1
+}
+
+const fn default_true() -> bool {
+    true
+}
+
+#[derive(Debug, Deserialize, Serialize, PartialEq, Clone)]
+#[serde(deny_unknown_fields)]
+/// Configuration for the `tcp_rr` generator.
+pub struct Config {
+    /// The address of the `tcp_rr` server to connect to.
+    pub addr: String,
+    /// Number of OS threads (neper -T). Default 1.
+    #[serde(default = "default_one")]
+    pub threads: u16,
+    /// Total number of TCP flows/connections (neper -F). Default 1.
+    #[serde(default = "default_one")]
+    pub flows: u16,
+    /// Bytes per request. Default 1.
+    #[serde(default = "default_one_usize")]
+    pub request_size: usize,
+    /// Bytes per response to read back. Default 1.
+    #[serde(default = "default_one_usize")]
+    pub response_size: usize,
+    /// Whether to set `TCP_NODELAY` on connections. Default true.
+    #[serde(default = "default_true")]
+    pub no_delay: bool,
+}
+
+#[derive(thiserror::Error, Debug)]
+/// Errors produced by [`TcpRr`].
+pub enum Error {
+    /// IO error
+    #[error(transparent)]
+    Io(#[from] std::io::Error),
+    /// Worker thread panicked
+    #[error("Worker thread panicked")]
+    ThreadPanicked,
+}
+
+#[derive(Debug)]
+/// The `tcp_rr` generator (client side).
+pub struct TcpRr {
+    config: Config,
+    metric_labels: Vec<(String, String)>,
+    shutdown: lading_signal::Watcher,
+    sample_period: Duration,
+}
+
+enum ClientState {
+    SendRequest,
+    RecvResponse,
+}
+
+impl TcpRr {
+    /// Create a new [`TcpRr`] generator instance.
+    #[must_use]
+    pub fn new(
+        general: General,
+        config: &Config,
+        shutdown: lading_signal::Watcher,
+        sample_period: Duration,
+    ) -> Self {
+        let metric_labels = MetricsBuilder::new("tcp_rr")
+            .with_id(general.id)
+            .build();
+        Self {
+            config: config.clone(),
+            metric_labels,
+            shutdown,
+            sample_period,
+        }
+    }
+
+    /// Run the generator to completion or until a shutdown signal is received.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if a worker thread panics.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `addr` cannot be resolved to a socket address.
+    pub async fn spin(self) -> Result<(), Error> {
+        let addr = self
+            .config
+            .addr
+            .to_socket_addrs()
+            .expect("invalid addr")
+            .next()
+            .expect("no socket addr resolved");
+
+        let shutdown_flag = thread::new_shutdown_flag();
+        let flow_dist = thread::distribute_flows(self.config.flows, self.config.threads);
+
+        let thread_metrics = Arc::new(
+            (0..self.config.threads)
+                .map(|_| ThreadMetrics::new())
+                .collect::<Vec<_>>(),
+        );
+
+        let metrics_handle = {
+            let tm = Arc::clone(&thread_metrics);
+            let labels = self.metric_labels.clone();
+            let interval = self.sample_period;
+            let flag = Arc::clone(&shutdown_flag);
+            thread::spawn_named("tcp_rr-metrics", move || {
+                metrics::run_metrics_thread(&tm, &labels, interval, &flag);
+            })
+        };
+
+        let mut worker_handles = Vec::with_capacity(self.config.threads as usize);
+        for i in 0..self.config.threads {
+            let num_flows = flow_dist[i as usize];
+            let flag = Arc::clone(&shutdown_flag);
+            let tm = Arc::clone(&thread_metrics);
+            let request_size = self.config.request_size;
+            let response_size = self.config.response_size;
+            let no_delay = self.config.no_delay;
+            let handle = thread::spawn_named(&format!("tcp_rr-client-{i}"), move || {
+                client_thread_main(addr, num_flows, request_size, response_size, no_delay, &flag, &tm[i as usize]);
+            });
+            worker_handles.push(handle);
+        }
+
+        self.shutdown.recv().await;
+        info!("shutdown signal received");
+        shutdown_flag.store(true, Relaxed);
+
+        worker_handles.push(metrics_handle);
+        thread::join_all(worker_handles).map_err(|()| Error::ThreadPanicked)?;
+
+        Ok(())
+    }
+}
+
+fn client_thread_main(
+    addr: SocketAddr,
+    num_flows: u16,
+    request_size: usize,
+    response_size: usize,
+    no_delay: bool,
+    shutdown_flag: &std::sync::atomic::AtomicBool,
+    metrics: &ThreadMetrics,
+) {
+    let mut poll = Poll::new().expect("failed to create mio::Poll");
+    let mut events = Events::with_capacity(num_flows as usize);
+    let request_buf = vec![0u8; request_size];
+    let mut response_buf = vec![0u8; response_size];
+    let mut flows: FlowMap<ClientState> = FlowMap::new();
+    let mut next_token: usize = 0;
+
+    for _ in 0..num_flows {
+        match std::net::TcpStream::connect(addr) {
+            Ok(std_stream) => {
+                let _ = std_stream.set_nodelay(no_delay);
+                std_stream
+                    .set_nonblocking(true)
+                    .expect("failed to set nonblocking");
+                let mut stream =
+                    TcpStream::from_std(std_stream);
+                let token = Token(next_token);
+                next_token += 1;
+                poll.registry()
+                    .register(&mut stream, token, Interest::WRITABLE)
+                    .expect("failed to register flow");
+                flows.insert(Flow {
+                    stream,
+                    token,
+                    state: ClientState::SendRequest,
+                    xfer: request_size,
+                });
+            }
+            Err(e) => {
+                trace!("connection to {addr} failed: {e}");
+                metrics.connections_failed.add(1);
+            }
+        }
+    }
+
+    loop {
+        let _ = poll.poll(&mut events, Some(Duration::from_millis(100)));
+        if shutdown_flag.load(Relaxed) {
+            break;
+        }
+        for event in &events {
+            let token = event.token();
+            let Some(fl) = flows.get_mut(token) else {
+                continue;
+            };
+            let action =
+                handle_client_event(fl, &request_buf, &mut response_buf, metrics);
+            flow::apply_action(action, token, &mut flows, poll.registry());
+        }
+    }
+}
+
+fn handle_client_event(
+    flow: &mut Flow<ClientState>,
+    request_buf: &[u8],
+    response_buf: &mut [u8],
+    metrics: &ThreadMetrics,
+) -> Action {
+    match flow.state {
+        ClientState::SendRequest => {
+            let offset = request_buf.len() - flow.xfer;
+            match flow.stream.write(&request_buf[offset..]) {
+                Ok(n) => {
+                    flow.xfer -= n;
+                    if flow.xfer == 0 {
+                        flow.xfer = response_buf.len();
+                        flow.state = ClientState::RecvResponse;
+                        metrics.requests_sent.add(1);
+                        metrics.bytes_written.add(request_buf.len() as u64);
+                        Action::Reregister(Interest::READABLE)
+                    } else {
+                        Action::Continue
+                    }
+                }
+                Err(e) if e.kind() == std::io::ErrorKind::WouldBlock => Action::Continue,
+                Err(e) => {
+                    trace!("write error: {e}");
+                    Action::Remove
+                }
+            }
+        }
+        ClientState::RecvResponse => {
+            let offset = response_buf.len() - flow.xfer;
+            match flow.stream.read(&mut response_buf[offset..]) {
+                Ok(0) => Action::Remove,
+                Ok(n) => {
+                    flow.xfer -= n;
+                    if flow.xfer == 0 {
+                        flow.xfer = request_buf.len();
+                        flow.state = ClientState::SendRequest;
+                        metrics.responses_received.add(1);
+                        metrics.bytes_read.add(response_buf.len() as u64);
+                        Action::Reregister(Interest::WRITABLE)
+                    } else {
+                        Action::Continue
+                    }
+                }
+                Err(e) if e.kind() == std::io::ErrorKind::WouldBlock => Action::Continue,
+                Err(e) => {
+                    trace!("read error: {e}");
+                    Action::Remove
+                }
+            }
+        }
+    }
+}

--- a/lading/src/generator/tcp_rr.rs
+++ b/lading/src/generator/tcp_rr.rs
@@ -1,5 +1,5 @@
 //! TCP request/response (`tcp_rr`) generator — the client side.
-//! Based on https://github.com/google/neper
+//! Based on <https://github.com/google/neper>
 //!
 //! Implements neper's `tcp_rr` protocol: each flow sends a fixed-size request,
 //! waits for a fixed-size response, and repeats. Flows are distributed across

--- a/lading/src/generator/tcp_rr.rs
+++ b/lading/src/generator/tcp_rr.rs
@@ -14,8 +14,8 @@
 
 use std::io::{Read, Write};
 use std::net::{SocketAddr, ToSocketAddrs};
-use std::sync::atomic::Ordering::Relaxed;
 use std::sync::Arc;
+use std::sync::atomic::Ordering::Relaxed;
 use std::time::Duration;
 
 use mio::net::TcpStream;
@@ -98,9 +98,7 @@ impl TcpRr {
         shutdown: lading_signal::Watcher,
         sample_period: Duration,
     ) -> Self {
-        let metric_labels = MetricsBuilder::new("tcp_rr")
-            .with_id(general.id)
-            .build();
+        let metric_labels = MetricsBuilder::new("tcp_rr").with_id(general.id).build();
         Self {
             config: config.clone(),
             metric_labels,
@@ -155,7 +153,15 @@ impl TcpRr {
             let response_size = self.config.response_size;
             let no_delay = self.config.no_delay;
             let handle = thread::spawn_named(&format!("tcp_rr-client-{i}"), move || {
-                client_thread_main(addr, num_flows, request_size, response_size, no_delay, &flag, &tm[i as usize]);
+                client_thread_main(
+                    addr,
+                    num_flows,
+                    request_size,
+                    response_size,
+                    no_delay,
+                    &flag,
+                    &tm[i as usize],
+                );
             });
             worker_handles.push(handle);
         }
@@ -194,8 +200,7 @@ fn client_thread_main(
                 std_stream
                     .set_nonblocking(true)
                     .expect("failed to set nonblocking");
-                let mut stream =
-                    TcpStream::from_std(std_stream);
+                let mut stream = TcpStream::from_std(std_stream);
                 let token = Token(next_token);
                 next_token += 1;
                 poll.registry()
@@ -225,8 +230,7 @@ fn client_thread_main(
             let Some(fl) = flows.get_mut(token) else {
                 continue;
             };
-            let action =
-                handle_client_event(fl, &request_buf, &mut response_buf, metrics);
+            let action = handle_client_event(fl, &request_buf, &mut response_buf, metrics);
             flow::apply_action(action, token, &mut flows, poll.registry());
         }
     }

--- a/lading/src/generator/tcp_rr.rs
+++ b/lading/src/generator/tcp_rr.rs
@@ -14,7 +14,7 @@
 //! `connections_failed`: Failed connection attempts
 
 use std::io::{Read, Write};
-use std::net::{SocketAddr, ToSocketAddrs};
+use std::net::SocketAddr;
 use std::num::{NonZeroU16, NonZeroUsize};
 use std::sync::Arc;
 use std::sync::atomic::Ordering::Relaxed;
@@ -49,12 +49,19 @@ fn default_control_port() -> u16 {
     12866
 }
 
+fn default_data_port() -> u16 {
+    12867
+}
+
 #[derive(Debug, Deserialize, Serialize, PartialEq, Clone)]
 #[serde(deny_unknown_fields)]
 /// Configuration for the `tcp_rr` generator.
 pub struct Config {
-    /// The address of the `tcp_rr` server to connect to.
+    /// The IP address of the `tcp_rr` server.
     pub addr: String,
+    /// Data port for flow connections. Default 12867.
+    #[serde(default = "default_data_port")]
+    pub data_port: u16,
     /// Control port for startup synchronization with the blackhole. Default 12866.
     #[serde(default = "default_control_port")]
     pub control_port: u16,
@@ -130,18 +137,13 @@ impl TcpRr {
     ///
     /// Panics if `addr` cannot be resolved to a socket address.
     pub async fn spin(self) -> Result<(), Error> {
-        let addr = self
-            .config
-            .addr
-            .to_socket_addrs()
-            .expect("invalid addr")
-            .next()
-            .expect("no socket addr resolved");
+        let ip: std::net::IpAddr = self.config.addr.parse().expect("invalid addr");
+        let data_addr = SocketAddr::new(ip, self.config.data_port);
+        let control_addr = SocketAddr::new(ip, self.config.control_port);
 
         let shutdown_flag = thread::new_shutdown_flag();
 
         // Wait for the blackhole to be ready by connecting to its control port.
-        let control_addr = SocketAddr::new(addr.ip(), self.config.control_port);
         info!("waiting for blackhole control port at {control_addr}");
         let deadline = std::time::Instant::now() + Duration::from_secs(300);
         {
@@ -207,7 +209,7 @@ impl TcpRr {
             let no_delay = self.config.no_delay;
             let handle = thread::spawn_named(&format!("tcp_rr-client-{i}"), move || {
                 client_thread_main(
-                    addr,
+                    data_addr,
                     thread_flows,
                     request_size,
                     response_size,

--- a/lading/src/generator/tcp_rr.rs
+++ b/lading/src/generator/tcp_rr.rs
@@ -99,7 +99,6 @@ pub struct TcpRr {
     config: Config,
     metric_labels: Vec<(String, String)>,
     shutdown: lading_signal::Watcher,
-    sample_period: Duration,
 }
 
 enum ClientState {
@@ -110,18 +109,12 @@ enum ClientState {
 impl TcpRr {
     /// Create a new [`TcpRr`] generator instance.
     #[must_use]
-    pub fn new(
-        general: General,
-        config: &Config,
-        shutdown: lading_signal::Watcher,
-        sample_period: Duration,
-    ) -> Self {
+    pub fn new(general: General, config: &Config, shutdown: lading_signal::Watcher) -> Self {
         let metric_labels = MetricsBuilder::new("tcp_rr").with_id(general.id).build();
         Self {
             config: config.clone(),
             metric_labels,
             shutdown,
-            sample_period,
         }
     }
 
@@ -195,10 +188,9 @@ impl TcpRr {
         let metrics_handle = {
             let tm = Arc::clone(&thread_metrics);
             let labels = self.metric_labels.clone();
-            let interval = self.sample_period;
             let flag = Arc::clone(&shutdown_flag);
             thread::spawn_named("tcp_rr-metrics", move || {
-                metrics::run_metrics_thread(&tm, &labels, interval, &flag);
+                metrics::run_metrics_thread(&tm, &labels, &flag);
             })
         };
 

--- a/lading/src/generator/tcp_rr.rs
+++ b/lading/src/generator/tcp_rr.rs
@@ -89,6 +89,9 @@ pub enum Error {
     /// Worker thread panicked
     #[error("Worker thread panicked")]
     ThreadPanicked,
+    /// Invalid configuration.
+    #[error("invalid config: {0}")]
+    Config(String),
 }
 
 #[derive(Debug)]
@@ -126,6 +129,13 @@ impl TcpRr {
     ///
     /// Panics if `addr` cannot be resolved to a socket address.
     pub async fn spin(self) -> Result<(), Error> {
+        if self.config.threads > self.config.flows {
+            return Err(Error::Config(format!(
+                "threads ({}) must be <= flows ({})",
+                self.config.threads, self.config.flows
+            )));
+        }
+
         let ip: IpAddr = self.config.addr.parse().expect("invalid addr");
         let data_addr = SocketAddr::new(ip, self.config.data_port);
         let control_addr = SocketAddr::new(ip, self.config.control_port);

--- a/lading/src/generator/tcp_rr.rs
+++ b/lading/src/generator/tcp_rr.rs
@@ -107,8 +107,6 @@ enum ClientState {
     RecvResponse,
 }
 
-
-
 impl TcpRr {
     /// Create a new [`TcpRr`] generator instance.
     #[must_use]
@@ -159,7 +157,9 @@ impl TcpRr {
             if shutdown_flag.load(Relaxed) {
                 return Err(Error::Io(std::io::Error::new(
                     std::io::ErrorKind::ConnectionRefused,
-                    format!("shutdown before blackhole control port {control_addr} became reachable"),
+                    format!(
+                        "shutdown before blackhole control port {control_addr} became reachable"
+                    ),
                 )));
             }
             match std::net::TcpStream::connect(control_addr) {
@@ -171,7 +171,9 @@ impl TcpRr {
                     if std::time::Instant::now() >= deadline {
                         return Err(Error::Io(std::io::Error::new(
                             std::io::ErrorKind::TimedOut,
-                            format!("blackhole control port {control_addr} not reachable after 5 minutes: {e}"),
+                            format!(
+                                "blackhole control port {control_addr} not reachable after 5 minutes: {e}"
+                            ),
                         )));
                     }
                     std::thread::sleep(Duration::from_millis(100));

--- a/lading/src/generator/tcp_rr.rs
+++ b/lading/src/generator/tcp_rr.rs
@@ -15,6 +15,7 @@
 
 use std::io::{Read, Write};
 use std::net::{SocketAddr, ToSocketAddrs};
+use std::num::{NonZeroU16, NonZeroUsize};
 use std::sync::Arc;
 use std::sync::atomic::Ordering::Relaxed;
 use std::time::Duration;
@@ -30,12 +31,14 @@ use crate::neper::flow::{self, Action, Flow, FlowMap};
 use crate::neper::metrics::{self, ThreadMetrics};
 use crate::neper::thread;
 
-fn default_one() -> u16 {
-    1
+const fn default_nonzero_u16() -> NonZeroU16 {
+    // Safety: 1 != 0
+    unsafe { NonZeroU16::new_unchecked(1) }
 }
 
-fn default_one_usize() -> usize {
-    1
+const fn default_nonzero_usize() -> NonZeroUsize {
+    // Safety: 1 != 0
+    unsafe { NonZeroUsize::new_unchecked(1) }
 }
 
 const fn default_true() -> bool {
@@ -56,17 +59,17 @@ pub struct Config {
     #[serde(default = "default_control_port")]
     pub control_port: u16,
     /// Number of OS threads (neper -T). Default 1.
-    #[serde(default = "default_one")]
-    pub threads: u16,
+    #[serde(default = "default_nonzero_u16")]
+    pub threads: NonZeroU16,
     /// Total number of TCP flows/connections (neper -F). Default 1.
-    #[serde(default = "default_one")]
-    pub flows: u16,
+    #[serde(default = "default_nonzero_u16")]
+    pub flows: NonZeroU16,
     /// Bytes per request. Default 1.
-    #[serde(default = "default_one_usize")]
-    pub request_size: usize,
+    #[serde(default = "default_nonzero_usize")]
+    pub request_size: NonZeroUsize,
     /// Bytes per response to read back. Default 1.
-    #[serde(default = "default_one_usize")]
-    pub response_size: usize,
+    #[serde(default = "default_nonzero_usize")]
+    pub response_size: NonZeroUsize,
     /// Whether to set `TCP_NODELAY` on connections. Default true.
     #[serde(default = "default_true")]
     pub no_delay: bool,
@@ -173,10 +176,15 @@ impl TcpRr {
                 }
             }
         }
-        let flow_dist = thread::distribute_flows(self.config.flows, self.config.threads);
+        let num_threads = self.config.threads.get();
+        let num_flows = self.config.flows.get();
+        let request_size = self.config.request_size.get();
+        let response_size = self.config.response_size.get();
+
+        let flow_dist = thread::distribute_flows(num_flows, num_threads);
 
         let thread_metrics = Arc::new(
-            (0..self.config.threads)
+            (0..num_threads)
                 .map(|_| ThreadMetrics::new())
                 .collect::<Vec<_>>(),
         );
@@ -191,18 +199,16 @@ impl TcpRr {
             })
         };
 
-        let mut worker_handles = Vec::with_capacity(self.config.threads as usize);
-        for i in 0..self.config.threads {
-            let num_flows = flow_dist[i as usize];
+        let mut worker_handles = Vec::with_capacity(num_threads as usize);
+        for i in 0..num_threads {
+            let thread_flows = flow_dist[i as usize];
             let flag = Arc::clone(&shutdown_flag);
             let tm = Arc::clone(&thread_metrics);
-            let request_size = self.config.request_size;
-            let response_size = self.config.response_size;
             let no_delay = self.config.no_delay;
             let handle = thread::spawn_named(&format!("tcp_rr-client-{i}"), move || {
                 client_thread_main(
                     addr,
-                    num_flows,
+                    thread_flows,
                     request_size,
                     response_size,
                     no_delay,

--- a/lading/src/generator/tcp_rr.rs
+++ b/lading/src/generator/tcp_rr.rs
@@ -13,12 +13,12 @@
 //! `bytes_read`: Response bytes received
 //! `connections_failed`: Failed connection attempts
 
-use std::io::{Read, Write};
-use std::net::SocketAddr;
+use std::io::{self, ErrorKind, Read, Write};
+use std::net::{self, IpAddr, SocketAddr};
 use std::num::{NonZeroU16, NonZeroUsize};
 use std::sync::Arc;
-use std::sync::atomic::Ordering::Relaxed;
-use std::time::Duration;
+use std::sync::atomic::{AtomicBool, Ordering::Relaxed};
+use std::time::{Duration, Instant};
 
 use mio::net::TcpStream;
 use mio::{Events, Interest, Poll, Token};
@@ -126,7 +126,7 @@ impl TcpRr {
     ///
     /// Panics if `addr` cannot be resolved to a socket address.
     pub async fn spin(self) -> Result<(), Error> {
-        let ip: std::net::IpAddr = self.config.addr.parse().expect("invalid addr");
+        let ip: IpAddr = self.config.addr.parse().expect("invalid addr");
         let data_addr = SocketAddr::new(ip, self.config.data_port);
         let control_addr = SocketAddr::new(ip, self.config.control_port);
 
@@ -134,7 +134,7 @@ impl TcpRr {
 
         // Wait for the blackhole to be ready by connecting to its control port.
         info!("waiting for blackhole control port at {control_addr}");
-        let deadline = std::time::Instant::now() + Duration::from_secs(300);
+        let deadline = Instant::now() + Duration::from_secs(300);
         {
             let flag = Arc::clone(&shutdown_flag);
             let shutdown = self.shutdown.clone();
@@ -145,22 +145,22 @@ impl TcpRr {
         }
         loop {
             if shutdown_flag.load(Relaxed) {
-                return Err(Error::Io(std::io::Error::new(
-                    std::io::ErrorKind::ConnectionRefused,
+                return Err(Error::Io(io::Error::new(
+                    ErrorKind::ConnectionRefused,
                     format!(
                         "shutdown before blackhole control port {control_addr} became reachable"
                     ),
                 )));
             }
-            match std::net::TcpStream::connect(control_addr) {
+            match net::TcpStream::connect(control_addr) {
                 Ok(_conn) => {
                     info!("blackhole ready, starting flows");
                     break;
                 }
                 Err(e) => {
-                    if std::time::Instant::now() >= deadline {
-                        return Err(Error::Io(std::io::Error::new(
-                            std::io::ErrorKind::TimedOut,
+                    if Instant::now() >= deadline {
+                        return Err(Error::Io(io::Error::new(
+                            ErrorKind::TimedOut,
                             format!(
                                 "blackhole control port {control_addr} not reachable after 5 minutes: {e}"
                             ),
@@ -229,7 +229,7 @@ fn client_thread_main(
     request_size: usize,
     response_size: usize,
     no_delay: bool,
-    shutdown_flag: &std::sync::atomic::AtomicBool,
+    shutdown_flag: &AtomicBool,
     metrics: &ThreadMetrics,
 ) {
     let mut poll = Poll::new().expect("failed to create mio::Poll");
@@ -240,7 +240,7 @@ fn client_thread_main(
     let mut next_token: usize = 0;
 
     for _ in 0..num_flows {
-        match std::net::TcpStream::connect(addr) {
+        match net::TcpStream::connect(addr) {
             Ok(std_stream) => {
                 let _ = std_stream.set_nodelay(no_delay);
                 std_stream
@@ -304,7 +304,7 @@ fn handle_client_event(
                         Action::Continue
                     }
                 }
-                Err(e) if e.kind() == std::io::ErrorKind::WouldBlock => Action::Continue,
+                Err(e) if e.kind() == ErrorKind::WouldBlock => Action::Continue,
                 Err(e) => {
                     trace!("write error: {e}");
                     Action::Remove
@@ -327,7 +327,7 @@ fn handle_client_event(
                         Action::Continue
                     }
                 }
-                Err(e) if e.kind() == std::io::ErrorKind::WouldBlock => Action::Continue,
+                Err(e) if e.kind() == ErrorKind::WouldBlock => Action::Continue,
                 Err(e) => {
                     trace!("read error: {e}");
                     Action::Remove

--- a/lading/src/generator/tcp_rr.rs
+++ b/lading/src/generator/tcp_rr.rs
@@ -31,14 +31,12 @@ use crate::neper::flow::{self, Action, Flow, FlowMap};
 use crate::neper::metrics::{self, ThreadMetrics};
 use crate::neper::thread;
 
-const fn default_nonzero_u16() -> NonZeroU16 {
-    // Safety: 1 != 0
-    unsafe { NonZeroU16::new_unchecked(1) }
+fn default_nonzero_u16() -> NonZeroU16 {
+    NonZeroU16::new(1).expect("1 is nonzero")
 }
 
-const fn default_nonzero_usize() -> NonZeroUsize {
-    // Safety: 1 != 0
-    unsafe { NonZeroUsize::new_unchecked(1) }
+fn default_nonzero_usize() -> NonZeroUsize {
+    NonZeroUsize::new(1).expect("1 is nonzero")
 }
 
 const fn default_true() -> bool {

--- a/lading/src/lib.rs
+++ b/lading/src/lib.rs
@@ -17,6 +17,7 @@ mod common;
 pub mod config;
 pub mod generator;
 pub mod inspector;
+mod neper;
 pub mod observer;
 pub(crate) mod proto;
 pub mod target;

--- a/lading/src/neper.rs
+++ b/lading/src/neper.rs
@@ -4,6 +4,10 @@
 //! metrics, and OS thread lifecycle helpers — that are composed by mode-specific
 //! generators and blackholes (e.g. `tcp_rr`, `tcp_crr`, `tcp_stream`).
 
+#[cfg(target_os = "linux")]
+pub(crate) mod bpf;
+#[cfg(not(target_os = "linux"))]
+#[path = "neper/bpf_stub.rs"]
 pub(crate) mod bpf;
 pub(crate) mod flow;
 pub(crate) mod metrics;

--- a/lading/src/neper.rs
+++ b/lading/src/neper.rs
@@ -1,0 +1,10 @@
+//! Shared networking infrastructure for neper-style workloads.
+//!
+//! This module provides reusable building blocks — flow management, per-thread
+//! metrics, and OS thread lifecycle helpers — that are composed by mode-specific
+//! generators and blackholes (e.g. `tcp_rr`, `tcp_crr`, `tcp_stream`).
+
+pub(crate) mod bpf;
+pub(crate) mod flow;
+pub(crate) mod metrics;
+pub(crate) mod thread;

--- a/lading/src/neper/bpf.rs
+++ b/lading/src/neper/bpf.rs
@@ -14,6 +14,7 @@
     clippy::cast_sign_loss
 )]
 
+use std::ffi::CStr;
 use std::io;
 use std::os::fd::{AsRawFd, FromRawFd, OwnedFd, RawFd};
 
@@ -123,7 +124,7 @@ pub(crate) fn load_reuseport_ebpf(num_sockets: u32) -> Result<OwnedFd, Error> {
     if fd < 0 {
         let os_err = io::Error::last_os_error();
         // Extract the verifier log (null-terminated string written by the kernel).
-        let log = std::ffi::CStr::from_bytes_until_nul(&log_buf)
+        let log = CStr::from_bytes_until_nul(&log_buf)
             .map(|s| s.to_string_lossy().into_owned())
             .unwrap_or_default();
         let reason = if log.trim().is_empty() {

--- a/lading/src/neper/bpf.rs
+++ b/lading/src/neper/bpf.rs
@@ -17,6 +17,14 @@
 use std::io;
 use std::os::fd::{AsRawFd, FromRawFd, OwnedFd, RawFd};
 
+#[derive(thiserror::Error, Debug)]
+pub(crate) enum Error {
+    #[error("bpf load failed: {reason}")]
+    Load { reason: String },
+    #[error("bpf attach failed: {reason}")]
+    Attach { reason: String },
+}
+
 // eBPF instruction encoding: { code:u8, dst_reg:4|src_reg:4, off:i16, imm:i32 }
 #[repr(C)]
 struct BpfInsn {
@@ -81,7 +89,7 @@ struct BpfAttrProgLoad {
 ///
 /// Returns an error if the `bpf()` syscall fails (e.g. missing permissions,
 /// kernel too old).
-pub(crate) fn load_reuseport_ebpf(num_sockets: u32) -> io::Result<OwnedFd> {
+pub(crate) fn load_reuseport_ebpf(num_sockets: u32) -> Result<OwnedFd, Error> {
     let imm = num_sockets as i32;
     let prog = [
         BpfInsn::new(BPF_JMP | BPF_CALL, 0, 0, 0, BPF_FUNC_GET_PRANDOM_U32),
@@ -113,7 +121,17 @@ pub(crate) fn load_reuseport_ebpf(num_sockets: u32) -> io::Result<OwnedFd> {
     };
 
     if fd < 0 {
-        return Err(io::Error::last_os_error());
+        let os_err = io::Error::last_os_error();
+        // Extract the verifier log (null-terminated string written by the kernel).
+        let log = std::ffi::CStr::from_bytes_until_nul(&log_buf)
+            .map(|s| s.to_string_lossy().into_owned())
+            .unwrap_or_default();
+        let reason = if log.trim().is_empty() {
+            os_err.to_string()
+        } else {
+            format!("{os_err}: {}", log.trim())
+        };
+        return Err(Error::Load { reason });
     }
 
     Ok(unsafe { OwnedFd::from_raw_fd(fd as RawFd) })
@@ -127,7 +145,7 @@ pub(crate) fn load_reuseport_ebpf(num_sockets: u32) -> io::Result<OwnedFd> {
 /// # Errors
 ///
 /// Returns an error if `setsockopt` fails.
-pub(crate) fn attach_reuseport_ebpf(socket_fd: RawFd, prog: &OwnedFd) -> io::Result<()> {
+pub(crate) fn attach_reuseport_ebpf(socket_fd: RawFd, prog: &OwnedFd) -> Result<(), Error> {
     let prog_fd: libc::c_int = prog.as_raw_fd();
     let ret = unsafe {
         libc::setsockopt(
@@ -139,7 +157,9 @@ pub(crate) fn attach_reuseport_ebpf(socket_fd: RawFd, prog: &OwnedFd) -> io::Res
         )
     };
     if ret < 0 {
-        return Err(io::Error::last_os_error());
+        return Err(Error::Attach {
+            reason: io::Error::last_os_error().to_string(),
+        });
     }
     Ok(())
 }

--- a/lading/src/neper/bpf.rs
+++ b/lading/src/neper/bpf.rs
@@ -1,0 +1,145 @@
+//! eBPF program for `SO_REUSEPORT` load balancing.
+//!
+//! Provides an eBPF program matching neper's `prog1`: select random
+//! socket
+//!
+//! The program is loaded via the `bpf()` syscall and attached to a listener
+//! socket with `SO_ATTACH_REUSEPORT_EBPF`. Only the first socket in the
+//! reuseport group needs the program attached — the kernel applies it to the
+//! entire group.
+
+#![allow(
+    clippy::cast_possible_truncation,
+    clippy::cast_possible_wrap,
+    clippy::cast_sign_loss
+)]
+
+use std::io;
+use std::os::fd::{AsRawFd, FromRawFd, OwnedFd, RawFd};
+
+// eBPF instruction encoding: { code:u8, dst_reg:4|src_reg:4, off:i16, imm:i32 }
+#[repr(C)]
+struct BpfInsn {
+    code: u8,
+    regs: u8, // dst_reg:4 (low) | src_reg:4 (high)
+    off: i16,
+    imm: i32,
+}
+
+impl BpfInsn {
+    const fn new(code: u8, dst: u8, src: u8, off: i16, imm: i32) -> Self {
+        Self {
+            code,
+            regs: (src << 4) | (dst & 0x0f),
+            off,
+            imm,
+        }
+    }
+}
+
+// BPF instruction classes and opcodes (from linux/bpf.h).
+const BPF_JMP: u8 = 0x05;
+const BPF_ALU: u8 = 0x04;
+const BPF_CALL: u8 = 0x80;
+const BPF_EXIT: u8 = 0x90;
+const BPF_MOD: u8 = 0x90;
+const BPF_K: u8 = 0x00;
+
+// BPF registers.
+const BPF_REG_0: u8 = 0;
+
+// BPF helper function IDs.
+const BPF_FUNC_GET_PRANDOM_U32: i32 = 7;
+
+// BPF program types and commands.
+const BPF_PROG_LOAD: libc::c_int = 5;
+const BPF_PROG_TYPE_SOCKET_FILTER: u32 = 1;
+
+// bpf_attr union for BPF_PROG_LOAD — only the fields we need.
+#[repr(C)]
+struct BpfAttrProgLoad {
+    prog_type: u32,
+    insn_cnt: u32,
+    insns: u64,
+    license: u64,
+    log_level: u32,
+    log_size: u32,
+    log_buf: u64,
+    // Pad to cover the full bpf_attr union size the kernel expects.
+    _pad: [u8; 96],
+}
+
+/// Build and load the reuseport eBPF program.
+///
+/// The program randomly selects a socket index for incoming connections:
+/// ```text
+/// r0 = get_prandom_u32() % num_sockets
+/// return r0
+/// ```
+///
+/// # Errors
+///
+/// Returns an error if the `bpf()` syscall fails (e.g. missing permissions,
+/// kernel too old).
+pub(crate) fn load_reuseport_ebpf(num_sockets: u32) -> io::Result<OwnedFd> {
+    let imm = num_sockets as i32;
+    let prog = [
+        BpfInsn::new(BPF_JMP | BPF_CALL, 0, 0, 0, BPF_FUNC_GET_PRANDOM_U32),
+        BpfInsn::new(BPF_ALU | BPF_MOD | BPF_K, BPF_REG_0, 0, 0, imm),
+        BpfInsn::new(BPF_JMP | BPF_EXIT, 0, 0, 0, 0),
+    ];
+
+    let license = b"GPL\0";
+    let mut log_buf = [0u8; 4096];
+
+    let attr = BpfAttrProgLoad {
+        prog_type: BPF_PROG_TYPE_SOCKET_FILTER,
+        insn_cnt: prog.len() as u32,
+        insns: prog.as_ptr() as u64,
+        license: license.as_ptr() as u64,
+        log_level: 1,
+        log_size: log_buf.len() as u32,
+        log_buf: log_buf.as_mut_ptr() as u64,
+        _pad: [0u8; 96],
+    };
+
+    let fd = unsafe {
+        libc::syscall(
+            libc::SYS_bpf,
+            BPF_PROG_LOAD,
+            (&raw const attr).cast::<libc::c_void>(),
+            std::mem::size_of::<BpfAttrProgLoad>() as libc::c_int,
+        )
+    };
+
+    if fd < 0 {
+        return Err(io::Error::last_os_error());
+    }
+
+    Ok(unsafe { OwnedFd::from_raw_fd(fd as RawFd) })
+}
+
+/// Attach a loaded reuseport eBPF program to a socket.
+///
+/// Must be called on the first socket in the `SO_REUSEPORT` group before
+/// other sockets bind to the same address.
+///
+/// # Errors
+///
+/// Returns an error if `setsockopt` fails.
+pub(crate) fn attach_reuseport_ebpf(socket_fd: RawFd, prog: &OwnedFd) -> io::Result<()> {
+    let prog_fd: libc::c_int = prog.as_raw_fd();
+    let ret = unsafe {
+        libc::setsockopt(
+            socket_fd,
+            libc::SOL_SOCKET,
+            libc::SO_ATTACH_REUSEPORT_EBPF,
+            (&raw const prog_fd).cast::<libc::c_void>(),
+            std::mem::size_of::<libc::c_int>() as libc::socklen_t,
+        )
+    };
+    if ret < 0 {
+        return Err(io::Error::last_os_error());
+    }
+    Ok(())
+}

--- a/lading/src/neper/bpf_stub.rs
+++ b/lading/src/neper/bpf_stub.rs
@@ -1,18 +1,23 @@
 //! Stub for non-Linux platforms where eBPF is unavailable.
 
-use std::io;
 use std::os::fd::{OwnedFd, RawFd};
 
-pub(crate) fn load_reuseport_ebpf(_num_sockets: u32) -> io::Result<OwnedFd> {
-    Err(io::Error::new(
-        io::ErrorKind::Unsupported,
-        "reuseport eBPF is only supported on Linux",
-    ))
+#[derive(thiserror::Error, Debug)]
+pub(crate) enum Error {
+    #[error("bpf load failed: {reason}")]
+    Load { reason: String },
+    #[error("bpf attach failed: {reason}")]
+    Attach { reason: String },
 }
 
-pub(crate) fn attach_reuseport_ebpf(_socket_fd: RawFd, _prog: &OwnedFd) -> io::Result<()> {
-    Err(io::Error::new(
-        io::ErrorKind::Unsupported,
-        "reuseport eBPF is only supported on Linux",
-    ))
+pub(crate) fn load_reuseport_ebpf(_num_sockets: u32) -> Result<OwnedFd, Error> {
+    Err(Error::Load {
+        reason: "reuseport eBPF is only supported on Linux".to_string(),
+    })
+}
+
+pub(crate) fn attach_reuseport_ebpf(_socket_fd: RawFd, _prog: &OwnedFd) -> Result<(), Error> {
+    Err(Error::Attach {
+        reason: "reuseport eBPF is only supported on Linux".to_string(),
+    })
 }

--- a/lading/src/neper/bpf_stub.rs
+++ b/lading/src/neper/bpf_stub.rs
@@ -1,0 +1,18 @@
+//! Stub for non-Linux platforms where eBPF is unavailable.
+
+use std::io;
+use std::os::fd::{OwnedFd, RawFd};
+
+pub(crate) fn load_reuseport_ebpf(_num_sockets: u32) -> io::Result<OwnedFd> {
+    Err(io::Error::new(
+        io::ErrorKind::Unsupported,
+        "reuseport eBPF is only supported on Linux",
+    ))
+}
+
+pub(crate) fn attach_reuseport_ebpf(_socket_fd: RawFd, _prog: &OwnedFd) -> io::Result<()> {
+    Err(io::Error::new(
+        io::ErrorKind::Unsupported,
+        "reuseport eBPF is only supported on Linux",
+    ))
+}

--- a/lading/src/neper/flow.rs
+++ b/lading/src/neper/flow.rs
@@ -1,0 +1,85 @@
+//! Flow management for neper-style workloads.
+//!
+//! A "flow" is a single TCP connection managed by a thread's mio event loop.
+//! This module provides the generic [`Flow`] struct, token-indexed storage
+//! ([`FlowMap`]), and the [`Action`] enum that event handlers return to
+//! drive flow lifecycle.
+
+use mio::net::TcpStream;
+use mio::{Interest, Registry, Token};
+
+/// A network flow (TCP connection) managed by a thread's event loop.
+pub(crate) struct Flow<S> {
+    pub(crate) stream: TcpStream,
+    pub(crate) token: Token,
+    pub(crate) state: S,
+    /// Remaining bytes for the current I/O operation.
+    pub(crate) xfer: usize,
+}
+
+/// What the event loop should do after processing a flow event.
+#[derive(Clone, Copy)]
+pub(crate) enum Action {
+    /// No change to mio registration.
+    Continue,
+    /// Reregister the flow with a new interest set.
+    Reregister(Interest),
+    /// Deregister and remove the flow.
+    Remove,
+}
+
+/// Token-indexed flow storage.
+///
+/// Flows are stored in a `Vec` indexed by token value. Removed slots become
+/// `None` and are not reused — tokens are monotonically increasing, matching
+/// neper's behavior.
+pub(crate) struct FlowMap<S> {
+    inner: Vec<Option<Flow<S>>>,
+}
+
+impl<S> FlowMap<S> {
+    pub(crate) fn new() -> Self {
+        Self { inner: Vec::new() }
+    }
+
+    /// Insert a flow. Grows the backing vec if needed.
+    pub(crate) fn insert(&mut self, flow: Flow<S>) {
+        let idx = flow.token.0;
+        if idx >= self.inner.len() {
+            self.inner.resize_with(idx + 1, || None);
+        }
+        self.inner[idx] = Some(flow);
+    }
+
+    /// Get a mutable reference to the flow at the given token.
+    pub(crate) fn get_mut(&mut self, token: Token) -> Option<&mut Flow<S>> {
+        self.inner.get_mut(token.0).and_then(|slot| slot.as_mut())
+    }
+
+    /// Remove and return the flow at the given token.
+    pub(crate) fn remove(&mut self, token: Token) -> Option<Flow<S>> {
+        self.inner.get_mut(token.0).and_then(Option::take)
+    }
+}
+
+/// Apply an [`Action`] to a flow via the poll registry.
+pub(crate) fn apply_action<S>(
+    action: Action,
+    token: Token,
+    flows: &mut FlowMap<S>,
+    registry: &Registry,
+) {
+    match action {
+        Action::Continue => {}
+        Action::Reregister(interest) => {
+            if let Some(flow) = flows.get_mut(token) {
+                let _ = registry.reregister(&mut flow.stream, flow.token, interest);
+            }
+        }
+        Action::Remove => {
+            if let Some(mut flow) = flows.remove(token) {
+                let _ = registry.deregister(&mut flow.stream);
+            }
+        }
+    }
+}

--- a/lading/src/neper/metrics.rs
+++ b/lading/src/neper/metrics.rs
@@ -2,7 +2,7 @@
 //!
 //! Each OS thread owns a [`ThreadMetrics`] struct containing plain `u64`
 //! counters behind [`UnsafeCell`]. Workers increment via [`ThreadCounter::add`].
-//! A dedicated metrics thread periodically snapshots all counters, computes deltas, 
+//! A dedicated metrics thread periodically snapshots all counters, computes deltas,
 //! and submits aggregated values to the `metrics` crate via `counter!()`.
 //!
 //! ## Safety

--- a/lading/src/neper/metrics.rs
+++ b/lading/src/neper/metrics.rs
@@ -1,0 +1,162 @@
+//! Per-thread lock-free metrics for neper-style workloads.
+//!
+//! Each OS thread owns a [`ThreadMetrics`] struct containing plain `u64`
+//! counters behind [`UnsafeCell`]. Workers increment via [`ThreadCounter::add`].
+//! A dedicated metrics thread periodically snapshots all counters, computes deltas, 
+//! and submits aggregated values to the `metrics` crate via `counter!()`.
+//!
+//! ## Safety
+//!
+//! [`ThreadCounter`] is `Sync` because:
+//! - Only one thread (the owner) writes to the counter.
+//! - The snapshot thread only reads.
+//! - Since there is a single writer, and the snapshotter does not need the
+//!   precise counts every time, we avoid the use of atomics.
+
+use std::cell::UnsafeCell;
+use std::sync::atomic::{AtomicBool, Ordering::Relaxed};
+use std::time::{Duration, Instant};
+
+use metrics::counter;
+
+/// A counter written by exactly one thread and read (snapshot) by another.
+///
+/// Uses plain `u64` for zero overhead on the write path.
+#[repr(C, align(8))]
+pub(crate) struct ThreadCounter {
+    value: UnsafeCell<u64>,
+}
+
+// Safety: only one thread writes; reads are tear-free on aligned u64.
+unsafe impl Sync for ThreadCounter {}
+// Required for Arc<Vec<ThreadMetrics>>.
+unsafe impl Send for ThreadCounter {}
+
+impl ThreadCounter {
+    pub(crate) const fn new() -> Self {
+        Self {
+            value: UnsafeCell::new(0),
+        }
+    }
+
+    /// Increment. Must only be called from the owning thread.
+    #[inline]
+    pub(crate) fn add(&self, n: u64) {
+        unsafe { *self.value.get() += n }
+    }
+
+    /// Read current value. May be called from any thread (snapshot reader).
+    #[inline]
+    pub(crate) fn get(&self) -> u64 {
+        unsafe { *self.value.get() }
+    }
+}
+
+/// Defines [`ThreadMetrics`], the field-name array, and the `read_all` helper
+/// from a single list of field names. Add new metrics below to the macro call
+macro_rules! define_thread_metrics {
+    ($($name:ident),* $(,)?) => {
+        /// Per-thread counters.
+        /// Fields are a superset used across all modes — unused fields stay at 0.
+        #[repr(C, align(128))]
+        pub(crate) struct ThreadMetrics {
+            $(pub(crate) $name: ThreadCounter,)*
+        }
+
+        impl ThreadMetrics {
+            pub(crate) const fn new() -> Self {
+                Self {
+                    $($name: ThreadCounter::new(),)*
+                }
+            }
+        }
+
+        const FIELD_NAMES: &[&str] = &[$(stringify!($name),)*];
+
+        fn read_all(tm: &ThreadMetrics) -> Vec<u64> {
+            vec![$(tm.$name.get(),)*]
+        }
+    };
+}
+
+define_thread_metrics! {
+    requests_sent,
+    responses_received,
+    bytes_written,
+    bytes_read,
+    connections_failed,
+    connections_accepted,
+    requests_received_count,
+    responses_sent,
+    bytes_received,
+}
+
+/// Tracks previous snapshot values and computes deltas.
+struct MetricsSnapshot {
+    prev: Vec<Vec<u64>>,
+}
+
+impl MetricsSnapshot {
+    fn new(num_threads: usize) -> Self {
+        Self {
+            prev: vec![vec![0u64; FIELD_NAMES.len()]; num_threads],
+        }
+    }
+
+    fn snapshot_and_submit(
+        &mut self,
+        thread_metrics: &[ThreadMetrics],
+        labels: &[(String, String)],
+    ) {
+        let num_fields = FIELD_NAMES.len();
+        let mut totals = vec![0u64; num_fields];
+        for (i, tm) in thread_metrics.iter().enumerate() {
+            let curr = read_all(tm);
+            for f in 0..num_fields {
+                let delta = curr[f].wrapping_sub(self.prev[i][f]);
+                totals[f] += delta;
+            }
+            self.prev[i] = curr;
+        }
+        for f in 0..num_fields {
+            if totals[f] > 0 {
+                counter!(FIELD_NAMES[f], labels).increment(totals[f]);
+            }
+        }
+    }
+}
+
+/// Run the metrics snapshot loop on the current thread.
+///
+/// Blocks until `shutdown` is set. Performs a final snapshot before returning
+/// to flush any remaining deltas.
+pub(crate) fn run_metrics_thread(
+    thread_metrics: &[ThreadMetrics],
+    labels: &[(String, String)],
+    sample_period: Duration,
+    shutdown: &AtomicBool,
+) {
+    let mut snapshot = MetricsSnapshot::new(thread_metrics.len());
+
+    let mut total_snapshot_ns: u64 = 0;
+    let mut snapshot_count: u64 = 0;
+
+    while !shutdown.load(Relaxed) {
+        std::thread::sleep(sample_period);
+        let start = Instant::now();
+        snapshot.snapshot_and_submit(thread_metrics, labels);
+        total_snapshot_ns += u64::from(start.elapsed().subsec_nanos());
+        snapshot_count += 1;
+    }
+    // Final snapshot to capture remaining deltas.
+    snapshot.snapshot_and_submit(thread_metrics, labels);
+
+    if snapshot_count > 0 {
+        let avg_ns = total_snapshot_ns / snapshot_count;
+        tracing::info!(
+            avg_snapshot_ns = avg_ns,
+            snapshots = snapshot_count,
+            "metrics snapshot average: {avg_ns}ns over {snapshot_count} snapshots"
+        );
+    }
+}

--- a/lading/src/neper/metrics.rs
+++ b/lading/src/neper/metrics.rs
@@ -118,16 +118,16 @@ impl MetricsSnapshot {
 pub(crate) fn run_metrics_thread(
     thread_metrics: &[ThreadMetrics],
     labels: &[(String, String)],
-    sample_period: Duration,
     shutdown: &AtomicBool,
 ) {
     let mut snapshot = MetricsSnapshot::new(thread_metrics.len());
 
+    let interval = Duration::from_secs(5);
     let mut total_snapshot_ns: u64 = 0;
     let mut snapshot_count: u64 = 0;
 
     while !shutdown.load(Relaxed) {
-        std::thread::sleep(sample_period);
+        std::thread::sleep(interval);
         let start = Instant::now();
         snapshot.snapshot_and_submit(thread_metrics, labels);
         total_snapshot_ns += u64::from(start.elapsed().subsec_nanos());

--- a/lading/src/neper/metrics.rs
+++ b/lading/src/neper/metrics.rs
@@ -1,59 +1,44 @@
-//! Per-thread lock-free metrics for neper-style workloads.
+//! Per-thread metrics for neper-style workloads.
 //!
-//! Each OS thread owns a [`ThreadMetrics`] struct containing plain `u64`
-//! counters behind [`UnsafeCell`]. Workers increment via [`ThreadCounter::add`].
-//! A dedicated metrics thread periodically snapshots all counters, computes deltas,
-//! and submits aggregated values to the `metrics` crate via `counter!()`.
-//!
-//! ## Safety
-//!
-//! [`ThreadCounter`] is `Sync` because:
-//! - Only one thread (the owner) writes to the counter.
-//! - The snapshot thread only reads.
-//! - Since there is a single writer, and the snapshotter does not need the
-//!   precise counts every time, we avoid the use of atomics.
+//! Each OS thread owns a [`ThreadMetrics`] struct containing `AtomicU64`
+//! counters. Workers increment via [`ThreadCounter::add`] with `Relaxed`
+//! ordering. A dedicated metrics thread periodically snapshots all counters,
+//! computes deltas, and submits aggregated values to the `metrics` crate
+//! via `counter!()`.
 
-use std::cell::UnsafeCell;
-use std::sync::atomic::{AtomicBool, Ordering::Relaxed};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering::Relaxed};
 use std::time::{Duration, Instant};
 
 use metrics::counter;
 
-/// A counter written by exactly one thread and read (snapshot) by another.
-///
-/// Uses plain `u64` for zero overhead on the write path.
+/// A per-thread atomic counter.
 #[repr(C, align(8))]
 pub(crate) struct ThreadCounter {
-    value: UnsafeCell<u64>,
+    value: AtomicU64,
 }
-
-// Safety: only one thread writes; reads are tear-free on aligned u64.
-unsafe impl Sync for ThreadCounter {}
-// Required for Arc<Vec<ThreadMetrics>>.
-unsafe impl Send for ThreadCounter {}
 
 impl ThreadCounter {
     pub(crate) const fn new() -> Self {
         Self {
-            value: UnsafeCell::new(0),
+            value: AtomicU64::new(0),
         }
     }
 
-    /// Increment. Must only be called from the owning thread.
+    /// Increment the counter.
     #[inline]
     pub(crate) fn add(&self, n: u64) {
-        unsafe { *self.value.get() += n }
+        self.value.fetch_add(n, Relaxed);
     }
 
-    /// Read current value. May be called from any thread (snapshot reader).
+    /// Read current value.
     #[inline]
     pub(crate) fn get(&self) -> u64 {
-        unsafe { *self.value.get() }
+        self.value.load(Relaxed)
     }
 }
 
 /// Defines [`ThreadMetrics`], the field-name array, and the `read_all` helper
-/// from a single list of field names. Add new metrics below to the macro call
+/// from a single list of field names. Add new metrics below to the macro call.
 macro_rules! define_thread_metrics {
     ($($name:ident),* $(,)?) => {
         /// Per-thread counters.

--- a/lading/src/neper/metrics.rs
+++ b/lading/src/neper/metrics.rs
@@ -71,7 +71,7 @@ define_thread_metrics! {
     bytes_read,
     connections_failed,
     connections_accepted,
-    requests_received_count,
+    requests_received,
     responses_sent,
     bytes_received,
 }

--- a/lading/src/neper/thread.rs
+++ b/lading/src/neper/thread.rs
@@ -3,8 +3,8 @@
 //! Provides shutdown flag management, flow distribution, and thread
 //! spawning/joining utilities.
 
-use std::sync::atomic::AtomicBool;
 use std::sync::Arc;
+use std::sync::atomic::AtomicBool;
 use std::thread::{self, JoinHandle};
 
 /// Shared shutdown flag. Set by the async side when `lading_signal` fires.
@@ -41,11 +41,7 @@ pub(crate) fn join_all<T>(handles: Vec<JoinHandle<T>>) -> Result<Vec<T>, ()> {
             Err(_) => had_panic = true,
         }
     }
-    if had_panic {
-        Err(())
-    } else {
-        Ok(results)
-    }
+    if had_panic { Err(()) } else { Ok(results) }
 }
 
 /// Spawn a named OS thread running `f`.

--- a/lading/src/neper/thread.rs
+++ b/lading/src/neper/thread.rs
@@ -1,0 +1,86 @@
+//! OS thread lifecycle helpers for network throughput workloads
+//!
+//! Provides shutdown flag management, flow distribution, and thread
+//! spawning/joining utilities.
+
+use std::sync::atomic::AtomicBool;
+use std::sync::Arc;
+use std::thread::{self, JoinHandle};
+
+/// Shared shutdown flag. Set by the async side when `lading_signal` fires.
+/// Polled by OS threads in their event loops.
+pub(crate) type ShutdownFlag = Arc<AtomicBool>;
+
+/// Create a new shutdown flag, initially `false`.
+pub(crate) fn new_shutdown_flag() -> ShutdownFlag {
+    Arc::new(AtomicBool::new(false))
+}
+
+/// Distribute `total_flows` across `num_threads` threads.
+///
+/// Returns a `Vec` of length `num_threads` where entry `i` is the number of
+/// flows assigned to thread `i`. The remainder is distributed round-robin to
+/// the first threads.
+pub(crate) fn distribute_flows(total_flows: u16, num_threads: u16) -> Vec<u16> {
+    let base = total_flows / num_threads;
+    let remainder = total_flows % num_threads;
+    (0..num_threads)
+        .map(|i| base + u16::from(i < remainder))
+        .collect()
+}
+
+/// Join all thread handles.
+///
+/// Returns `Ok` with the collected results, or `Err` if any thread panicked.
+pub(crate) fn join_all<T>(handles: Vec<JoinHandle<T>>) -> Result<Vec<T>, ()> {
+    let mut results = Vec::with_capacity(handles.len());
+    let mut had_panic = false;
+    for handle in handles {
+        match handle.join() {
+            Ok(val) => results.push(val),
+            Err(_) => had_panic = true,
+        }
+    }
+    if had_panic {
+        Err(())
+    } else {
+        Ok(results)
+    }
+}
+
+/// Spawn a named OS thread running `f`.
+pub(crate) fn spawn_named<F, T>(name: &str, f: F) -> JoinHandle<T>
+where
+    F: FnOnce() -> T + Send + 'static,
+    T: Send + 'static,
+{
+    thread::Builder::new()
+        .name(name.to_string())
+        .spawn(f)
+        .expect("failed to spawn thread")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn distribute_even() {
+        assert_eq!(distribute_flows(4, 2), vec![2, 2]);
+    }
+
+    #[test]
+    fn distribute_remainder() {
+        assert_eq!(distribute_flows(5, 2), vec![3, 2]);
+    }
+
+    #[test]
+    fn distribute_more_threads_than_flows() {
+        assert_eq!(distribute_flows(2, 4), vec![1, 1, 0, 0]);
+    }
+
+    #[test]
+    fn distribute_single_thread() {
+        assert_eq!(distribute_flows(10, 1), vec![10]);
+    }
+}


### PR DESCRIPTION
### What does this PR do?

This PR adds a new tcp based network workload in lading supporting an application level measure of throughput. The workload performs transactions (ping/pongs), and the number of transactions performed within an experiment duration is the throughput. This is tracked via responses received by the generator.

This is an almost 1-1 rewrite of the tcp_rr tests in [neper](https://github.com/google/neper), with some simplifications for our usecase.

This load generator offers few advantages on top of the already existing tcp load generator:
- User controlled number of threads and flows.
- A more efficient blackhole implementation which can handle multiple flows distributed over a set number of threads.
- Precisely tuning the networking stack to load the intended parts of the system, for example set `TCP_NODELAY` to avoid buffering data.

In the future more toggles can be exposed such as pinning threads, different algorithms for assigning flows to sockets on the server side, etc.

### Motivation

Support load testing eBPF based network tracers.

### Related issues


### Additional Notes
