### PR TITLE
Widen scopes_per_resource and metrics_per_scope to u16 in OTel metrics config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 - Updated to rand 0.10.x
+- Widened `scopes_per_resource` and `metrics_per_scope` in the OpenTelemetry metrics `Contexts` config from `u8` to `u16`, raising the per-emission cardinality ceiling from 65,025 to ~4.3B unique metric sites.
 
 ## [0.32.0]
 ## Changed

--- a/lading_payload/src/opentelemetry/metric.rs
+++ b/lading_payload/src/opentelemetry/metric.rs
@@ -77,11 +77,11 @@ pub struct Contexts {
     /// The range of attributes for resources.
     pub attributes_per_resource: ConfRange<u8>,
     /// The range of scopes that will be generated per resource.
-    pub scopes_per_resource: ConfRange<u8>,
+    pub scopes_per_resource: ConfRange<u16>,
     /// The range of attributes for each scope.
     pub attributes_per_scope: ConfRange<u8>,
     /// The range of metrics that will be generated per scope.
-    pub metrics_per_scope: ConfRange<u8>,
+    pub metrics_per_scope: ConfRange<u16>,
     /// The range of attributes for each metric.
     pub attributes_per_metric: ConfRange<u8>,
 }
@@ -238,7 +238,7 @@ impl Config {
                     ConfRange::Constant(m) => u32::from(m),
                     ConfRange::Inclusive { min, .. } => u32::from(min),
                 };
-                u32::from(n) * metrics
+                u32::from(n).saturating_mul(metrics)
             }
             ConfRange::Inclusive { min, .. } => {
                 let metrics = match self.contexts.metrics_per_scope {
@@ -246,7 +246,7 @@ impl Config {
                     ConfRange::Constant(m) => u32::from(m),
                     ConfRange::Inclusive { min, .. } => u32::from(min),
                 };
-                u32::from(min) * metrics
+                u32::from(min).saturating_mul(metrics)
             }
         };
 
@@ -258,7 +258,7 @@ impl Config {
                     ConfRange::Constant(m) => u32::from(m),
                     ConfRange::Inclusive { max, .. } => u32::from(max),
                 };
-                u32::from(n) * metrics
+                u32::from(n).saturating_mul(metrics)
             }
             ConfRange::Inclusive { max, .. } => {
                 let metrics = match self.contexts.metrics_per_scope {
@@ -266,7 +266,7 @@ impl Config {
                     ConfRange::Constant(m) => u32::from(m),
                     ConfRange::Inclusive { max, .. } => u32::from(max),
                 };
-                u32::from(max) * metrics
+                u32::from(max).saturating_mul(metrics)
             }
         };
 
