### PR TITLE
Add DogStatsD timestamp extension generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   extension fields via the new `container_ids`, `external_data`, and
   `cardinality` config options. Each field randomly selects from its pool per
   metric, or omits the field entirely if the pool is empty.
+- `dogstatsd` generator now supports DogStatsD protocol v1.3 `|T` timestamps
+  for count and gauge metrics via `timestamp.range` and `timestamp.probability`.
 
 ## [0.32.0]
 ## Changed

--- a/examples/dogstatsd-generation.yaml
+++ b/examples/dogstatsd-generation.yaml
@@ -30,6 +30,21 @@ generator:
             distribution: 0
             set: 0
             histogram: 0
+          container_ids:
+            - "abc123def456"
+            - "def456abc123"
+          external_data:
+            - "pu-abc123,cn-mycontainer,it-false"
+            - "pu-def456,cn-othercontainer,it-true"
+          cardinality:
+            - "low"
+            - "orchestrator"
+          timestamp:
+            range:
+              inclusive:
+                min: 1656581400
+                max: 1656585000
+            probability: 0.25
       bytes_per_second: "80 MiB"
       maximum_prebuild_cache_size_bytes: "1 GiB"
 

--- a/lading_payload/src/dogstatsd.rs
+++ b/lading_payload/src/dogstatsd.rs
@@ -213,6 +213,52 @@ pub struct Config {
     /// When non-empty, each generated metric randomly selects from this pool (or omits the field).
     /// When empty, the field is never emitted.
     pub cardinality: Vec<String>,
+    /// Configuration for the optional `|T` `DogStatsD` protocol v1.3 timestamp field.
+    pub timestamp: Box<TimestampConfig>,
+}
+
+/// Configuration for the optional `|T` `DogStatsD` protocol v1.3 timestamp field.
+#[derive(Debug, Deserialize, serde::Serialize, Clone, Copy, PartialEq)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[serde(deny_unknown_fields, default)]
+pub struct TimestampConfig {
+    /// Range of possible Unix timestamps for the `|T` `DogStatsD` protocol v1.3 field.
+    ///
+    /// The `DogStatsD` protocol only supports this field for count and gauge metrics.
+    pub range: ConfRange<u32>,
+    /// Probability between 0 and 1 that a generated count or gauge metric includes `|T`.
+    pub probability: f32,
+}
+
+impl Default for TimestampConfig {
+    fn default() -> Self {
+        Self {
+            range: ConfRange::Constant(1),
+            probability: 0.0,
+        }
+    }
+}
+
+impl TimestampConfig {
+    fn valid(&self) -> Result<(), String> {
+        let (range_valid, reason) = self.range.valid();
+        if !range_valid {
+            return Result::Err(format!("Timestamp range is invalid: {reason}"));
+        }
+        if !self.probability.is_finite() || self.probability < 0.0 || self.probability > 1.0 {
+            return Result::Err(format!(
+                "Timestamp probability {} must be finite and in range [0.0, 1.0]",
+                self.probability
+            ));
+        }
+        if self.probability > 0.0 && self.range.start() == 0 {
+            return Result::Err(
+                "Timestamp range start value cannot be 0 when timestamps are enabled".to_string(),
+            );
+        }
+
+        Ok(())
+    }
 }
 
 impl Default for Config {
@@ -246,6 +292,7 @@ impl Default for Config {
             container_ids: Vec::default(),
             external_data: Vec::default(),
             cardinality: Vec::default(),
+            timestamp: Box::default(),
         }
     }
 }
@@ -340,6 +387,8 @@ impl Config {
             ));
         }
 
+        self.timestamp.valid()?;
+
         if self.kind_weights.metric == 0
             && self.kind_weights.event == 0
             && self.kind_weights.service_check == 0
@@ -400,6 +449,8 @@ impl MemberGenerator {
         container_ids: Vec<String>,
         external_data: Vec<String>,
         cardinality: Vec<String>,
+        timestamp_range: ConfRange<u32>,
+        timestamp_probability: f32,
         mut rng: &mut R,
     ) -> Result<Self, crate::Error>
     where
