### PR TITLE
Update rand crate from 0.9 to 0.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+- Updated to rand 0.10.x
 
 ## [0.32.0]
 ## Changed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -599,6 +599,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
+name = "chacha20"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "rand_core 0.10.0",
+]
+
+[[package]]
 name = "chrono"
 version = "0.4.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -709,7 +720,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "531185e432bb31db1ecda541e9e7ab21468d4d844ad7505e0546a49b4945d49b"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "proptest",
  "serde_core",
 ]
@@ -755,6 +766,15 @@ name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
 ]
@@ -1284,6 +1304,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "r-efi 6.0.0",
+ "rand_core 0.10.0",
  "wasip2",
  "wasip3",
 ]
@@ -1930,7 +1951,7 @@ dependencies = [
  "proptest",
  "prost",
  "prost-build",
- "rand 0.9.2",
+ "rand 0.10.1",
  "regex",
  "reqwest",
  "rustc-hash",
@@ -1977,7 +1998,7 @@ dependencies = [
  "parquet",
  "proptest",
  "protobuf",
- "rand 0.9.2",
+ "rand 0.10.1",
  "rustc-hash",
  "serde",
  "serde_json",
@@ -2014,7 +2035,7 @@ dependencies = [
  "proptest",
  "proptest-derive",
  "prost",
- "rand 0.9.2",
+ "rand 0.10.1",
  "rmp-serde",
  "rustc-hash",
  "serde",
@@ -3102,6 +3123,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
+dependencies = [
+ "chacha20",
+ "getrandom 0.4.2",
+ "rand_core 0.10.0",
+]
+
+[[package]]
 name = "rand_chacha"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3138,6 +3170,12 @@ checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
  "getrandom 0.3.4",
 ]
+
+[[package]]
+name = "rand_core"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c8d0fd677905edcbeedbf2edb6494d676f0e98d54d5cf9bda0b061cb8fb8aba"
 
 [[package]]
 name = "rand_xorshift"
@@ -3730,7 +3768,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest",
 ]
 
@@ -3917,7 +3955,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.2",
+ "getrandom 0.3.4",
  "once_cell",
  "rustix 1.1.4",
  "windows-sys 0.61.2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ metrics-exporter-prometheus = { version = "0.18", default-features = false, feat
 ] }
 prost = "0.14"
 prost-build = "0.14"
-rand = { version = "0.9", default-features = false }
+rand = { version = "0.10", default-features = false }
 rustc-hash = "2.1"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/lading/Cargo.toml
+++ b/lading/Cargo.toml
@@ -60,7 +60,7 @@ num-traits = { version = "0.2", default-features = false }
 once_cell = { workspace = true }
 opentelemetry-proto = { workspace = true }
 prost = { workspace = true }
