### PR TITLE
Allow seed to be specified as a string.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+## Added
+- The top-level `seed` config option now accepts a string in addition to the
+  existing 32-element byte array. String seeds are hashed with SHA-256 to
+  derive the 32 seed bytes, allowing memorable seeds like `"black cat"`.
 
 ## [0.32.0]
 ## Changed

--- a/lading/src/bin/payloadtool.rs
+++ b/lading/src/bin/payloadtool.rs
@@ -253,6 +253,7 @@ fn shannon_entropy(data: &[u8]) -> f64 {
     entropy
 }
 
+use lading::common::Seed;
 use tracing::{error, info, trace, warn};
 use tracing_subscriber::{fmt::format::FmtSpan, util::SubscriberInitExt};
 
@@ -283,12 +284,12 @@ struct Args {
 
 fn generate_and_check(
     config: &lading_payload::Config,
-    seed: [u8; 32],
+    seed: Seed,
     total_bytes: NonZeroU32,
     max_block_size: Byte,
     args: &Args,
 ) -> Result<Option<Fingerprint>> {
-    let mut rng = StdRng::from_seed(seed);
+    let mut rng = StdRng::from_seed(*seed);
     let start = Instant::now();
     let blocks = match block::Cache::fixed_with_max_overhead(
         &mut rng,

--- a/lading/src/common.rs
+++ b/lading/src/common.rs
@@ -1,6 +1,77 @@
-use std::{fmt, fs, path::PathBuf, process::Stdio, str};
+use std::{fmt, fs, ops::Deref, path::PathBuf, process::Stdio, str};
 
-use serde::Deserialize;
+use serde::{Deserialize, Deserializer, Serialize};
+use sha2::{Digest, Sha256};
+
+/// A seed for random number generation.
+///
+/// Accepts either a 32-element byte array (e.g. `[1, 2, 3, ...]`) or a plain
+/// string. When a string is given, its SHA-256 hash is used as the seed bytes,
+/// so any two invocations with the same string produce identical output.
+///
+/// # YAML examples
+///
+/// ```yaml
+/// seed: [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53,
+///        59, 61, 67, 71, 73, 79, 83, 89, 97, 101, 103, 107, 109, 113, 127, 131]
+/// ```
+///
+/// ```yaml
+/// seed: "black cat"
+/// ```
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(transparent)]
+pub struct Seed([u8; 32]);
+
+impl Default for Seed {
+    fn default() -> Self {
+        Self([0u8; 32])
+    }
+}
+
+impl Deref for Seed {
+    type Target = [u8; 32];
+
+    fn deref(&self) -> &[u8; 32] {
+        &self.0
+    }
+}
+
+impl From<[u8; 32]> for Seed {
+    fn from(value: [u8; 32]) -> Self {
+        Self(value)
+    }
+}
+
+impl From<Seed> for [u8; 32] {
+    fn from(value: Seed) -> Self {
+        value.0
+    }
+}
+
+impl<'de> Deserialize<'de> for Seed {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        #[derive(Deserialize)]
+        #[serde(untagged)]
+        enum Helper {
+            Bytes([u8; 32]),
+            String(String),
+        }
+
+        match Helper::deserialize(deserializer)? {
+            Helper::Bytes(arr) => Ok(Seed(arr)),
+            Helper::String(s) => {
+                let hash = Sha256::digest(s.as_bytes());
+                let mut arr = [0u8; 32];
+                arr.copy_from_slice(&hash);
+                Ok(Seed(arr))
+            }
+        }
+    }
+}
 
 #[derive(Debug, Deserialize, PartialEq, Eq, Clone)]
 #[serde(deny_unknown_fields)]
@@ -48,6 +119,52 @@ impl str::FromStr for Behavior {
         let mut path = PathBuf::new();
         path.push(input);
         Ok(Behavior::Log(path))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Seed;
+
+    #[test]
+    fn seed_from_byte_array() {
+        let yaml = "[1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32]";
+        let seed: Seed = serde_yaml::from_str(yaml).unwrap();
+        assert_eq!(
+            *seed,
+            [
+                1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23,
+                24, 25, 26, 27, 28, 29, 30, 31, 32
+            ]
+        );
+    }
+
+    #[test]
+    fn seed_from_string_is_deterministic() {
+        let a: Seed = serde_yaml::from_str("\"black cat\"").unwrap();
+        let b: Seed = serde_yaml::from_str("\"black cat\"").unwrap();
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn seed_different_strings_differ() {
+        let a: Seed = serde_yaml::from_str("\"black cat\"").unwrap();
+        let b: Seed = serde_yaml::from_str("\"umbrella\"").unwrap();
+        assert_ne!(a, b);
+    }
+
+    #[test]
+    fn seed_roundtrips_via_serde() {
+        let original: Seed = serde_yaml::from_str("\"hello world\"").unwrap();
+        let serialized = serde_yaml::to_string(&original).unwrap();
+        let roundtripped: Seed = serde_yaml::from_str(&serialized).unwrap();
+        assert_eq!(original, roundtripped);
+    }
+
+    #[test]
+    fn seed_default_is_zeroes() {
+        let s = Seed::default();
+        assert_eq!(*s, [0u8; 32]);
     }
 }
 

--- a/lading/src/config.rs
+++ b/lading/src/config.rs
@@ -508,7 +508,7 @@ mod tests {
                 id: id.map(String::from),
             },
             inner: generator::Inner::Tcp(generator::tcp::Config {
-                seed: [0; 32],
+                seed: Default::default(),
                 addr: format!("127.0.0.1:{port}").parse().unwrap(),
                 variant: lading_payload::Config::Ascii,
                 bytes_per_second: None,

--- a/lading/src/generator/file_gen/logrotate.rs
+++ b/lading/src/generator/file_gen/logrotate.rs
@@ -38,6 +38,7 @@ use tracing::{debug, error, info};
 use lading_payload::block;
 
 use super::General;
+use crate::common::Seed;
 use crate::generator::common::{
     BlockThrottle, MetricsBuilder, ThrottleConfig, ThrottleConversionError, create_throttle,
 };
@@ -129,7 +130,7 @@ fn default_flush_every() -> Duration {
 /// Configuration of [`FileGen`]
 pub struct Config {
     /// The seed for random operations against this target
-    pub seed: [u8; 32],
+    pub seed: Seed,
     /// The root path for writing logs.
     pub root: PathBuf,
     /// Total number of concurrent logs.
@@ -191,7 +192,7 @@ impl Server {
         config: Config,
         shutdown: lading_signal::Watcher,
     ) -> Result<Self, Error> {
-        let mut rng = StdRng::from_seed(config.seed);
+        let mut rng = StdRng::from_seed(config.seed.into());
         let labels = MetricsBuilder::new("logrotate").with_id(general.id).build();
 
         let maximum_bytes_per_log =

--- a/lading/src/generator/file_gen/logrotate_fs.rs
+++ b/lading/src/generator/file_gen/logrotate_fs.rs
@@ -40,7 +40,7 @@ const TTL: Duration = Duration::from_secs(1); // Attribute cache timeout
 /// Configuration of [`FileGen`]
 pub struct Config {
     /// The seed for random operations against this target
-    pub seed: [u8; 32],
+    pub seed: crate::common::Seed,
     /// Total number of concurrent logs.
     concurrent_logs: u16,
     /// The maximum byte size of each log.
@@ -175,7 +175,7 @@ impl Server {
         config: Config,
         shutdown: lading_signal::Watcher,
     ) -> Result<Self, Error> {
-        let mut rng = SmallRng::from_seed(config.seed);
+        let mut rng = SmallRng::from_seed(config.seed.into());
 
         let total_bytes =
             NonZeroU32::new(config.maximum_prebuild_cache_size_bytes.as_u128() as u32)

--- a/lading/src/generator/file_gen/traditional.rs
+++ b/lading/src/generator/file_gen/traditional.rs
@@ -90,7 +90,7 @@ fn default_flush_every() -> Duration {
 /// Configuration of [`FileGen`]
 pub struct Config {
     /// The seed for random operations against this target
-    pub seed: [u8; 32],
+    pub seed: crate::common::Seed,
     /// The path template for logs. "%NNN%" will be replaced in the template
     /// with the duplicate number.
     pub path_template: String,
@@ -162,7 +162,7 @@ impl Server {
         config: Config,
         shutdown: lading_signal::Watcher,
     ) -> Result<Self, Error> {
-        let mut rng = StdRng::from_seed(config.seed);
+        let mut rng = StdRng::from_seed(config.seed.into());
         let _labels = MetricsBuilder::new("file_gen").with_id(general.id).build();
 
         let maximum_bytes_per_file =

--- a/lading/src/generator/file_tree.rs
+++ b/lading/src/generator/file_tree.rs
@@ -116,7 +116,7 @@ fn default_rename_per_name() -> NonZeroU32 {
 /// Configuration of [`FileTree`]
 pub struct Config {
     /// The seed for random operations against this target
-    pub seed: [u8; 32],
+    pub seed: crate::common::Seed,
     /// The maximum depth of the file tree
     #[serde(default = "default_max_depth")]
     pub max_depth: NonZeroUsize,
@@ -167,7 +167,7 @@ impl FileTree {
     /// Creation will fail if the target file/folder cannot be opened for writing.
     #[allow(clippy::cast_possible_truncation)]
     pub fn new(config: &Config, shutdown: lading_signal::Watcher) -> Result<Self, Error> {
-        let mut rng = StdRng::from_seed(config.seed);
+        let mut rng = StdRng::from_seed(config.seed.into());
         let (nodes, _total_files, total_folder) = generate_tree(&mut rng, config)?;
 
         let _labels = [

--- a/lading/src/generator/grpc.rs
+++ b/lading/src/generator/grpc.rs
@@ -98,7 +98,7 @@ pub struct Config {
     /// The gRPC URI. Looks like `http://<host>/<service path>/<endpoint>`
     pub target_uri: String,
     /// The seed for random operations against this target
-    pub seed: [u8; 32],
+    pub seed: crate::common::Seed,
     /// The payload variant. This should be protobuf encoded for typical gRPC
     /// endpoints.
     pub variant: lading_payload::Config,
@@ -197,7 +197,7 @@ impl Grpc {
         config: Config,
         shutdown: lading_signal::Watcher,
     ) -> Result<Self, Error> {
-        let mut rng = StdRng::from_seed(config.seed);
+        let mut rng = StdRng::from_seed(config.seed.into());
         let labels = MetricsBuilder::new("grpc").with_id(general.id).build();
 
         let throttle = create_throttle(config.throttle.as_ref(), config.bytes_per_second.as_ref())?;

--- a/lading/src/generator/http.rs
+++ b/lading/src/generator/http.rs
@@ -58,7 +58,7 @@ pub enum Method {
 /// Configuration of this generator.
 pub struct Config {
     /// The seed for random operations against this target
-    pub seed: [u8; 32],
+    pub seed: crate::common::Seed,
     /// The URI for the target, must be a valid URI
     #[serde(with = "http_serde::uri")]
     pub target_uri: Uri,
@@ -146,7 +146,7 @@ impl Http {
         config: Config,
         shutdown: lading_signal::Watcher,
     ) -> Result<Self, Error> {
-        let mut rng = StdRng::from_seed(config.seed);
+        let mut rng = StdRng::from_seed(config.seed.into());
 
         let labels = MetricsBuilder::new("http").with_id(general.id).build();
 

--- a/lading/src/generator/passthru_file.rs
+++ b/lading/src/generator/passthru_file.rs
@@ -31,7 +31,7 @@ use crate::generator::common::{
 /// Configuration of this generator.
 pub struct Config {
     /// The seed for random operations against this target
-    pub seed: [u8; 32],
+    pub seed: crate::common::Seed,
     /// The local filesystem path to write data to
     pub path: String,
     /// The payload variant
@@ -96,7 +96,7 @@ impl PassthruFile {
         config: &Config,
         shutdown: lading_signal::Watcher,
     ) -> Result<Self, Error> {
-        let mut rng = StdRng::from_seed(config.seed);
+        let mut rng = StdRng::from_seed(config.seed.into());
         let labels = MetricsBuilder::new("passthru_file")
             .with_id(general.id)
             .build();

--- a/lading/src/generator/process_tree.rs
+++ b/lading/src/generator/process_tree.rs
@@ -220,7 +220,7 @@ pub struct Executable {
 /// Configuration of [`ProcessTree`]
 pub struct Config {
     /// The seed for random operations against this target
-    pub seed: [u8; 32],
+    pub seed: crate::common::Seed,
     /// The number of process created per second
     pub max_tree_per_second: Option<NonZeroU32>,
     /// The maximum depth of the process tree

--- a/lading/src/generator/procfs.rs
+++ b/lading/src/generator/procfs.rs
@@ -42,7 +42,7 @@ fn default_copy_from_host() -> Vec<PathBuf> {
 /// Configuration of [`Procfs`]
 pub struct Config {
     /// Seed for random operations against this target
-    pub seed: [u8; 32],
+    pub seed: crate::common::Seed,
     /// Root path for `procfs` filesystem
     pub root: PathBuf,
     /// Total number of processes created
@@ -72,7 +72,7 @@ impl ProcFs {
     ///
     /// Function should never panic.
     pub fn new(config: &Config, shutdown: lading_signal::Watcher) -> Result<Self, Error> {
-        let mut rng = StdRng::from_seed(config.seed);
+        let mut rng = StdRng::from_seed(config.seed.into());
 
         let total_processes = config.total_processes.get();
         let mut processes = procfs::fixed(&mut rng, total_processes as usize)?;

--- a/lading/src/generator/splunk_hec.rs
+++ b/lading/src/generator/splunk_hec.rs
@@ -70,7 +70,7 @@ pub struct AckSettings {
 #[serde(deny_unknown_fields)]
 pub struct Config {
     /// The seed for random operations against this target
-    pub seed: [u8; 32],
+    pub seed: crate::common::Seed,
     /// The URI for the target, must be a valid URI
     #[serde(with = "http_serde::uri")]
     pub target_uri: Uri,
@@ -197,7 +197,7 @@ impl SplunkHec {
         config: Config,
         shutdown: lading_signal::Watcher,
     ) -> Result<Self, Error> {
-        let mut rng = StdRng::from_seed(config.seed);
+        let mut rng = StdRng::from_seed(config.seed.into());
         let labels = MetricsBuilder::new("splunk_hec")
             .with_id(general.id)
             .build();

--- a/lading/src/generator/tcp.rs
+++ b/lading/src/generator/tcp.rs
@@ -45,7 +45,7 @@ fn default_parallel_connections() -> u16 {
 /// Configuration of this generator.
 pub struct Config {
     /// The seed for random operations against this target
-    pub seed: [u8; 32],
+    pub seed: crate::common::Seed,
     /// The address for the target, must be a valid `SocketAddr`
     pub addr: String,
     /// The payload variant
@@ -136,7 +136,7 @@ impl Tcp {
         config: &Config,
         shutdown: lading_signal::Watcher,
     ) -> Result<Self, Error> {
-        let mut rng = StdRng::from_seed(config.seed);
+        let mut rng = StdRng::from_seed(config.seed.into());
         let labels = MetricsBuilder::new("tcp").with_id(general.id).build();
 
         let total_bytes =

--- a/lading/src/generator/trace_agent.rs
+++ b/lading/src/generator/trace_agent.rs
@@ -155,7 +155,7 @@ impl fmt::Display for Version {
 #[serde(deny_unknown_fields)]
 pub struct Config {
     /// The seed for random operations against this target
-    pub seed: [u8; 32],
+    pub seed: crate::common::Seed,
     /// The base URI for the trace-agent
     #[serde(with = "http_serde::uri")]
     pub target_uri: Uri,
@@ -273,7 +273,7 @@ impl TraceAgent {
         config: &Config,
         shutdown: lading_signal::Watcher,
     ) -> Result<Self, Error> {
-        let mut rng = StdRng::from_seed(config.seed);
+        let mut rng = StdRng::from_seed(config.seed.into());
 
         let labels = MetricsBuilder::new("trace_agent")
             .with_id(general.id)

--- a/lading/src/generator/udp.rs
+++ b/lading/src/generator/udp.rs
@@ -54,7 +54,7 @@ fn maximum_block_size() -> Byte {
 /// Configuration of this generator.
 pub struct Config {
     /// The seed for random operations against this target
-    pub seed: [u8; 32],
+    pub seed: crate::common::Seed,
     /// The address for the target, must be a valid `SocketAddr`
     pub addr: String,
     /// The local address to bind the UDP socket to. Defaults to 127.0.0.1:0.
@@ -146,7 +146,7 @@ impl Udp {
         config: &Config,
         shutdown: lading_signal::Watcher,
     ) -> Result<Self, Error> {
-        let mut rng = StdRng::from_seed(config.seed);
+        let mut rng = StdRng::from_seed(config.seed.into());
         let labels = MetricsBuilder::new("udp").with_id(general.id).build();
 
         let total_bytes =

--- a/lading/src/generator/unix_datagram.rs
+++ b/lading/src/generator/unix_datagram.rs
@@ -46,7 +46,7 @@ fn maximum_block_size() -> Byte {
 /// Configuration of this generator.
 pub struct Config {
     /// The seed for random operations against this target
-    pub seed: [u8; 32],
+    pub seed: crate::common::Seed,
     /// The path of the socket to write to.
     pub path: PathBuf,
     /// The payload variant
@@ -153,7 +153,7 @@ impl UnixDatagram {
         config: &Config,
         shutdown: lading_signal::Watcher,
     ) -> Result<Self, Error> {
-        let mut rng = StdRng::from_seed(config.seed);
+        let mut rng = StdRng::from_seed(config.seed.into());
         let labels = MetricsBuilder::new("unix_datagram")
             .with_id(general.id)
             .build();

--- a/lading/src/generator/unix_stream.rs
+++ b/lading/src/generator/unix_stream.rs
@@ -38,7 +38,7 @@ fn default_parallel_connections() -> u16 {
 /// Configuration of this generator.
 pub struct Config {
     /// The seed for random operations against this target
-    pub seed: [u8; 32],
+    pub seed: crate::common::Seed,
     /// The path of the socket to write to.
     pub path: PathBuf,
     /// The payload variant
@@ -150,7 +150,7 @@ impl UnixStream {
         config: &Config,
         shutdown: lading_signal::Watcher,
     ) -> Result<Self, Error> {
-        let mut rng = StdRng::from_seed(config.seed);
+        let mut rng = StdRng::from_seed(config.seed.into());
         let labels = MetricsBuilder::new("unix_stream")
             .with_id(general.id)
             .build();

--- a/lading/src/lib.rs
+++ b/lading/src/lib.rs
@@ -13,7 +13,7 @@ use http_body_util::BodyExt;
 
 pub mod blackhole;
 pub(crate) mod codec;
-mod common;
+pub mod common;
 pub mod config;
 pub mod generator;
 pub mod inspector;


### PR DESCRIPTION

### What does this PR do?

Add a Seed newtype wrapping [u8; 32] with custom deserialization that accepts either a 32-element byte array (existing behavior) or a plain string. String seeds are hashed with SHA-256 to produce the 32 seed bytes, so "black cat" and "umbrella" each yield a unique but consistent seed without forcing users to supply raw byte arrays.

### Motivation

Sorry this is a bit of a drive-by PR. But I noticed we keep copying the same array over and over, basically always using the same seed, because we are too lazy to edit those u8s. A colleague suggested maybe they would open a PR to maybe make it possible to just bloop a string there and have it hashed stably, so I scooped him and opened a PR.

### Related issues

It just makes it easier to bloop your stable seed when copying a lading config.