@@ -516,6 +567,8 @@ impl MemberGenerator {
             container_ids,
             external_data,
             cardinality,
+            timestamp_range,
+            timestamp_probability,
             &mut tags_generator,
             &pools,
             value_conf,
@@ -646,6 +699,8 @@ impl DogStatsD {
             config.container_ids.clone(),
             config.external_data.clone(),
             config.cardinality.clone(),
+            config.timestamp.range,
+            config.timestamp.probability,
             rng,
         )?;
 
@@ -778,7 +833,7 @@ impl DogStatsD {
 
 #[cfg(test)]
 mod test {
-    use super::{ConfRange, Config};
+    use super::{ConfRange, Config, KindWeights, MetricWeights, TimestampConfig};
     use proptest::prelude::*;
     use rand::{SeedableRng, rngs::SmallRng};
 
@@ -881,6 +936,107 @@ mod test {
     }
 
     #[test]
+    fn timestamp_emitted_when_probability_is_one() {
+        let config = Config {
+            kind_weights: KindWeights::new(100, 0, 0),
+            metric_weights: MetricWeights::new(100, 100, 0, 0, 0, 0),
+            timestamp: Box::new(TimestampConfig {
+                range: ConfRange::Constant(1_656_581_400),
+                probability: 1.0,
+            }),
+            ..Default::default()
+        };
+        assert_field_emitted_at_least_once(&config, b"|T1656581400");
+    }
+
+    #[test]
+    fn timestamp_absent_when_probability_is_zero() {
+        let config = Config {
+            kind_weights: KindWeights::new(100, 0, 0),
+            metric_weights: MetricWeights::new(100, 100, 0, 0, 0, 0),
+            timestamp: Box::new(TimestampConfig {
+                range: ConfRange::Constant(1_656_581_400),
+                probability: 0.0,
+            }),
+            ..Default::default()
+        };
+        let bytes = generate_bytes(&config, 0);
+        assert!(
+            !bytes.windows(2).any(|w| w == b"|T"),
+            "expected no |T field when timestamp_probability is 0"
+        );
+    }
+
+    #[test]
+    fn timestamp_values_come_from_range() {
+        let config = Config {
+            kind_weights: KindWeights::new(100, 0, 0),
+            metric_weights: MetricWeights::new(100, 100, 0, 0, 0, 0),
+            timestamp: Box::new(TimestampConfig {
+                range: ConfRange::Inclusive { min: 10, max: 20 },
+                probability: 1.0,
+            }),
+            ..Default::default()
+        };
+        let bytes = generate_bytes(&config, 0);
+        let text = std::str::from_utf8(&bytes).expect("output should be valid utf-8");
+        for segment in text.split("|T").skip(1) {
+            let value = segment
+                .split(['|', '\n'])
+                .next()
+                .unwrap_or("")
+                .parse::<u32>()
+                .expect("timestamp should parse as u64");
+            assert!(
+                (10..=20).contains(&value),
+                "|T value {value} was not inside the configured timestamp range"
+            );
+        }
+    }
+
+    #[test]
+    fn timestamp_only_emitted_for_count_and_gauge() {
+        let config = Config {
+            kind_weights: KindWeights::new(100, 0, 0),
+            metric_weights: MetricWeights::new(0, 0, 100, 0, 0, 0),
+            timestamp: Box::new(TimestampConfig {
+                range: ConfRange::Constant(1_656_581_400),
+                probability: 1.0,
+            }),
+            ..Default::default()
+        };
+        let bytes = generate_bytes(&config, 0);
+        assert!(
+            !bytes.windows(2).any(|w| w == b"|T"),
+            "expected no |T field for metric types outside count and gauge"
+        );
+    }
+
+    #[test]
+    fn timestamp_probability_must_be_valid() {
+        let config = Config {
+            timestamp: Box::new(TimestampConfig {
+                probability: 2.0,
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        assert!(config.valid().is_err());
+    }
+
+    #[test]
+    fn timestamp_range_must_be_positive_when_enabled() {
+        let config = Config {
+            timestamp: Box::new(TimestampConfig {
+                range: ConfRange::Constant(0),
+                probability: 1.0,
+            }),
+            ..Default::default()
+        };
+        assert!(config.valid().is_err());
+    }
+
+    #[test]
     fn zero_contexts_should_be_rejected() {
         let config = Config {
             contexts: ConfRange::Constant(0),
@@ -896,6 +1052,24 @@ mod test {
             err == "Contexts start value cannot be 0" || err == "Contexts cannot be 0",
             "Expected error about 0 contexts, got: {err}"
         );
+    }
+
+    // For all seeds, generation with the same timestamp configuration and same seed
+    // produces byte-identical output.
+    proptest! {
+        #[test]
+        fn timestamp_generation_is_deterministic(seed: u64) {
+            let config = Config {
+                kind_weights: KindWeights::new(100, 0, 0),
+                metric_weights: MetricWeights::new(100, 100, 0, 0, 0, 0),
+                timestamp: Box::new(TimestampConfig {
+                    range: ConfRange::Inclusive { min: 10, max: 20 },
+                    probability: 0.5,
+                }),
+                ..Default::default()
+            };
+            prop_assert_eq!(generate_bytes(&config, seed), generate_bytes(&config, seed));
+        }
     }
 
     // We want to be sure that the serialized size of the payload does not

--- a/lading_payload/src/dogstatsd/metric.rs
+++ b/lading_payload/src/dogstatsd/metric.rs
@@ -3,7 +3,7 @@ use std::fmt;
 
 use rand::{
     Rng,
-    distr::{OpenClosed01, weighted::WeightedIndex},
+    distr::{OpenClosed01, StandardUniform, weighted::WeightedIndex},
     prelude::Distribution,
     seq::IteratorRandom,
 };
@@ -25,6 +25,8 @@ pub(crate) struct MetricGenerator {
     pub(crate) container_ids: Vec<String>,
     pub(crate) external_data: Vec<String>,
     pub(crate) cardinality: Vec<String>,
+    pub(crate) timestamp_range: ConfRange<u32>,
+    pub(crate) timestamp_probability: f32,
     pub(crate) templates: Vec<template::Template>,
     pub(crate) multivalue_count: ConfRange<u16>,
     pub(crate) multivalue_pack_probability: f32,
@@ -51,6 +53,8 @@ impl MetricGenerator {
         container_ids: Vec<String>,
         external_data: Vec<String>,
         cardinality: Vec<String>,
+        timestamp_range: ConfRange<u32>,
+        timestamp_probability: f32,
         tags_generator: &mut common::tags::Generator,
         pools: &StringPools,
         value_conf: ValueConf,
@@ -88,6 +92,8 @@ impl MetricGenerator {
             container_ids,
             external_data,
             cardinality,
+            timestamp_range,
+            timestamp_probability,
             templates,
             multivalue_count,
             multivalue_pack_probability,
@@ -97,6 +103,22 @@ impl MetricGenerator {
             pools: pools.clone(),
             tags,
         })
+    }
+
+    fn timestamp<R>(&self, rng: &mut R) -> Option<u32>
+    where
+        R: Rng + ?Sized,
+    {
+        if self.timestamp_probability == 0.0 {
+            return None;
+        }
+
+        let prob: f32 = StandardUniform.sample(rng);
+        if prob < self.timestamp_probability {
+            Some(self.timestamp_range.sample(rng))
+        } else {
+            None
+        }
     }
 }
 
@@ -159,6 +181,7 @@ impl<'a> Generator<'a> for MetricGenerator {
                     container_id,
                     external_data,
                     cardinality,
+                    timestamp: self.timestamp(&mut rng),
                 }))
             }
             Template::Gauge(gauge) => {
@@ -175,6 +198,7 @@ impl<'a> Generator<'a> for MetricGenerator {
                     container_id,
                     external_data,
                     cardinality,
+                    timestamp: self.timestamp(&mut rng),
                 }))
             }
             Template::Distribution(dist) => {
@@ -310,6 +334,8 @@ pub struct Count<'a> {
     pub external_data: Option<&'a str>,
     /// Cardinality override for the `|card:` origin detection extension field.
     pub cardinality: Option<&'a str>,
+    /// Unix timestamp for the `|T` `DogStatsD` protocol v1.3 extension field.
+    pub timestamp: Option<u32>,
 }
 
 impl fmt::Display for Count<'_> {
@@ -355,6 +381,9 @@ impl fmt::Display for Count<'_> {
         if let Some(cardinality) = self.cardinality {
             write!(f, "|card:{cardinality}")?;
         }
+        if let Some(timestamp) = self.timestamp {
+            write!(f, "|T{timestamp}")?;
+        }
 
         Ok(())
     }
@@ -377,6 +406,8 @@ pub struct Gauge<'a> {
     pub external_data: Option<&'a str>,
     /// Cardinality override for the `|card:` origin detection extension field.
     pub cardinality: Option<&'a str>,
+    /// Unix timestamp for the `|T` `DogStatsD` protocol v1.3 extension field.
+    pub timestamp: Option<u32>,
 }
 
 impl fmt::Display for Gauge<'_> {
@@ -417,6 +448,9 @@ impl fmt::Display for Gauge<'_> {
         }
         if let Some(cardinality) = self.cardinality {
             write!(f, "|card:{cardinality}")?;
+        }
+        if let Some(timestamp) = self.timestamp {
+            write!(f, "|T{timestamp}")?;
         }
 
         Ok(())


### PR DESCRIPTION
## Summary
- add DogStatsD protocol v1.3 `|T` timestamp generation for count and gauge metrics
- configure timestamps with `timestamp.range` and `timestamp.probability`
- add tests for emission, omission, range bounds, count/gauge-only behavior, and determinism
- update the DogStatsD example and changelog

## Validation
- `ci/fmt` passed
- `cargo check -p lading-payload --tests` passed
- `cargo clippy -p lading-payload --tests -- -D warnings` passed
- `cargo test -p lading-payload dogstatsd --lib` passed
- `ci/validate` attempted, but local full workspace check is blocked by missing system `fuse`/`osxfuse` libraries required by `fuser` (`fuse.pc`/`osxfuse.pc` not found via pkg-config)