-rand = { workspace = true, features = ["small_rng", "thread_rng"] }
+rand = { workspace = true, features = ["thread_rng"] }
 regex = { version = "1.12" }
 reqwest = { version = "0.12", default-features = false, features = [
   "default-tls",

--- a/lading/src/blackhole/sqs.rs
+++ b/lading/src/blackhole/sqs.rs
@@ -11,7 +11,7 @@ use bytes::Bytes;
 use http_body_util::{BodyExt, combinators::BoxBody};
 use hyper::{Request, Response, StatusCode};
 use metrics::counter;
-use rand::{Rng, distr::Alphanumeric};
+use rand::{RngExt, distr::Alphanumeric};
 use serde::{Deserialize, Serialize};
 use std::{fmt::Write, net::SocketAddr};
 use tracing::{debug, error};

--- a/lading/src/generator/file_gen/logrotate.rs
+++ b/lading/src/generator/file_gen/logrotate.rs
@@ -26,7 +26,7 @@ use tokio::time::{Instant, MissedTickBehavior, interval_at};
 use byte_unit::Byte;
 use futures::future::join_all;
 use metrics::counter;
-use rand::{Rng, SeedableRng, prelude::StdRng};
+use rand::{RngExt, SeedableRng, prelude::StdRng};
 use serde::{Deserialize, Serialize};
 use tokio::{
     fs,

--- a/lading/src/generator/file_gen/logrotate_fs/model.rs
+++ b/lading/src/generator/file_gen/logrotate_fs/model.rs
@@ -3,7 +3,7 @@
 use bytes::Bytes;
 use lading_payload::block;
 use metrics::counter;
-use rand::{Rng, SeedableRng, rngs::SmallRng};
+use rand::{Rng, RngExt, SeedableRng, rngs::SmallRng};
 use rustc_hash::FxHashMap;
 use std::collections::BTreeSet;
 use tracing::info;

--- a/lading/src/generator/kubernetes/state_machine.rs
+++ b/lading/src/generator/kubernetes/state_machine.rs
@@ -564,7 +564,7 @@ mod tests {
     }
 
     fn generate_event_sequence(seed: u64, instances: u32) -> Vec<Event> {
-        use rand::{Rng, SeedableRng, rngs::StdRng};
+        use rand::{RngExt, SeedableRng, rngs::StdRng};
 
         let mut rng = StdRng::seed_from_u64(seed);
         let mut events = Vec::new();

--- a/lading_capture/Cargo.toml
+++ b/lading_capture/Cargo.toml
@@ -59,9 +59,8 @@ path = "../lading_fuzz"
 optional = true
 
 [dependencies.rand]
-version = "0.9"
-default-features = false
-features = ["small_rng", "std"]
+workspace = true
+features = ["std"]
 optional = true
 
 [dependencies.anyhow]

--- a/lading_capture/src/bin/fuzz_capture_harness.rs
+++ b/lading_capture/src/bin/fuzz_capture_harness.rs
@@ -14,7 +14,7 @@ use lading_capture::{
     formats::jsonl, line::Line, manager::CaptureManager, manager::RealClock,
     test::writer::InMemoryWriter, validate,
 };
-use rand::{Rng, SeedableRng, rngs::SmallRng};
+use rand::{Rng, RngExt, SeedableRng, rngs::SmallRng};
 use std::io::{self, Read};
 use std::process::ExitCode;
 use std::time::{Duration, Instant};

--- a/lading_payload/Cargo.toml
+++ b/lading_payload/Cargo.toml
@@ -18,7 +18,7 @@ byte-unit = { workspace = true }
 chrono = { workspace = true }
 opentelemetry-proto = { workspace = true }
 prost = { workspace = true }
-rand = { workspace = true, features = ["small_rng", "std", "std_rng"] }
+rand = { workspace = true, features = ["std", "std_rng"] }
 rustc-hash = { workspace = true }
 rmp-serde = { version = "1.3", default-features = false }
 serde = { workspace = true }

--- a/lading_payload/fuzz/Cargo.toml
+++ b/lading_payload/fuzz/Cargo.toml
@@ -10,8 +10,7 @@ cargo-fuzz = true
 [dependencies]
 libfuzzer-sys = "0.4"
 arbitrary = { version = "1", features = ["derive"] }
-rand = { version = "0.9", default-features = false, features = [
-  "small_rng",
+rand = { version = "0.10", default-features = false, features = [
   "std",
   "std_rng",
 ] }

--- a/lading_payload/src/apache_common.rs
+++ b/lading_payload/src/apache_common.rs
@@ -3,7 +3,7 @@
 use crate::{Error, Generator, common::strings};
 
 use core::fmt;
-use rand::{Rng, distr::StandardUniform, prelude::Distribution, seq::IndexedRandom};
+use rand::{Rng, RngExt, distr::StandardUniform, prelude::Distribution, seq::IndexedRandom};
 use std::io::Write;
 
 const PATH_NAMES: [&str; 25] = [

--- a/lading_payload/src/ascii.rs
+++ b/lading_payload/src/ascii.rs
@@ -2,7 +2,7 @@
 
 use std::io::Write;
 
-use rand::Rng;
+use rand::{Rng, RngExt};
 
 use crate::{Error, common::strings};
 

--- a/lading_payload/src/block.rs
+++ b/lading_payload/src/block.rs
@@ -9,7 +9,7 @@ use std::num::NonZeroU32;
 
 use byte_unit::{Byte, Unit};
 use bytes::{BufMut, Bytes, BytesMut, buf::Writer};
-use rand::Rng;
+use rand::{Rng, RngExt};
 use serde::{Deserialize, Serialize};
 use tokio::time::Instant;
 use tracing::{Level, debug, error, info, span, warn};

--- a/lading_payload/src/common/config.rs
+++ b/lading_payload/src/common/config.rs
@@ -1,6 +1,6 @@
 //! Common configuration for all lading payloads
 
-use rand::distr::uniform::SampleUniform;
+use rand::{RngExt, distr::uniform::SampleUniform};
 use serde::Deserialize;
 use std::{cmp, fmt};
 

--- a/lading_payload/src/common/strings.rs
+++ b/lading_payload/src/common/strings.rs
@@ -1,7 +1,7 @@
 //! Code for the quick creation of randomize strings
 
 use enum_dispatch::enum_dispatch;
-use rand::seq::IndexedRandom;
+use rand::{RngExt, seq::IndexedRandom};
 
 mod random_string_pool;
 mod string_list_pool;

--- a/lading_payload/src/common/strings/random_string_pool.rs
+++ b/lading_payload/src/common/strings/random_string_pool.rs
@@ -1,5 +1,5 @@
-use rand::Rng;
 use rand::distr::uniform::SampleUniform;
+use rand::{Rng, RngExt};
 use std::ops::Range;
 use std::rc::Rc;
 

--- a/lading_payload/src/common/strings/string_list_pool.rs
+++ b/lading_payload/src/common/strings/string_list_pool.rs
@@ -1,3 +1,5 @@
+use rand::RngExt;
+
 use super::{Handle, Pool};
 
 /// Error type for `StringListPool` pattern expansion

--- a/lading_payload/src/common/tags.rs
+++ b/lading_payload/src/common/tags.rs
@@ -3,8 +3,8 @@ use std::cell::{Cell, RefCell};
 use std::collections::HashSet;
 use std::rc::Rc;
 
-use rand::Rng;
 use rand::distr::{Distribution, OpenClosed01};
+use rand::{Rng, RngExt};
 use rand::{SeedableRng, rngs::SmallRng};
 use tracing::warn;
 

--- a/lading_payload/src/datadog_logs.rs
+++ b/lading_payload/src/datadog_logs.rs
@@ -2,7 +2,7 @@
 
 use std::io::Write;
 
-use rand::{Rng, distr::StandardUniform, prelude::Distribution, seq::IndexedRandom};
+use rand::{Rng, RngExt, distr::StandardUniform, prelude::Distribution, seq::IndexedRandom};
 
 use crate::{Error, Generator, common::strings};
 

--- a/lading_payload/src/dogstatsd.rs
+++ b/lading_payload/src/dogstatsd.rs
@@ -2,7 +2,7 @@
 
 use std::{fmt, io::Write, rc::Rc};
 
-use rand::{Rng, distr::weighted::WeightedIndex, prelude::Distribution};
+use rand::{Rng, RngExt, distr::weighted::WeightedIndex, prelude::Distribution};
 use serde::Deserialize;
 use tracing::{debug, warn};
 

--- a/lading_payload/src/dogstatsd/common.rs
+++ b/lading_payload/src/dogstatsd/common.rs
@@ -1,7 +1,7 @@
 use std::fmt;
 
 use rand::{
-    Rng,
+    Rng, RngExt,
     distr::{OpenClosed01, StandardUniform, Uniform},
     prelude::Distribution,
 };

--- a/lading_payload/src/dogstatsd/event.rs
+++ b/lading_payload/src/dogstatsd/event.rs
@@ -1,7 +1,7 @@
 //! `DogStatsD` event.
 use std::{fmt, ops::Range};
 
-use rand::{Rng, distr::StandardUniform, prelude::Distribution};
+use rand::{Rng, RngExt, distr::StandardUniform, prelude::Distribution};
 
 use crate::{Error, Generator, common::strings};
 

--- a/lading_payload/src/dogstatsd/service_check.rs
+++ b/lading_payload/src/dogstatsd/service_check.rs
@@ -1,7 +1,7 @@
 //! `DogStatsD` service check.
 use std::fmt;
 
-use rand::{Rng, distr::StandardUniform, prelude::Distribution, seq::IndexedRandom};
+use rand::{Rng, RngExt, distr::StandardUniform, prelude::Distribution, seq::IndexedRandom};
 
 use crate::{
     Error, Generator,

--- a/lading_payload/src/fluent.rs
+++ b/lading_payload/src/fluent.rs
@@ -5,7 +5,7 @@
 use std::collections::BTreeMap;
 use std::io::Write;
 
-use rand::Rng;
+use rand::{Rng, RngExt};
 use rmp_serde::Serializer;
 use serde::Serialize;
 use serde_tuple::Serialize_tuple;

--- a/lading_payload/src/json.rs
+++ b/lading_payload/src/json.rs
@@ -2,7 +2,7 @@
 
 use std::io::Write;
 
-use rand::{Rng, distr::StandardUniform, prelude::Distribution, seq::IndexedRandom};
+use rand::{Rng, RngExt, distr::StandardUniform, prelude::Distribution, seq::IndexedRandom};
 
 use crate::Error;
 

--- a/lading_payload/src/opentelemetry/log.rs
+++ b/lading_payload/src/opentelemetry/log.rs
@@ -50,7 +50,7 @@ use opentelemetry_proto::tonic::{
     collector::logs::v1::ExportLogsServiceRequest, logs::v1::ResourceLogs,
 };
 use prost::Message;
-use rand::Rng;
+use rand::{Rng, RngExt};
 use serde::Deserialize;
 use std::{cell::RefCell, io::Write, rc::Rc};
 

--- a/lading_payload/src/opentelemetry/log/templates.rs
+++ b/lading_payload/src/opentelemetry/log/templates.rs
@@ -7,7 +7,7 @@ use opentelemetry_proto::tonic::{
 };
 use prost::Message;
 use rand::{
-    Rng,
+    Rng, RngExt,
     distr::{Distribution, weighted::WeightedIndex},
 };
 

--- a/lading_payload/src/opentelemetry/metric.rs
+++ b/lading_payload/src/opentelemetry/metric.rs
@@ -41,6 +41,7 @@
 pub(crate) mod templates;
 pub(crate) mod unit;
 
+use rand::RngExt;
 use std::rc::Rc;
 use std::{cell::RefCell, io::Write};
 

--- a/lading_payload/src/opentelemetry/metric/templates.rs
+++ b/lading_payload/src/opentelemetry/metric/templates.rs
@@ -12,7 +12,7 @@ use opentelemetry_proto::tonic::{
 };
 use prost::Message;
 use rand::{
-    Rng,
+    Rng, RngExt,
     distr::{Distribution, StandardUniform, weighted::WeightedIndex},
 };
 use tracing::debug;

--- a/lading_payload/src/opentelemetry/metric/unit.rs
+++ b/lading_payload/src/opentelemetry/metric/unit.rs
@@ -7,6 +7,8 @@
 // that for our purposes, so for now we rely on a simple table method. I imagine
 // we can just keep stuffing the table for a while as seems desirable.
 
+use rand::RngExt;
+
 use crate::opentelemetry::common::GeneratorError;
 
 const UNITS: &[&str] = &[

--- a/lading_payload/src/opentelemetry/trace.rs
+++ b/lading_payload/src/opentelemetry/trace.rs
@@ -15,7 +15,7 @@ use opentelemetry_proto::tonic::{
 };
 use opentelemetry_proto::tonic::{resource::v1::Resource, trace::v1};
 use prost::Message;
-use rand::{Rng, seq::IndexedRandom};
+use rand::{Rng, RngExt, seq::IndexedRandom};
 use std::{
     collections::{BTreeMap, BTreeSet},
     io::Write,

--- a/lading_payload/src/procfs.rs
+++ b/lading_payload/src/procfs.rs
@@ -1,7 +1,7 @@
 //! Procfs payload.
 
 use crate::{Error, Generator, common::strings};
-use rand::{Rng, distr::StandardUniform, prelude::Distribution};
+use rand::{Rng, RngExt, distr::StandardUniform, prelude::Distribution};
 use std::{cmp, fmt};
 
 mod proc;

--- a/lading_payload/src/procfs/proc.rs
+++ b/lading_payload/src/procfs/proc.rs
@@ -1,4 +1,4 @@
-use rand::{Rng, distr::StandardUniform, prelude::Distribution};
+use rand::{Rng, RngExt, distr::StandardUniform, prelude::Distribution};
 use std::fmt;
 
 #[derive(Debug, Clone, Copy)]

--- a/lading_payload/src/splunk_hec.rs
+++ b/lading_payload/src/splunk_hec.rs
@@ -2,7 +2,7 @@
 
 use std::io::Write;
 
-use rand::{Rng, distr::StandardUniform, prelude::Distribution, seq::IndexedRandom};
+use rand::{Rng, RngExt, distr::StandardUniform, prelude::Distribution, seq::IndexedRandom};
 use serde::{Deserialize, Serialize};
 
 use crate::Error;

--- a/lading_payload/src/static_chunks.rs
+++ b/lading_payload/src/static_chunks.rs
@@ -6,7 +6,7 @@ use std::{
     path::{Path, PathBuf},
 };
 
-use rand::Rng;
+use rand::{Rng, RngExt};
 use tracing::debug;
 
 #[derive(Debug)]

--- a/lading_payload/src/static_timestamped.rs
+++ b/lading_payload/src/static_timestamped.rs
@@ -9,7 +9,7 @@ use std::{
 };
 
 use chrono::{DateTime, FixedOffset, NaiveDateTime, TimeZone, Utc};
-use rand::Rng;
+use rand::{Rng, RngExt};
 use tracing::{info, warn};
 
 #[derive(Debug)]

--- a/lading_payload/src/syslog.rs
+++ b/lading_payload/src/syslog.rs
@@ -2,7 +2,7 @@
 
 use std::io::Write;
 
-use rand::{Rng, distr::StandardUniform, prelude::Distribution, seq::IndexedRandom};
+use rand::{Rng, RngExt, distr::StandardUniform, prelude::Distribution, seq::IndexedRandom};
 use time::{OffsetDateTime, format_description::well_known::Rfc3339};
 
 use crate::Error;

--- a/lading_payload/src/templated_json/generator.rs
+++ b/lading_payload/src/templated_json/generator.rs
@@ -2,8 +2,8 @@ use std::cell::{Cell, RefCell};
 use std::io::Write;
 use std::num::NonZeroI64;
 
-use rand::Rng;
 use rand::prelude::IndexedRandom;
+use rand::{Rng, RngExt};
 use time::OffsetDateTime;
 use time::format_description::well_known::Rfc3339;
 

--- a/lading_payload/src/trace_agent/v04.rs
+++ b/lading_payload/src/trace_agent/v04.rs
@@ -5,7 +5,7 @@
 //! 8cc5eb3e024ee54283efad4614175a065642bd9c.
 use std::{collections::BTreeMap, io::Write, rc::Rc};
 
-use rand::{Rng, seq::IndexedRandom};
+use rand::{Rng, RngExt, seq::IndexedRandom};
 use rmp_serde::Serializer;
 use serde::Serialize;
 


### PR DESCRIPTION
## Summary
- Update `rand` from 0.9 to 0.10.1
- Remove `small_rng` feature flag (SmallRng is always available in 0.10)
- Add `RngExt` import where needed (extension methods like `random()`, `random_range()`, `random_bool()` moved from `Rng` to `RngExt`)