### PR TITLE
feat(dogstatsd): add configurable pools for origin detection extension fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 - Updated to rand 0.10.x
+- `dogstatsd` generator now supports configurable pools for the `|c:` (container
+  ID), `|e:` (external data), and `|card:` (cardinality) origin detection
+  extension fields via the new `container_ids`, `external_data`, and
+  `cardinality` config options. Each field randomly selects from its pool per
+  metric, or omits the field entirely if the pool is empty.
 
 ## [0.32.0]
 ## Changed

--- a/lading_payload/src/common/strings.rs
+++ b/lading_payload/src/common/strings.rs
@@ -62,6 +62,9 @@ pub(crate) fn choose_or_not_ref<'a, R, T>(mut rng: &mut R, pool: &'a [T]) -> Opt
 where
     R: rand::Rng + ?Sized,
 {
+    if pool.is_empty() {
+        return None;
+    }
     if rng.random() {
         pool.choose(&mut rng)
     } else {

--- a/lading_payload/src/dogstatsd.rs
+++ b/lading_payload/src/dogstatsd.rs
@@ -198,6 +198,23 @@ pub struct Config {
     pub tag_names: Vec<String>,
     /// A list of possible tag values to generate
     pub tag_values: Vec<String>,
+    /// Pool of possible container ID values for the `|c:` origin detection extension field.
+    ///
+    /// When non-empty, each generated metric randomly selects from this pool (or omits the field).
+    /// When empty, a random value is used, which matches the behavior prior to this field existing.
+    pub container_ids: Vec<String>,
+    /// Pool of possible External Data strings for the `|e:` origin detection extension field.
+    ///
+    /// When non-empty, each generated metric randomly selects from this pool (or omits the field).
+    /// Format: `pu-<pod_uid>,cn-<container_name>,it-<bool>`.
+    /// When empty, the field is never emitted.
+    pub external_data: Vec<String>,
+    /// Pool of possible cardinality values for the `|card:` origin detection extension field.
+    ///
+    /// When non-empty, each generated metric randomly selects from this pool (or omits the field).
+    /// Valid values: `low`, `orchestrator`, `high`, `none`.
+    /// When empty, the field is never emitted.
+    pub cardinality: Vec<String>,
 }
 
 impl Default for Config {
@@ -228,6 +245,9 @@ impl Default for Config {
             metric_names: Vec::default(),
             tag_names: Vec::default(),
             tag_values: Vec::default(),
+            container_ids: Vec::default(),
+            external_data: Vec::default(),
+            cardinality: Vec::default(),
         }
     }
 }
@@ -379,6 +399,9 @@ impl MemberGenerator {
         metric_names: &[String],
         tag_names: &[String],
         tag_values: &[String],
+        container_ids: Vec<String>,
+        external_data: Vec<String>,
+        cardinality: Vec<String>,
         mut rng: &mut R,
     ) -> Result<Self, crate::Error>
     where
@@ -397,6 +420,12 @@ impl MemberGenerator {
 
         let texts_or_messages = random_strings_with_length(&pool, 4..128, 1024, &mut rng);
         let small_strings = random_strings_with_length(&pool, 16..1024, 8, &mut rng);
+        // Use caller-provided container IDs when available; fall back to random small strings.
+        let container_ids = if container_ids.is_empty() {
+            small_strings.clone()
+        } else {
+            container_ids
+        };
 
         let str_pool = Rc::new(pool.clone());
         let pool = Rc::new(strings::PoolKind::RandomStringPool(pool));
@@ -486,7 +515,9 @@ impl MemberGenerator {
             sampling,
             sampling_probability,
             &WeightedIndex::new(metric_choices)?,
-            small_strings,
+            container_ids,
+            external_data,
+            cardinality,
             &mut tags_generator,
             &pools,
             value_conf,
@@ -614,6 +645,9 @@ impl DogStatsD {
             &config.metric_names,
             &config.tag_names,
             &config.tag_values,
+            config.container_ids.clone(),
+            config.external_data.clone(),
+            config.cardinality.clone(),
             rng,
         )?;
 

--- a/lading_payload/src/dogstatsd.rs
+++ b/lading_payload/src/dogstatsd.rs
@@ -206,13 +206,11 @@ pub struct Config {
     /// Pool of possible External Data strings for the `|e:` origin detection extension field.
     ///
     /// When non-empty, each generated metric randomly selects from this pool (or omits the field).
-    /// Format: `pu-<pod_uid>,cn-<container_name>,it-<bool>`.
     /// When empty, the field is never emitted.
     pub external_data: Vec<String>,
     /// Pool of possible cardinality values for the `|card:` origin detection extension field.
     ///
     /// When non-empty, each generated metric randomly selects from this pool (or omits the field).
-    /// Valid values: `low`, `orchestrator`, `high`, `none`.
     /// When empty, the field is never emitted.
     pub cardinality: Vec<String>,
 }

--- a/lading_payload/src/dogstatsd.rs
+++ b/lading_payload/src/dogstatsd.rs
@@ -848,6 +848,8 @@ mod test {
 
     #[test]
     fn container_id_uses_configured_pool() {
+        // No absence test for container_ids: an empty pool falls back to random strings rather
+        // than suppressing the field, so there is no "absent when empty" condition to assert.
         let id = "abc123def456";
         let config = Config {
             container_ids: vec![id.to_string()],
@@ -858,7 +860,7 @@ mod test {
     }
 
     #[test]
-    fn extension_field_values_come_from_pool() {
+    fn cardinality_values_come_from_pool() {
         // When a pool is non-empty, only values from that pool should appear after the prefix.
         let config = Config {
             cardinality: vec!["low".to_string()],

--- a/lading_payload/src/dogstatsd.rs
+++ b/lading_payload/src/dogstatsd.rs
@@ -869,7 +869,10 @@ mod test {
             let text = std::str::from_utf8(&bytes).expect("output should be valid utf-8");
             for segment in text.split("|card:").skip(1) {
                 // Each metric is newline-terminated, so split on both | and \n to isolate the value.
-                let value = segment.split(|c: char| c == '|' || c == '\n').next().unwrap_or("");
+                let value = segment
+                    .split(|c: char| c == '|' || c == '\n')
+                    .next()
+                    .unwrap_or("");
                 assert_eq!(
                     value, "low",
                     "|card: value {value:?} was not from the configured pool"

--- a/lading_payload/src/dogstatsd.rs
+++ b/lading_payload/src/dogstatsd.rs
@@ -797,9 +797,9 @@ mod test {
 
     // With a non-empty pool, the extension field must appear in at least one metric across a
     // set of differently-seeded runs. Each metric has a 50% chance of including the field, so
-    // the probability of never seeing it across N independent runs is 0.5^N.
+    // the probability of never seeing it across N independent runs is 0.5^N (~10^-30 for N=100).
     fn assert_field_emitted_at_least_once(config: &Config, field_prefix: &[u8]) {
-        let seen = (0..20).any(|seed| {
+        let seen = (0..100).any(|seed| {
             let bytes = generate_bytes(config, seed);
             bytes.windows(field_prefix.len()).any(|w| w == field_prefix)
         });

--- a/lading_payload/src/dogstatsd.rs
+++ b/lading_payload/src/dogstatsd.rs
@@ -784,6 +784,100 @@ mod test {
 
     use crate::{DogStatsD, Serialize};
 
+    // Generate a batch of raw DogStatsD bytes using the given config and seed.
+    fn generate_bytes(config: &Config, seed: u64) -> Vec<u8> {
+        let mut rng = SmallRng::seed_from_u64(seed);
+        let mut dogstatsd = DogStatsD::new(config, &mut rng).expect("failed to create DogStatsD");
+        let mut bytes = Vec::new();
+        dogstatsd
+            .to_bytes(rng, 65536, &mut bytes)
+            .expect("failed to generate bytes");
+        bytes
+    }
+
+    // With a non-empty pool, the extension field must appear in at least one metric across a
+    // set of differently-seeded runs. Each metric has a 50% chance of including the field, so
+    // the probability of never seeing it across N independent runs is 0.5^N.
+    fn assert_field_emitted_at_least_once(config: &Config, field_prefix: &[u8]) {
+        let seen = (0..20).any(|seed| {
+            let bytes = generate_bytes(config, seed);
+            bytes.windows(field_prefix.len()).any(|w| w == field_prefix)
+        });
+        assert!(
+            seen,
+            "expected '{}' to appear in generated output with a non-empty pool, but it never did",
+            std::str::from_utf8(field_prefix).unwrap_or("<non-utf8>")
+        );
+    }
+
+    #[test]
+    fn external_data_emitted_when_pool_nonempty() {
+        let config = Config {
+            external_data: vec!["pu-abc123,cn-mycontainer,it-false".to_string()],
+            ..Default::default()
+        };
+        assert_field_emitted_at_least_once(&config, b"|e:");
+    }
+
+    #[test]
+    fn external_data_absent_when_pool_empty() {
+        let bytes = generate_bytes(&Config::default(), 0);
+        assert!(
+            !bytes.windows(3).any(|w| w == b"|e:"),
+            "expected no |e: field when external_data pool is empty"
+        );
+    }
+
+    #[test]
+    fn cardinality_emitted_when_pool_nonempty() {
+        let config = Config {
+            cardinality: vec!["low".to_string(), "orchestrator".to_string()],
+            ..Default::default()
+        };
+        assert_field_emitted_at_least_once(&config, b"|card:");
+    }
+
+    #[test]
+    fn cardinality_absent_when_pool_empty() {
+        let bytes = generate_bytes(&Config::default(), 0);
+        assert!(
+            !bytes.windows(6).any(|w| w == b"|card:"),
+            "expected no |card: field when cardinality pool is empty"
+        );
+    }
+
+    #[test]
+    fn container_id_uses_configured_pool() {
+        let id = "abc123def456";
+        let config = Config {
+            container_ids: vec![id.to_string()],
+            ..Default::default()
+        };
+        let needle = format!("|c:{id}");
+        assert_field_emitted_at_least_once(&config, needle.as_bytes());
+    }
+
+    #[test]
+    fn extension_field_values_come_from_pool() {
+        // When a pool is non-empty, only values from that pool should appear after the prefix.
+        let config = Config {
+            cardinality: vec!["low".to_string()],
+            ..Default::default()
+        };
+        for seed in 0..10 {
+            let bytes = generate_bytes(&config, seed);
+            let text = std::str::from_utf8(&bytes).expect("output should be valid utf-8");
+            for segment in text.split("|card:").skip(1) {
+                // Each metric is newline-terminated, so split on both | and \n to isolate the value.
+                let value = segment.split(|c: char| c == '|' || c == '\n').next().unwrap_or("");
+                assert_eq!(
+                    value, "low",
+                    "|card: value {value:?} was not from the configured pool"
+                );
+            }
+        }
+    }
+
     #[test]
     fn zero_contexts_should_be_rejected() {
         let config = Config {

--- a/lading_payload/src/dogstatsd.rs
+++ b/lading_payload/src/dogstatsd.rs
@@ -871,10 +871,7 @@ mod test {
             let text = std::str::from_utf8(&bytes).expect("output should be valid utf-8");
             for segment in text.split("|card:").skip(1) {
                 // Each metric is newline-terminated, so split on both | and \n to isolate the value.
-                let value = segment
-                    .split(|c: char| c == '|' || c == '\n')
-                    .next()
-                    .unwrap_or("");
+                let value = segment.split(['|', '\n']).next().unwrap_or("");
                 assert_eq!(
                     value, "low",
                     "|card: value {value:?} was not from the configured pool"

--- a/lading_payload/src/dogstatsd/metric.rs
+++ b/lading_payload/src/dogstatsd/metric.rs
@@ -23,6 +23,8 @@ mod template;
 #[derive(Clone, Debug)]
 pub(crate) struct MetricGenerator {
     pub(crate) container_ids: Vec<String>,
+    pub(crate) external_data: Vec<String>,
+    pub(crate) cardinality: Vec<String>,
     pub(crate) templates: Vec<template::Template>,
     pub(crate) multivalue_count: ConfRange<u16>,
     pub(crate) multivalue_pack_probability: f32,
@@ -47,6 +49,8 @@ impl MetricGenerator {
         sampling_probability: f32,
         metric_weights: &WeightedIndex<u16>,
         container_ids: Vec<String>,
+        external_data: Vec<String>,
+        cardinality: Vec<String>,
         tags_generator: &mut common::tags::Generator,
         pools: &StringPools,
         value_conf: ValueConf,
@@ -82,6 +86,8 @@ impl MetricGenerator {
 
         Ok(MetricGenerator {
             container_ids,
+            external_data,
+            cardinality,
             templates,
             multivalue_count,
             multivalue_pack_probability,
@@ -112,6 +118,8 @@ impl<'a> Generator<'a> for MetricGenerator {
         let tags = &self.tags[template_idx];
 
         let container_id = choose_or_not_ref(&mut rng, &self.container_ids).map(String::as_str);
+        let external_data = choose_or_not_ref(&mut rng, &self.external_data).map(String::as_str);
+        let cardinality = choose_or_not_ref(&mut rng, &self.cardinality).map(String::as_str);
         // https://docs.datadoghq.com/metrics/custom_metrics/dogstatsd_metrics_submission/#sample-rates
         let prob: f32 = OpenClosed01.sample(&mut rng);
         let sample_rate = if prob < self.sampling_probability {
@@ -149,6 +157,8 @@ impl<'a> Generator<'a> for MetricGenerator {
                     tags,
                     pools: &self.pools,
                     container_id,
+                    external_data,
+                    cardinality,
                 }))
             }
             Template::Gauge(gauge) => {
@@ -163,6 +173,8 @@ impl<'a> Generator<'a> for MetricGenerator {
                     tags,
                     pools: &self.pools,
                     container_id,
+                    external_data,
+                    cardinality,
                 }))
             }
             Template::Distribution(dist) => {
@@ -178,6 +190,8 @@ impl<'a> Generator<'a> for MetricGenerator {
                     tags,
                     pools: &self.pools,
                     container_id,
+                    external_data,
+                    cardinality,
                 }))
             }
             Template::Histogram(hist) => {
@@ -193,6 +207,8 @@ impl<'a> Generator<'a> for MetricGenerator {
                     tags,
                     pools: &self.pools,
                     container_id,
+                    external_data,
+                    cardinality,
                 }))
             }
             Template::Timer(timer) => {
@@ -208,6 +224,8 @@ impl<'a> Generator<'a> for MetricGenerator {
                     tags,
                     pools: &self.pools,
                     container_id,
+                    external_data,
+                    cardinality,
                 }))
             }
             Template::Set(set) => {
@@ -222,6 +240,8 @@ impl<'a> Generator<'a> for MetricGenerator {
                     tags,
                     pools: &self.pools,
                     container_id,
+                    external_data,
+                    cardinality,
                 }))
             }
         }
@@ -284,8 +304,12 @@ pub struct Count<'a> {
     pub(crate) tags: &'a common::tags::Tagset,
     /// String pools for tag handle lookups during serialization.
     pub(crate) pools: &'a StringPools,
-    /// Container ID of the metric.
+    /// Container ID for the `|c:` origin detection extension field.
     pub container_id: Option<&'a str>,
+    /// External Data for the `|e:` origin detection extension field.
+    pub external_data: Option<&'a str>,
+    /// Cardinality override for the `|card:` origin detection extension field.
+    pub cardinality: Option<&'a str>,
 }
 
 impl fmt::Display for Count<'_> {
@@ -325,6 +349,12 @@ impl fmt::Display for Count<'_> {
         if let Some(container_id) = self.container_id {
             write!(f, "|c:{container_id}")?;
         }
+        if let Some(external_data) = self.external_data {
+            write!(f, "|e:{external_data}")?;
+        }
+        if let Some(cardinality) = self.cardinality {
+            write!(f, "|card:{cardinality}")?;
+        }
 
         Ok(())
     }
@@ -341,8 +371,12 @@ pub struct Gauge<'a> {
     pub(crate) tags: &'a common::tags::Tagset,
     /// String pools for tag handle lookups during serialization.
     pub(crate) pools: &'a StringPools,
-    /// Container ID of the metric.
+    /// Container ID for the `|c:` origin detection extension field.
     pub container_id: Option<&'a str>,
+    /// External Data for the `|e:` origin detection extension field.
+    pub external_data: Option<&'a str>,
+    /// Cardinality override for the `|card:` origin detection extension field.
+    pub cardinality: Option<&'a str>,
 }
 
 impl fmt::Display for Gauge<'_> {
@@ -378,6 +412,12 @@ impl fmt::Display for Gauge<'_> {
         if let Some(container_id) = self.container_id {
             write!(f, "|c:{container_id}")?;
         }
+        if let Some(external_data) = self.external_data {
+            write!(f, "|e:{external_data}")?;
+        }
+        if let Some(cardinality) = self.cardinality {
+            write!(f, "|card:{cardinality}")?;
+        }
 
         Ok(())
     }
@@ -396,8 +436,12 @@ pub struct Timer<'a> {
     pub(crate) tags: &'a common::tags::Tagset,
     /// String pools for tag handle lookups during serialization.
     pub(crate) pools: &'a StringPools,
-    /// Container ID of the metric.
+    /// Container ID for the `|c:` origin detection extension field.
     pub container_id: Option<&'a str>,
+    /// External Data for the `|e:` origin detection extension field.
+    pub external_data: Option<&'a str>,
+    /// Cardinality override for the `|card:` origin detection extension field.
+    pub cardinality: Option<&'a str>,
 }
 
 impl fmt::Display for Timer<'_> {
@@ -436,6 +480,12 @@ impl fmt::Display for Timer<'_> {
         if let Some(container_id) = self.container_id {
             write!(f, "|c:{container_id}")?;
         }
+        if let Some(external_data) = self.external_data {
+            write!(f, "|e:{external_data}")?;
+        }
+        if let Some(cardinality) = self.cardinality {
+            write!(f, "|card:{cardinality}")?;
+        }
 
         Ok(())
     }
@@ -454,8 +504,12 @@ pub struct Dist<'a> {
     pub(crate) tags: &'a common::tags::Tagset,
     /// String pools for tag handle lookups during serialization.
     pub(crate) pools: &'a StringPools,
-    /// Container ID of the metric.
+    /// Container ID for the `|c:` origin detection extension field.
     pub container_id: Option<&'a str>,
+    /// External Data for the `|e:` origin detection extension field.
+    pub external_data: Option<&'a str>,
+    /// Cardinality override for the `|card:` origin detection extension field.
+    pub cardinality: Option<&'a str>,
 }
 
 impl fmt::Display for Dist<'_> {
@@ -494,6 +548,12 @@ impl fmt::Display for Dist<'_> {
         if let Some(container_id) = self.container_id {
             write!(f, "|c:{container_id}")?;
         }
+        if let Some(external_data) = self.external_data {
+            write!(f, "|e:{external_data}")?;
+        }
+        if let Some(cardinality) = self.cardinality {
+            write!(f, "|card:{cardinality}")?;
+        }
 
         Ok(())
     }
@@ -510,8 +570,12 @@ pub struct Set<'a> {
     pub(crate) tags: &'a common::tags::Tagset,
     /// String pools for tag handle lookups during serialization.
     pub(crate) pools: &'a StringPools,
-    /// Container ID of the metric.
+    /// Container ID for the `|c:` origin detection extension field.
     pub container_id: Option<&'a str>,
+    /// External Data for the `|e:` origin detection extension field.
+    pub external_data: Option<&'a str>,
+    /// Cardinality override for the `|card:` origin detection extension field.
+    pub cardinality: Option<&'a str>,
 }
 
 impl fmt::Display for Set<'_> {
@@ -543,6 +607,12 @@ impl fmt::Display for Set<'_> {
         if let Some(container_id) = self.container_id {
             write!(f, "|c:{container_id}")?;
         }
+        if let Some(external_data) = self.external_data {
+            write!(f, "|e:{external_data}")?;
+        }
+        if let Some(cardinality) = self.cardinality {
+            write!(f, "|card:{cardinality}")?;
+        }
 
         Ok(())
     }
@@ -561,8 +631,12 @@ pub struct Histogram<'a> {
     pub(crate) tags: &'a common::tags::Tagset,
     /// String pools for tag handle lookups during serialization.
     pub(crate) pools: &'a StringPools,
-    /// Container ID of the metric.
+    /// Container ID for the `|c:` origin detection extension field.
     pub container_id: Option<&'a str>,
+    /// External Data for the `|e:` origin detection extension field.
+    pub external_data: Option<&'a str>,
+    /// Cardinality override for the `|card:` origin detection extension field.
+    pub cardinality: Option<&'a str>,
 }
 
 impl fmt::Display for Histogram<'_> {
@@ -600,6 +674,12 @@ impl fmt::Display for Histogram<'_> {
         }
         if let Some(container_id) = self.container_id {
             write!(f, "|c:{container_id}")?;
+        }
+        if let Some(external_data) = self.external_data {
+            write!(f, "|e:{external_data}")?;
+        }
+        if let Some(cardinality) = self.cardinality {
+            write!(f, "|card:{cardinality}")?;
         }
 
         Ok(())


### PR DESCRIPTION
## Summary

- Adds three new optional `Config` fields to the DogStatsD payload generator, each holding a pool of possible values for one of the origin detection protocol extension fields
- Per generated metric, a value is randomly selected from the pool or the field is omitted entirely — consistent with the existing behavior of `|c:` with its internal random pool
- Because millstone's `Payload::DogStatsD` wraps `lading_payload::dogstatsd::Config` directly via serde, all three fields are immediately usable in millstone's YAML configuration with no changes to millstone required
- No breaking changes: all existing `Config` constructions use `..Default::default()` or `Config::default()`; the metric structs cannot be externally constructed due to `pub(crate)` fields; internal constructors are all crate-private
- Fixes `choose_or_not_ref` to short-circuit before touching the RNG when the pool is empty, preserving determinism for seeded output when optional fields are unconfigured

### New fields

**`container_ids`** — pool for the `|c:` Local Data field. When empty, falls back to the prior behavior of using an internally generated random value. When non-empty, only values from the pool are used, so callers can supply real container IDs.

**`external_data`** — pool for the `|e:` External Data field. Empty by default; field is never emitted when empty.

**`cardinality`** — pool for the `|card:` cardinality override field. Empty by default; field is never emitted when empty.

### Fuzz corpus note

`Config` derives `arbitrary::Arbitrary` and is used as a fuzz input in two targets. Adding fields changes what the fuzzer generates, so saved fuzz corpora for those targets should be reset.

## Test plan

- [x] All existing `lading-payload` tests pass
- [x] New tests verify fields are emitted when pools are non-empty, absent when empty, and that emitted values come only from the configured pool
- [x] Probabilistic emission tests run 100 seeds (p(false negative) ≈ 10^-30)

🤖 Generated with [Claude Code](https://claude.com/claude-code)