@@ -556,9 +556,9 @@ mod test {
             seed: u64,
             total_contexts in 1..1_000_u32,
             attributes_per_resource in 0..20_u8,
-            scopes_per_resource in 0..20_u8,
+            scopes_per_resource in 0..20_u16,
             attributes_per_scope in 0..20_u8,
-            metrics_per_scope in 0..20_u8,
+            metrics_per_scope in 0..20_u16,
             attributes_per_metric in 0..10_u8,
             steps in 1..u8::MAX,
         ) {
@@ -599,9 +599,9 @@ mod test {
             seed: u64,
             total_contexts in 1..1_000_u32,
             attributes_per_resource in 0..20_u8,
-            scopes_per_resource in 0..20_u8,
+            scopes_per_resource in 0..20_u16,
             attributes_per_scope in 0..20_u8,
-            metrics_per_scope in 0..20_u8,
+            metrics_per_scope in 0..20_u16,
             attributes_per_metric in 0..10_u8,
             steps in 1..u8::MAX,
             budget in 128..2048_usize,
@@ -647,9 +647,9 @@ mod test {
             total_contexts_min in 1..4_u32,
             total_contexts_max in 5..100_u32,
             attributes_per_resource in 0..25_u8,
-            scopes_per_resource in 1..10_u8,
+            scopes_per_resource in 1..10_u16,
             attributes_per_scope in 0..20_u8,
-            metrics_per_scope in 1..10_u8,
+            metrics_per_scope in 1..10_u16,
             attributes_per_metric in 0..100_u8,
             budget in 128..2048_usize,
         ) {
@@ -693,9 +693,9 @@ mod test {
             seed: u64,
             total_contexts in 1..1_000_u32,
             attributes_per_resource in 0..20_u8,
-            scopes_per_resource in 0..20_u8,
+            scopes_per_resource in 0..20_u16,
             attributes_per_scope in 0..20_u8,
-            metrics_per_scope in 0..20_u8,
+            metrics_per_scope in 0..20_u16,
             attributes_per_metric in 0..10_u8,
             budget in SMALLEST_PROTOBUF..2048_usize,
         ) {
@@ -767,9 +767,9 @@ mod test {
             seed: u64,
             total_contexts in 1..1_000_u32,
             attributes_per_resource in 0..20_u8,
-            scopes_per_resource in 0..20_u8,
+            scopes_per_resource in 0..20_u16,
             attributes_per_scope in 0..20_u8,
-            metrics_per_scope in 0..20_u8,
+            metrics_per_scope in 0..20_u16,
             attributes_per_metric in 0..10_u8,
             steps in 1..u8::MAX,
             budget in SMALLEST_PROTOBUF..2048_usize,
@@ -912,9 +912,9 @@ mod test {
             seed: u64,
             total_contexts in 1..1_000_u32,
             attributes_per_resource in 0..20_u8,
-            scopes_per_resource in 1..20_u8,
+            scopes_per_resource in 1..20_u16,
             attributes_per_scope in 0..20_u8,
-            metrics_per_scope in 1..20_u8,
+            metrics_per_scope in 1..20_u16,
             attributes_per_metric in 0..10_u8,
             budget in SMALLEST_PROTOBUF..4098_usize,
         ) {
@@ -958,9 +958,9 @@ mod test {
             seed: u64,
             total_contexts in 1..1_000_u32,
             attributes_per_resource in 0..20_u8,
-            scopes_per_resource in 0..20_u8,
+            scopes_per_resource in 0..20_u16,
             attributes_per_scope in 0..20_u8,
-            metrics_per_scope in 0..20_u8,
+            metrics_per_scope in 0..20_u16,
             attributes_per_metric in 0..10_u8,
             steps in 1..u8::MAX,
             budget in SMALLEST_PROTOBUF..2048_usize,
@@ -1041,9 +1041,9 @@ mod test {
             seed: u64,
             total_contexts in 1..1_000_u32,
             attributes_per_resource in 0..20_u8,
-            scopes_per_resource in 0..20_u8,
+            scopes_per_resource in 0..20_u16,
             attributes_per_scope in 0..20_u8,
-            metrics_per_scope in 0..20_u8,
+            metrics_per_scope in 0..20_u16,
             attributes_per_metric in 0..10_u8,
             budget in SMALLEST_PROTOBUF..4098_usize,
         ) {
@@ -1081,9 +1081,9 @@ mod test {
             seed: u64,
             total_contexts in 1..1_000_u32,
             attributes_per_resource in 0..20_u8,
-            scopes_per_resource in 0..20_u8,
+            scopes_per_resource in 0..20_u16,
             attributes_per_scope in 0..20_u8,
-            metrics_per_scope in 0..20_u8,
+            metrics_per_scope in 0..20_u16,
             attributes_per_metric in 0..10_u8,
             budget in SMALLEST_PROTOBUF..512_usize, // see note below about repetition
         ) {

--- a/lading_payload/src/opentelemetry/metric/templates.rs
+++ b/lading_payload/src/opentelemetry/metric/templates.rs
@@ -285,7 +285,7 @@ pub(crate) enum Kind {
 
 #[derive(Clone, Debug)]
 pub(crate) struct ScopeTemplateGenerator {
-    metrics_per_scope: ConfRange<u8>,
+    metrics_per_scope: ConfRange<u16>,
     metric_generator: MetricTemplateGenerator,
     str_pool: Rc<strings::RandomStringPool>,
     tags: TagGenerator,
@@ -404,7 +404,7 @@ impl<'a> crate::SizedGenerator<'a> for ScopeTemplateGenerator {
 
 #[derive(Clone, Debug)]
 pub(crate) struct ResourceTemplateGenerator {
-    scopes_per_resource: ConfRange<u8>,
+    scopes_per_resource: ConfRange<u16>,
     attributes_per_resource: ConfRange<u8>,
     scope_generator: ScopeTemplateGenerator,
     tags: TagGenerator,


### PR DESCRIPTION
## Summary

- Widens `scopes_per_resource` and `metrics_per_scope` in `lading_payload::opentelemetry::metric::Contexts` from `ConfRange<u8>` to `ConfRange<u16>`
- Updates validation arithmetic to use `saturating_mul` so `u16 * u16` doesn't overflow `u32`
- Updates proptest ranges to use `u16` types

## Why

The previous `u8` typing capped per-emission cardinality at 255 × 255 = **65,025 unique metric sites per resource**. With this change, that ceiling rises to ~4.3 billion, which fits within the existing `total_contexts: u32` envelope. This unblocks high-cardinality OTel load tests that need many distinct metric time series per emission.

The `attributes_per_*` fields are intentionally left as `u8` — 255 tags per metric/resource/scope is plenty, and widening them would cascade into the shared `TagGenerator` (which OTel logs also depends on).

## Test plan

- [ ] All existing OTel metric tests pass (`cargo test -p lading-payload --lib opentelemetry::metric`)
- [ ] Workspace builds clean (`cargo build --workspace`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)