### PR TITLE
payload config: add new Probability<const u32: MIN_AS_BITS> type

### DIFF
--- a/lading_payload/src/common/config.rs
+++ b/lading_payload/src/common/config.rs
@@ -92,7 +92,7 @@ const NEG_ZERO_AS_BITS: u32 = 0x8000_0000;
 /// Error returned when a value cannot be turned into a [`Probability`].
 #[derive(Debug, thiserror::Error, Clone, Copy)]
 pub enum ProbabilityError {
-    /// Value is NaN or `±∞`.
+    /// Value is [`f32::NAN`], [`f32::INFINITY`], or [`f32::NEG_INFINITY`].
     #[error("probability must be finite, got {0}")]
     NotFinite(f32),
     /// Value is below the type's compile-time lower bound.
@@ -110,10 +110,11 @@ pub enum ProbabilityError {
 
 /// An `f32`-valued probability with a compile-time lower bound.
 ///
-/// The const generic `MIN_AS_BITS` is the IEEE-754 bit pattern of the lower bound,
-/// obtained at the call site via [`f32::to_bits`]. The decoded bound must be a
-/// finite value in `[+0.0, +1.0]` and must not be `-0.0`; otherwise the type
-/// fails to instantiate at compile time via the assertions on [`Self::MIN`].
+/// The const generic `MIN_AS_BITS` is the IEEE-754 bit pattern of the lower
+/// bound, obtained at the call site via [`f32::to_bits`]. The decoded bound
+/// must be a finite value in `[+0.0, +1.0]` and must not be `-0.0`; otherwise
+/// the type fails to instantiate at compile time via the assertions on
+/// [`Self::MIN`].
 ///
 /// Stored values must be finite and lie in `[MIN, +1.0]`. Inputs of `-0.0` are
 /// normalized to `+0.0`; other invalid inputs are rejected via
@@ -122,25 +123,26 @@ pub enum ProbabilityError {
 /// # Design
 ///
 /// Rust does not yet allow floating-point types as const generic parameters on
-/// stable; tracking issue `rust-lang/rust#95174` covers `#![feature(adt_const_params)]`
-/// and its float-specific complications. To carry a compile-time lower bound
-/// today the type must be parameterized on an integer, so callers spell the
-/// bound as a `u32` bit pattern (`{ f32::to_bits(0.5) }`) and the type decodes
-/// it back to `f32` inside [`Self::MIN`].
+/// stable; tracking issue `rust-lang/rust#95174` covers
+/// `#![feature(adt_const_params)]` and its float-specific complications. To
+/// carry a compile-time lower bound today the type must be parameterized on an
+/// integer, so callers spell the bound as a `u32` bit pattern (`{
+/// f32::to_bits(0.5) }`) and the type decodes it back to `f32` inside
+/// [`Self::MIN`].
 ///
-/// Two IEEE-754 properties of the `f32` ↔ `u32` round trip exposed by
+/// Two IEEE-754 properties of the `f32` <-> `u32` round trip exposed by
 /// [`f32::to_bits`] / [`f32::from_bits`] inform the rest of the design:
 ///
-/// * For any two values `a, b` in `[+0.0, +∞)` (i.e. non-negative, non-NaN),
-///   `a <= b` iff `a.to_bits() <= b.to_bits()`. The sign bit is zero and the
-///   remaining 31 bits are laid out exponent-then-mantissa, so the unsigned
-///   integer ordering matches the numeric ordering.
+/// * For any two values `a, b` in `[+0.0, +inf)` (i.e. non-negative,
+///   non-[`f32::NAN`]), `a <= b` iff `a.to_bits() <= b.to_bits()`. The sign bit
+///   is zero and the remaining 31 bits are laid out exponent-then-mantissa, so
+///   the unsigned integer ordering matches the numeric ordering.
 /// * `+0.0` and `-0.0` are numerically equal under `==`/`<`/`<=` but have
 ///   distinct bit patterns (`0x0000_0000` vs `0x8000_0000`). Storing `-0.0`
-///   would break the order-preservation property above (`-0.0.to_bits()` is
-///   the largest `u32`), so [`Self::try_new`] normalizes `-0.0` inputs to
-///   `+0.0` before storage. This canonical-bit-pattern guarantee is what
-///   makes hashing on `value.to_bits()` consistent with numeric equality.
+///   would break the order-preservation property above (`-0.0.to_bits()` is the
+///   largest `u32`), so [`Self::try_new`] normalizes `-0.0` inputs to `+0.0`
+///   before storage. This canonical-bit-pattern guarantee is what makes hashing
+///   on `value.to_bits()` consistent with numeric equality.
 ///
 /// # Example
 ///
@@ -182,7 +184,8 @@ impl<const MIN_AS_BITS: u32> Probability<MIN_AS_BITS> {
     ///
     /// The `assert!`s here run at const-evaluation time for every
     /// monomorphization of [`Probability`], rejecting bit patterns that decode
-    /// to NaN, `±∞`, `-0.0`, or values outside `[+0.0, +1.0]`.
+    /// to [`f32::NAN`], [`f32::INFINITY`], [`f32::NEG_INFINITY`], `-0.0`, or
+    /// values outside `[+0.0, +1.0]`.
     pub const MIN: f32 = {
         assert!(
             MIN_AS_BITS != NEG_ZERO_AS_BITS,
@@ -199,8 +202,8 @@ impl<const MIN_AS_BITS: u32> Probability<MIN_AS_BITS> {
     pub const MAX: f32 = 1.0;
 
     /// Construct a [`Probability`] from `value`, validating that it lies in
-    /// `[MIN, +1.0]` and is not NaN or `±∞`. A `-0.0` input is normalized to
-    /// `+0.0`.
+    /// `[MIN, +1.0]` and is not [`f32::NAN`], [`f32::INFINITY`], or
+    /// [`f32::NEG_INFINITY`]. A `-0.0` input is normalized to `+0.0`.
     ///
     /// This is a `const fn`, so callers can build a [`Probability`] in a
     /// `const` context by matching on the returned [`Result`]; the validation
@@ -277,8 +280,7 @@ mod probability_tests {
             Ok(p) => p,
             Err(_) => panic!("0.75 is in [0.5, 1.0]"),
         };
-        const ABOVE_ONE: Result<AtLeastHalf, ProbabilityError> =
-            AtLeastHalf::try_new(2.0);
+        const ABOVE_ONE: Result<AtLeastHalf, ProbabilityError> = AtLeastHalf::try_new(2.0);
         assert_eq!(VALID.get().to_bits(), 0.75_f32.to_bits());
         assert!(matches!(ABOVE_ONE, Err(ProbabilityError::AboveOne(_))));
     }
@@ -348,18 +350,13 @@ mod probability_tests {
     }
 
     fn non_finite_strategy() -> impl Strategy<Value = f32> {
-        prop_oneof![
-            Just(f32::NAN),
-            Just(f32::INFINITY),
-            Just(f32::NEG_INFINITY),
-        ]
+        prop_oneof![Just(f32::NAN), Just(f32::INFINITY), Just(f32::NEG_INFINITY),]
     }
 
     // ===== Property-test helpers (generic over MIN_AS_BITS) =====
 
     fn check_accepts_in_range<const MIN_AS_BITS: u32>(v: f32) {
-        let p = Probability::<MIN_AS_BITS>::try_new(v)
-            .expect("v should be valid by construction");
+        let p = Probability::<MIN_AS_BITS>::try_new(v).expect("v should be valid by construction");
         assert_eq!(p.get().to_bits(), v.to_bits());
     }
 
@@ -387,23 +384,20 @@ mod probability_tests {
     fn check_serde_json_round_trip<const MIN_AS_BITS: u32>(v: f32) {
         let p = Probability::<MIN_AS_BITS>::try_new(v).expect("valid v");
         let json = serde_json::to_string(&p).expect("serialize");
-        let back: Probability<MIN_AS_BITS> =
-            serde_json::from_str(&json).expect("deserialize");
+        let back: Probability<MIN_AS_BITS> = serde_json::from_str(&json).expect("deserialize");
         assert_eq!(back.get().to_bits(), v.to_bits());
     }
 
     fn check_serde_yaml_round_trip<const MIN_AS_BITS: u32>(v: f32) {
         let p = Probability::<MIN_AS_BITS>::try_new(v).expect("valid v");
         let yaml = serde_yaml::to_string(&p).expect("serialize");
-        let back: Probability<MIN_AS_BITS> =
-            serde_yaml::from_str(&yaml).expect("deserialize");
+        let back: Probability<MIN_AS_BITS> = serde_yaml::from_str(&yaml).expect("deserialize");
         assert_eq!(back.get().to_bits(), v.to_bits());
     }
 
     fn check_serde_json_rejects_below_min<const MIN_AS_BITS: u32>(v: f32) {
         let json = serde_json::to_string(&v).expect("serialize raw f32");
-        let err = serde_json::from_str::<Probability<MIN_AS_BITS>>(&json)
-            .expect_err("v < MIN");
+        let err = serde_json::from_str::<Probability<MIN_AS_BITS>>(&json).expect_err("v < MIN");
         assert!(
             err.to_string().contains("below lower bound"),
             "unexpected error: {err}"
@@ -412,8 +406,7 @@ mod probability_tests {
 
     fn check_serde_yaml_rejects_below_min<const MIN_AS_BITS: u32>(v: f32) {
         let yaml = serde_yaml::to_string(&v).expect("serialize raw f32");
-        let err = serde_yaml::from_str::<Probability<MIN_AS_BITS>>(&yaml)
-            .expect_err("v < MIN");
+        let err = serde_yaml::from_str::<Probability<MIN_AS_BITS>>(&yaml).expect_err("v < MIN");
         assert!(
             err.to_string().contains("below lower bound"),
             "unexpected error: {err}"

--- a/lading_payload/src/common/config.rs
+++ b/lading_payload/src/common/config.rs
@@ -111,10 +111,13 @@ pub enum ProbabilityError {
 /// An `f32`-valued probability with a compile-time lower bound.
 ///
 /// The const generic `MIN_AS_BITS` is the IEEE-754 bit pattern of the lower
-/// bound, obtained at the call site via [`f32::to_bits`]. The decoded bound
-/// must be a finite value in `[+0.0, +1.0]` and must not be `-0.0`; otherwise
-/// the type fails to instantiate at compile time via the assertions on
-/// [`Self::MIN`].
+/// bound, obtained at the call site via [`f32::to_bits`]. This generic
+/// parameter exists because some payload generators have probability-valued
+/// fields with a minimum probability strictly greater than zero (e.g.,
+/// `unique_tag_probability` must be at least 0.1 in
+/// [`crate::common::tags::Generator`]). The decoded bound must be a finite
+/// value in `[+0.0, +1.0]` and must not be `-0.0`; otherwise the type fails to
+/// instantiate at compile time via the assertions on [`Self::MIN`].
 ///
 /// Stored values must be finite and lie in `[MIN, +1.0]`. Inputs of `-0.0` are
 /// normalized to `+0.0`; other invalid inputs are rejected via

--- a/lading_payload/src/common/config.rs
+++ b/lading_payload/src/common/config.rs
@@ -87,7 +87,7 @@ where
 
 /// Bit pattern of `-0.0_f32`. Used to reject negative zero, which compares
 /// equal to `+0.0` under IEEE-754 numeric ordering.
-const NEG_ZERO_BITS: u32 = 0x8000_0000;
+const NEG_ZERO_AS_BITS: u32 = 0x8000_0000;
 
 /// Error returned when a value cannot be turned into a [`Probability`].
 #[derive(Debug, thiserror::Error, Clone, Copy)]
@@ -113,7 +113,7 @@ pub enum ProbabilityError {
 
 /// An `f32`-valued probability with a compile-time lower bound.
 ///
-/// The const generic `MIN_BITS` is the IEEE-754 bit pattern of the lower bound,
+/// The const generic `MIN_AS_BITS` is the IEEE-754 bit pattern of the lower bound,
 /// obtained at the call site via [`f32::to_bits`]. The decoded bound must be a
 /// finite value in `[+0.0, +1.0]` and must not be `-0.0`; otherwise the type
 /// fails to instantiate at compile time via the assertions on [`Self::MIN`].
@@ -145,7 +145,7 @@ pub enum ProbabilityError {
 ///   the largest `u32`), so the type rejects `-0.0` explicitly.
 ///
 /// The current implementation still compares in the `f32` domain via
-/// [`PartialOrd`] for clarity, but `MIN_BITS` is stored as `u32` precisely so
+/// [`PartialOrd`] for clarity, but `MIN_AS_BITS` is stored as `u32` precisely so
 /// that future revisions can move the hot-path comparison into the integer
 /// domain without an API break.
 ///
@@ -160,11 +160,11 @@ pub enum ProbabilityError {
 /// ```
 #[derive(Debug, Clone, Copy, serde::Serialize, serde::Deserialize)]
 #[serde(into = "f32", try_from = "f32")]
-pub struct Probability<const MIN_BITS: u32> {
+pub struct Probability<const MIN_AS_BITS: u32> {
     value: f32,
 }
 
-impl<const MIN_BITS: u32> TryFrom<f32> for Probability<MIN_BITS> {
+impl<const MIN_AS_BITS: u32> TryFrom<f32> for Probability<MIN_AS_BITS> {
     type Error = ProbabilityError;
 
     fn try_from(value: f32) -> Result<Self, Self::Error> {
@@ -172,31 +172,31 @@ impl<const MIN_BITS: u32> TryFrom<f32> for Probability<MIN_BITS> {
     }
 }
 
-impl<const MIN_BITS: u32> From<Probability<MIN_BITS>> for f32 {
-    fn from(p: Probability<MIN_BITS>) -> Self {
+impl<const MIN_AS_BITS: u32> From<Probability<MIN_AS_BITS>> for f32 {
+    fn from(p: Probability<MIN_AS_BITS>) -> Self {
         p.value
     }
 }
 
-impl<const MIN_BITS: u32> fmt::Display for Probability<MIN_BITS> {
+impl<const MIN_AS_BITS: u32> fmt::Display for Probability<MIN_AS_BITS> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         fmt::Display::fmt(&self.value, f)
     }
 }
 
-impl<const MIN_BITS: u32> Probability<MIN_BITS> {
-    /// The lower bound decoded from `MIN_BITS`.
+impl<const MIN_AS_BITS: u32> Probability<MIN_AS_BITS> {
+    /// The lower bound decoded from `MIN_AS_BITS`.
     ///
     /// The `assert!`s here run at const-evaluation time for every
     /// monomorphization of [`Probability`], rejecting bit patterns that decode
     /// to NaN, `±∞`, `-0.0`, or values outside `[+0.0, +1.0]`.
     pub const MIN: f32 = {
         assert!(
-            MIN_BITS != NEG_ZERO_BITS,
-            "MIN_BITS must not encode -0.0"
+            MIN_AS_BITS != NEG_ZERO_AS_BITS,
+            "MIN_AS_BITS must not encode -0.0"
         );
-        let v = f32::from_bits(MIN_BITS);
-        assert!(v.is_finite(), "MIN_BITS must decode to a finite f32");
+        let v = f32::from_bits(MIN_AS_BITS);
+        assert!(v.is_finite(), "MIN_AS_BITS must decode to a finite f32");
         assert!(v >= 0.0, "lower bound must be >= +0.0");
         assert!(v <= 1.0, "lower bound must be <= +1.0");
         v
@@ -220,7 +220,7 @@ impl<const MIN_BITS: u32> Probability<MIN_BITS> {
         if !value.is_finite() {
             return Err(ProbabilityError::NotFinite(value));
         }
-        if value.to_bits() == NEG_ZERO_BITS {
+        if value.to_bits() == NEG_ZERO_AS_BITS {
             return Err(ProbabilityError::NegativeZero);
         }
         if value < min {
@@ -241,7 +241,7 @@ impl<const MIN_BITS: u32> Probability<MIN_BITS> {
 
 #[cfg(test)]
 mod probability_tests {
-    use super::{NEG_ZERO_BITS, Probability, ProbabilityError};
+    use super::{NEG_ZERO_AS_BITS, Probability, ProbabilityError};
 
     type ZeroOrMore = Probability<{ f32::to_bits(0.0) }>;
     type AtLeastHalf = Probability<{ f32::to_bits(0.5) }>;
@@ -324,7 +324,7 @@ mod probability_tests {
 
     #[test]
     fn rejects_negative_zero() {
-        let neg_zero = f32::from_bits(NEG_ZERO_BITS);
+        let neg_zero = f32::from_bits(NEG_ZERO_AS_BITS);
         let err = ZeroOrMore::try_new(neg_zero).expect_err("-0.0 is rejected");
         assert!(matches!(err, ProbabilityError::NegativeZero));
     }

--- a/lading_payload/src/common/config.rs
+++ b/lading_payload/src/common/config.rs
@@ -151,12 +151,12 @@ pub enum ProbabilityError {
 ///
 /// # Example
 ///
-/// ```ignore
+/// ```
 /// use lading_payload::common::config::Probability;
 ///
 /// type AtLeastHalf = Probability<{ f32::to_bits(0.5) }>;
 /// let p = AtLeastHalf::try_new(0.75).expect("0.75 is in [0.5, 1.0]");
-/// assert!((p.get() - 0.75).abs() < f32::EPSILON);
+/// assert_eq!(p.get(), 0.75);
 /// ```
 #[derive(Debug, Clone, Copy, serde::Serialize, serde::Deserialize)]
 #[serde(into = "f32", try_from = "f32")]

--- a/lading_payload/src/common/config.rs
+++ b/lading_payload/src/common/config.rs
@@ -84,3 +84,206 @@ where
         }
     }
 }
+
+/// Bit pattern of `-0.0_f32`. Used to reject negative zero, which compares
+/// equal to `+0.0` under IEEE-754 numeric ordering.
+const NEG_ZERO_BITS: u32 = 0x8000_0000;
+
+/// Error returned when a value cannot be turned into a [`Probability`].
+#[derive(Debug, thiserror::Error, Clone, Copy)]
+pub enum ProbabilityError {
+    /// Value is NaN or `±∞`.
+    #[error("probability must be finite, got {0}")]
+    NotFinite(f32),
+    /// Value has the bit pattern of `-0.0`.
+    #[error("probability must not be -0.0")]
+    NegativeZero,
+    /// Value is below the type's compile-time lower bound.
+    #[error("probability {value} is below lower bound {min}")]
+    BelowMin {
+        /// The lower bound encoded in the type parameter.
+        min: f32,
+        /// The offending value.
+        value: f32,
+    },
+    /// Value exceeds `+1.0`.
+    #[error("probability {0} exceeds 1.0")]
+    AboveOne(f32),
+}
+
+/// An `f32`-valued probability with a compile-time lower bound.
+///
+/// The const generic `MIN_BITS` is the IEEE-754 bit pattern of the lower bound,
+/// obtained at the call site via [`f32::to_bits`]. The decoded bound must be a
+/// finite value in `[+0.0, +1.0]` and must not be `-0.0`; otherwise the type
+/// fails to instantiate at compile time via the assertions on [`Self::MIN`].
+///
+/// Stored values are validated by [`Self::try_new`] against the same edge-case
+/// rules and must lie in `[MIN, +1.0]`.
+///
+/// # Example
+///
+/// ```ignore
+/// use lading_payload::common::config::Probability;
+///
+/// type AtLeastHalf = Probability<{ f32::to_bits(0.5) }>;
+/// let p = AtLeastHalf::try_new(0.75).expect("0.75 is in [0.5, 1.0]");
+/// assert!((p.get() - 0.75).abs() < f32::EPSILON);
+/// ```
+#[derive(Debug, Clone, Copy)]
+pub struct Probability<const MIN_BITS: u32> {
+    value: f32,
+}
+
+impl<const MIN_BITS: u32> Probability<MIN_BITS> {
+    /// The lower bound decoded from `MIN_BITS`.
+    ///
+    /// The `assert!`s here run at const-evaluation time for every
+    /// monomorphization of [`Probability`], rejecting bit patterns that decode
+    /// to NaN, `±∞`, `-0.0`, or values outside `[+0.0, +1.0]`.
+    pub const MIN: f32 = {
+        assert!(
+            MIN_BITS != NEG_ZERO_BITS,
+            "MIN_BITS must not encode -0.0"
+        );
+        let v = f32::from_bits(MIN_BITS);
+        assert!(v.is_finite(), "MIN_BITS must decode to a finite f32");
+        assert!(v >= 0.0, "lower bound must be >= +0.0");
+        assert!(v <= 1.0, "lower bound must be <= +1.0");
+        v
+    };
+
+    /// The upper bound, fixed at `+1.0`.
+    pub const MAX: f32 = 1.0;
+
+    /// Construct a [`Probability`] from `value`, validating that it lies in
+    /// `[MIN, +1.0]` and is not NaN, `±∞`, or `-0.0`.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ProbabilityError`] when validation fails.
+    pub fn try_new(value: f32) -> Result<Self, ProbabilityError> {
+        // Force evaluation of the const-eval bound check for this
+        // monomorphization. Without this reference the assertions in `MIN`
+        // can be elided when no caller names `Self::MIN` directly.
+        let min = Self::MIN;
+
+        if !value.is_finite() {
+            return Err(ProbabilityError::NotFinite(value));
+        }
+        if value.to_bits() == NEG_ZERO_BITS {
+            return Err(ProbabilityError::NegativeZero);
+        }
+        if value < min {
+            return Err(ProbabilityError::BelowMin { min, value });
+        }
+        if value > Self::MAX {
+            return Err(ProbabilityError::AboveOne(value));
+        }
+        Ok(Self { value })
+    }
+
+    /// Return the stored probability value.
+    #[must_use]
+    pub const fn get(&self) -> f32 {
+        self.value
+    }
+}
+
+#[cfg(test)]
+mod probability_tests {
+    use super::{NEG_ZERO_BITS, Probability, ProbabilityError};
+
+    type ZeroOrMore = Probability<{ f32::to_bits(0.0) }>;
+    type AtLeastHalf = Probability<{ f32::to_bits(0.5) }>;
+    type AtLeastOne = Probability<{ f32::to_bits(1.0) }>;
+
+    #[test]
+    fn min_const_matches_bit_pattern() {
+        assert_eq!(ZeroOrMore::MIN.to_bits(), 0.0_f32.to_bits());
+        assert_eq!(AtLeastHalf::MIN.to_bits(), 0.5_f32.to_bits());
+        assert_eq!(AtLeastOne::MIN.to_bits(), 1.0_f32.to_bits());
+    }
+
+    #[test]
+    fn max_const_is_one() {
+        assert_eq!(ZeroOrMore::MAX.to_bits(), 1.0_f32.to_bits());
+    }
+
+    #[test]
+    fn accepts_values_in_range() {
+        let p = ZeroOrMore::try_new(0.5).expect("0.5 is in [0.0, 1.0]");
+        assert_eq!(p.get().to_bits(), 0.5_f32.to_bits());
+
+        let p = AtLeastHalf::try_new(0.75).expect("0.75 is in [0.5, 1.0]");
+        assert_eq!(p.get().to_bits(), 0.75_f32.to_bits());
+    }
+
+    #[test]
+    fn accepts_lower_bound() {
+        let p = AtLeastHalf::try_new(0.5).expect("0.5 is the lower bound");
+        assert_eq!(p.get().to_bits(), 0.5_f32.to_bits());
+    }
+
+    #[test]
+    fn accepts_upper_bound() {
+        let p = ZeroOrMore::try_new(1.0).expect("1.0 is the upper bound");
+        assert_eq!(p.get().to_bits(), 1.0_f32.to_bits());
+    }
+
+    #[test]
+    fn accepts_only_one_for_unit_bound() {
+        let p = AtLeastOne::try_new(1.0).expect("1.0 is in [1.0, 1.0]");
+        assert_eq!(p.get().to_bits(), 1.0_f32.to_bits());
+    }
+
+    #[test]
+    fn rejects_below_min() {
+        let err = AtLeastHalf::try_new(0.1).expect_err("0.1 < 0.5");
+        match err {
+            ProbabilityError::BelowMin { min, value } => {
+                assert_eq!(min.to_bits(), 0.5_f32.to_bits());
+                assert_eq!(value.to_bits(), 0.1_f32.to_bits());
+            }
+            other => panic!("expected BelowMin, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn rejects_above_one() {
+        let err = ZeroOrMore::try_new(1.5).expect_err("1.5 > 1.0");
+        assert!(matches!(err, ProbabilityError::AboveOne(_)));
+    }
+
+    #[test]
+    fn rejects_nan() {
+        let err = ZeroOrMore::try_new(f32::NAN).expect_err("NaN is not finite");
+        assert!(matches!(err, ProbabilityError::NotFinite(_)));
+    }
+
+    #[test]
+    fn rejects_positive_infinity() {
+        let err = ZeroOrMore::try_new(f32::INFINITY).expect_err("+inf is not finite");
+        assert!(matches!(err, ProbabilityError::NotFinite(_)));
+    }
+
+    #[test]
+    fn rejects_negative_infinity() {
+        let err = ZeroOrMore::try_new(f32::NEG_INFINITY).expect_err("-inf is not finite");
+        assert!(matches!(err, ProbabilityError::NotFinite(_)));
+    }
+
+    #[test]
+    fn rejects_negative_zero() {
+        let neg_zero = f32::from_bits(NEG_ZERO_BITS);
+        let err = ZeroOrMore::try_new(neg_zero).expect_err("-0.0 is rejected");
+        assert!(matches!(err, ProbabilityError::NegativeZero));
+    }
+
+    #[test]
+    fn rejects_negative_nonzero() {
+        // -0.1 is finite and not -0.0, so it fails the lower-bound check.
+        let err = ZeroOrMore::try_new(-0.1).expect_err("-0.1 < 0.0");
+        assert!(matches!(err, ProbabilityError::BelowMin { .. }));
+    }
+}

--- a/lading_payload/src/common/config.rs
+++ b/lading_payload/src/common/config.rs
@@ -95,9 +95,6 @@ pub enum ProbabilityError {
     /// Value is NaN or `±∞`.
     #[error("probability must be finite, got {0}")]
     NotFinite(f32),
-    /// Value has the bit pattern of `-0.0`.
-    #[error("probability must not be -0.0")]
-    NegativeZero,
     /// Value is below the type's compile-time lower bound.
     #[error("probability {value} is below lower bound {min}")]
     BelowMin {
@@ -118,8 +115,9 @@ pub enum ProbabilityError {
 /// finite value in `[+0.0, +1.0]` and must not be `-0.0`; otherwise the type
 /// fails to instantiate at compile time via the assertions on [`Self::MIN`].
 ///
-/// Stored values are validated by [`Self::try_new`] against the same edge-case
-/// rules and must lie in `[MIN, +1.0]`.
+/// Stored values must be finite and lie in `[MIN, +1.0]`. Inputs of `-0.0` are
+/// normalized to `+0.0`; other invalid inputs are rejected via
+/// [`ProbabilityError`].
 ///
 /// # Design
 ///
@@ -140,9 +138,10 @@ pub enum ProbabilityError {
 ///   remaining 31 bits are laid out exponent-then-mantissa, so the unsigned
 ///   integer ordering matches the numeric ordering.
 /// * `+0.0` and `-0.0` are numerically equal under `==`/`<`/`<=` but have
-///   distinct bit patterns (`0x0000_0000` vs `0x8000_0000`). Allowing `-0.0`
+///   distinct bit patterns (`0x0000_0000` vs `0x8000_0000`). Storing `-0.0`
 ///   would break the order-preservation property above (`-0.0.to_bits()` is
-///   the largest `u32`), so the type rejects `-0.0` explicitly.
+///   the largest `u32`), so [`Self::try_new`] normalizes `-0.0` inputs to
+///   `+0.0` before storage.
 ///
 /// The current implementation still compares in the `f32` domain via
 /// [`PartialOrd`] for clarity, but `MIN_AS_BITS` is stored as `u32` precisely so
@@ -206,7 +205,8 @@ impl<const MIN_AS_BITS: u32> Probability<MIN_AS_BITS> {
     pub const MAX: f32 = 1.0;
 
     /// Construct a [`Probability`] from `value`, validating that it lies in
-    /// `[MIN, +1.0]` and is not NaN, `±∞`, or `-0.0`.
+    /// `[MIN, +1.0]` and is not NaN or `±∞`. A `-0.0` input is normalized to
+    /// `+0.0`.
     ///
     /// # Errors
     ///
@@ -220,9 +220,11 @@ impl<const MIN_AS_BITS: u32> Probability<MIN_AS_BITS> {
         if !value.is_finite() {
             return Err(ProbabilityError::NotFinite(value));
         }
-        if value.to_bits() == NEG_ZERO_AS_BITS {
-            return Err(ProbabilityError::NegativeZero);
-        }
+        let value = if value.to_bits() == NEG_ZERO_AS_BITS {
+            0.0_f32
+        } else {
+            value
+        };
         if value < min {
             return Err(ProbabilityError::BelowMin { min, value });
         }
@@ -269,10 +271,23 @@ mod probability_tests {
     }
 
     #[test]
-    fn rejects_negative_zero() {
+    fn normalizes_negative_zero() {
         let neg_zero = f32::from_bits(NEG_ZERO_AS_BITS);
-        let err = ZeroOrMore::try_new(neg_zero).expect_err("-0.0 is rejected");
-        assert!(matches!(err, ProbabilityError::NegativeZero));
+        let p = ZeroOrMore::try_new(neg_zero).expect("-0.0 normalizes to +0.0");
+        assert_eq!(p.get().to_bits(), 0.0_f32.to_bits());
+    }
+
+    #[test]
+    fn negative_zero_below_strict_min_is_below_min() {
+        let neg_zero = f32::from_bits(NEG_ZERO_AS_BITS);
+        let err = AtLeastHalf::try_new(neg_zero).expect_err("0.0 < 0.5");
+        match err {
+            ProbabilityError::BelowMin { min, value } => {
+                assert_eq!(min.to_bits(), AtLeastHalf::MIN.to_bits());
+                assert_eq!(value.to_bits(), 0.0_f32.to_bits());
+            }
+            other => panic!("expected BelowMin, got {other:?}"),
+        }
     }
 
     // ===== Unit tests: wire-format pins =====

--- a/lading_payload/src/common/config.rs
+++ b/lading_payload/src/common/config.rs
@@ -121,6 +121,34 @@ pub enum ProbabilityError {
 /// Stored values are validated by [`Self::try_new`] against the same edge-case
 /// rules and must lie in `[MIN, +1.0]`.
 ///
+/// # Design
+///
+/// Rust does not yet allow floating-point types as const generic parameters on
+/// stable; tracking issue `rust-lang/rust#95174` covers `#![feature(adt_const_params)]`
+/// and its float-specific complications. To carry a compile-time lower bound
+/// today the type must be parameterized on an integer, so callers spell the
+/// bound as a `u32` bit pattern (`{ f32::to_bits(0.5) }`) and the type decodes
+/// it back to `f32` inside [`Self::MIN`].
+///
+/// Once the const generic is an integer, the natural follow-up question is
+/// whether bound checks can stay in the integer domain. They can, for the
+/// values this type accepts, because of two IEEE-754 properties of the
+/// `f32` ↔ `u32` round trip exposed by [`f32::to_bits`] / [`f32::from_bits`]:
+///
+/// * For any two values `a, b` in `[+0.0, +∞)` (i.e. non-negative, non-NaN),
+///   `a <= b` iff `a.to_bits() <= b.to_bits()`. The sign bit is zero and the
+///   remaining 31 bits are laid out exponent-then-mantissa, so the unsigned
+///   integer ordering matches the numeric ordering.
+/// * `+0.0` and `-0.0` are numerically equal under `==`/`<`/`<=` but have
+///   distinct bit patterns (`0x0000_0000` vs `0x8000_0000`). Allowing `-0.0`
+///   would break the order-preservation property above (`-0.0.to_bits()` is
+///   the largest `u32`), so the type rejects `-0.0` explicitly.
+///
+/// The current implementation still compares in the `f32` domain via
+/// [`PartialOrd`] for clarity, but `MIN_BITS` is stored as `u32` precisely so
+/// that future revisions can move the hot-path comparison into the integer
+/// domain without an API break.
+///
 /// # Example
 ///
 /// ```ignore

--- a/lading_payload/src/common/config.rs
+++ b/lading_payload/src/common/config.rs
@@ -208,10 +208,14 @@ impl<const MIN_AS_BITS: u32> Probability<MIN_AS_BITS> {
     /// `[MIN, +1.0]` and is not NaN or `±∞`. A `-0.0` input is normalized to
     /// `+0.0`.
     ///
+    /// This is a `const fn`, so callers can build a [`Probability`] in a
+    /// `const` context by matching on the returned [`Result`]; the validation
+    /// then runs at compile time.
+    ///
     /// # Errors
     ///
     /// Returns [`ProbabilityError`] when validation fails.
-    pub fn try_new(value: f32) -> Result<Self, ProbabilityError> {
+    pub const fn try_new(value: f32) -> Result<Self, ProbabilityError> {
         // Force evaluation of the const-eval bound check for this
         // monomorphization. Without this reference the assertions in `MIN`
         // can be elided when no caller names `Self::MIN` directly.
@@ -268,6 +272,21 @@ mod probability_tests {
     fn accepts_only_one_for_unit_bound() {
         let p = AtLeastOne::try_new(1.0).expect("1.0 is in [1.0, 1.0]");
         assert_eq!(p.get().to_bits(), 1.0_f32.to_bits());
+    }
+
+    #[test]
+    fn try_new_is_const_evaluable() {
+        // `try_new` must remain a `const fn` so callers can validate
+        // literals at compile time. The `const` bindings below would fail
+        // to build if it ever lost that property.
+        const VALID: AtLeastHalf = match AtLeastHalf::try_new(0.75) {
+            Ok(p) => p,
+            Err(_) => panic!("0.75 is in [0.5, 1.0]"),
+        };
+        const ABOVE_ONE: Result<AtLeastHalf, ProbabilityError> =
+            AtLeastHalf::try_new(2.0);
+        assert_eq!(VALID.get().to_bits(), 0.75_f32.to_bits());
+        assert!(matches!(ABOVE_ONE, Err(ProbabilityError::AboveOne(_))));
     }
 
     #[test]

--- a/lading_payload/src/common/config.rs
+++ b/lading_payload/src/common/config.rs
@@ -128,10 +128,8 @@ pub enum ProbabilityError {
 /// bound as a `u32` bit pattern (`{ f32::to_bits(0.5) }`) and the type decodes
 /// it back to `f32` inside [`Self::MIN`].
 ///
-/// Once the const generic is an integer, the natural follow-up question is
-/// whether bound checks can stay in the integer domain. They can, for the
-/// values this type accepts, because of two IEEE-754 properties of the
-/// `f32` ↔ `u32` round trip exposed by [`f32::to_bits`] / [`f32::from_bits`]:
+/// Two IEEE-754 properties of the `f32` ↔ `u32` round trip exposed by
+/// [`f32::to_bits`] / [`f32::from_bits`] inform the rest of the design:
 ///
 /// * For any two values `a, b` in `[+0.0, +∞)` (i.e. non-negative, non-NaN),
 ///   `a <= b` iff `a.to_bits() <= b.to_bits()`. The sign bit is zero and the
@@ -141,12 +139,8 @@ pub enum ProbabilityError {
 ///   distinct bit patterns (`0x0000_0000` vs `0x8000_0000`). Storing `-0.0`
 ///   would break the order-preservation property above (`-0.0.to_bits()` is
 ///   the largest `u32`), so [`Self::try_new`] normalizes `-0.0` inputs to
-///   `+0.0` before storage.
-///
-/// The current implementation still compares in the `f32` domain via
-/// [`PartialOrd`] for clarity, but `MIN_AS_BITS` is stored as `u32` precisely so
-/// that future revisions can move the hot-path comparison into the integer
-/// domain without an API break.
+///   `+0.0` before storage. This canonical-bit-pattern guarantee is what
+///   makes hashing on `value.to_bits()` consistent with numeric equality.
 ///
 /// # Example
 ///

--- a/lading_payload/src/common/config.rs
+++ b/lading_payload/src/common/config.rs
@@ -242,10 +242,13 @@ impl<const MIN_AS_BITS: u32> Probability<MIN_AS_BITS> {
 #[cfg(test)]
 mod probability_tests {
     use super::{NEG_ZERO_AS_BITS, Probability, ProbabilityError};
+    use proptest::prelude::*;
 
     type ZeroOrMore = Probability<{ f32::to_bits(0.0) }>;
     type AtLeastHalf = Probability<{ f32::to_bits(0.5) }>;
     type AtLeastOne = Probability<{ f32::to_bits(1.0) }>;
+
+    // ===== Unit tests: constants =====
 
     #[test]
     fn min_const_matches_bit_pattern() {
@@ -260,66 +263,9 @@ mod probability_tests {
     }
 
     #[test]
-    fn accepts_values_in_range() {
-        let p = ZeroOrMore::try_new(0.5).expect("0.5 is in [0.0, 1.0]");
-        assert_eq!(p.get().to_bits(), 0.5_f32.to_bits());
-
-        let p = AtLeastHalf::try_new(0.75).expect("0.75 is in [0.5, 1.0]");
-        assert_eq!(p.get().to_bits(), 0.75_f32.to_bits());
-    }
-
-    #[test]
-    fn accepts_lower_bound() {
-        let p = AtLeastHalf::try_new(0.5).expect("0.5 is the lower bound");
-        assert_eq!(p.get().to_bits(), 0.5_f32.to_bits());
-    }
-
-    #[test]
-    fn accepts_upper_bound() {
-        let p = ZeroOrMore::try_new(1.0).expect("1.0 is the upper bound");
-        assert_eq!(p.get().to_bits(), 1.0_f32.to_bits());
-    }
-
-    #[test]
     fn accepts_only_one_for_unit_bound() {
         let p = AtLeastOne::try_new(1.0).expect("1.0 is in [1.0, 1.0]");
         assert_eq!(p.get().to_bits(), 1.0_f32.to_bits());
-    }
-
-    #[test]
-    fn rejects_below_min() {
-        let err = AtLeastHalf::try_new(0.1).expect_err("0.1 < 0.5");
-        match err {
-            ProbabilityError::BelowMin { min, value } => {
-                assert_eq!(min.to_bits(), 0.5_f32.to_bits());
-                assert_eq!(value.to_bits(), 0.1_f32.to_bits());
-            }
-            other => panic!("expected BelowMin, got {other:?}"),
-        }
-    }
-
-    #[test]
-    fn rejects_above_one() {
-        let err = ZeroOrMore::try_new(1.5).expect_err("1.5 > 1.0");
-        assert!(matches!(err, ProbabilityError::AboveOne(_)));
-    }
-
-    #[test]
-    fn rejects_nan() {
-        let err = ZeroOrMore::try_new(f32::NAN).expect_err("NaN is not finite");
-        assert!(matches!(err, ProbabilityError::NotFinite(_)));
-    }
-
-    #[test]
-    fn rejects_positive_infinity() {
-        let err = ZeroOrMore::try_new(f32::INFINITY).expect_err("+inf is not finite");
-        assert!(matches!(err, ProbabilityError::NotFinite(_)));
-    }
-
-    #[test]
-    fn rejects_negative_infinity() {
-        let err = ZeroOrMore::try_new(f32::NEG_INFINITY).expect_err("-inf is not finite");
-        assert!(matches!(err, ProbabilityError::NotFinite(_)));
     }
 
     #[test]
@@ -329,12 +275,7 @@ mod probability_tests {
         assert!(matches!(err, ProbabilityError::NegativeZero));
     }
 
-    #[test]
-    fn rejects_negative_nonzero() {
-        // -0.1 is finite and not -0.0, so it fails the lower-bound check.
-        let err = ZeroOrMore::try_new(-0.1).expect_err("-0.1 < 0.0");
-        assert!(matches!(err, ProbabilityError::BelowMin { .. }));
-    }
+    // ===== Unit tests: wire-format pins =====
 
     #[test]
     fn serde_round_trip_json() {
@@ -346,47 +287,327 @@ mod probability_tests {
     }
 
     #[test]
-    fn serde_deserialize_accepts_valid() {
-        let p: AtLeastHalf = serde_json::from_str("0.5").expect("0.5 is the lower bound");
-        assert_eq!(p.get().to_bits(), 0.5_f32.to_bits());
+    fn serde_round_trip_yaml_format() {
+        let p = AtLeastHalf::try_new(0.75).expect("0.75 in [0.5, 1.0]");
+        let yaml = serde_yaml::to_string(&p).expect("serialize");
+        assert_eq!(yaml, "0.75\n");
+        let back: AtLeastHalf = serde_yaml::from_str(&yaml).expect("deserialize");
+        assert_eq!(back.get().to_bits(), 0.75_f32.to_bits());
     }
 
-    #[test]
-    fn serde_deserialize_rejects_below_min() {
-        let err = serde_json::from_str::<AtLeastHalf>("0.1").expect_err("0.1 < 0.5");
-        // The serde error wraps our ProbabilityError's Display output.
+    // ===== Property-test strategies =====
+
+    fn valid_value_strategy(min: f32) -> BoxedStrategy<f32> {
+        // proptest's `RangeInclusive<f32>` panics on degenerate ranges, so
+        // produce a single-value strategy when `min == MAX`.
+        if min >= 1.0 {
+            Just(1.0_f32).boxed()
+        } else {
+            (min..=1.0_f32)
+                .prop_filter("not -0.0", |v| v.to_bits() != NEG_ZERO_AS_BITS)
+                .boxed()
+        }
+    }
+
+    fn below_min_strategy(min: f32) -> impl Strategy<Value = f32> {
+        (f32::MIN..min).prop_filter("finite, not -0.0", |v| {
+            v.is_finite() && v.to_bits() != NEG_ZERO_AS_BITS
+        })
+    }
+
+    fn above_one_strategy() -> impl Strategy<Value = f32> {
+        (1.0_f32..f32::MAX).prop_filter("> 1.0 and finite", |v| *v > 1.0 && v.is_finite())
+    }
+
+    fn non_finite_strategy() -> impl Strategy<Value = f32> {
+        prop_oneof![
+            Just(f32::NAN),
+            Just(f32::INFINITY),
+            Just(f32::NEG_INFINITY),
+        ]
+    }
+
+    // ===== Property-test helpers (generic over MIN_AS_BITS) =====
+
+    fn check_accepts_in_range<const MIN_AS_BITS: u32>(v: f32) {
+        let p = Probability::<MIN_AS_BITS>::try_new(v)
+            .expect("v should be valid by construction");
+        assert_eq!(p.get().to_bits(), v.to_bits());
+    }
+
+    fn check_rejects_below_min<const MIN_AS_BITS: u32>(v: f32) {
+        let err = Probability::<MIN_AS_BITS>::try_new(v).expect_err("v should be below MIN");
+        match err {
+            ProbabilityError::BelowMin { min, value } => {
+                assert_eq!(min.to_bits(), Probability::<MIN_AS_BITS>::MIN.to_bits());
+                assert_eq!(value.to_bits(), v.to_bits());
+            }
+            other => panic!("expected BelowMin, got {other:?}"),
+        }
+    }
+
+    fn check_display_matches<const MIN_AS_BITS: u32>(v: f32) {
+        let p = Probability::<MIN_AS_BITS>::try_new(v).expect("valid v");
+        assert_eq!(format!("{p}"), format!("{v}"));
+    }
+
+    fn check_display_precision<const MIN_AS_BITS: u32>(v: f32, n: usize) {
+        let p = Probability::<MIN_AS_BITS>::try_new(v).expect("valid v");
+        assert_eq!(format!("{p:.n$}"), format!("{v:.n$}"));
+    }
+
+    fn check_serde_json_round_trip<const MIN_AS_BITS: u32>(v: f32) {
+        let p = Probability::<MIN_AS_BITS>::try_new(v).expect("valid v");
+        let json = serde_json::to_string(&p).expect("serialize");
+        let back: Probability<MIN_AS_BITS> =
+            serde_json::from_str(&json).expect("deserialize");
+        assert_eq!(back.get().to_bits(), v.to_bits());
+    }
+
+    fn check_serde_yaml_round_trip<const MIN_AS_BITS: u32>(v: f32) {
+        let p = Probability::<MIN_AS_BITS>::try_new(v).expect("valid v");
+        let yaml = serde_yaml::to_string(&p).expect("serialize");
+        let back: Probability<MIN_AS_BITS> =
+            serde_yaml::from_str(&yaml).expect("deserialize");
+        assert_eq!(back.get().to_bits(), v.to_bits());
+    }
+
+    fn check_serde_json_rejects_below_min<const MIN_AS_BITS: u32>(v: f32) {
+        let json = serde_json::to_string(&v).expect("serialize raw f32");
+        let err = serde_json::from_str::<Probability<MIN_AS_BITS>>(&json)
+            .expect_err("v < MIN");
         assert!(
             err.to_string().contains("below lower bound"),
             "unexpected error: {err}"
         );
     }
 
-    #[test]
-    fn serde_deserialize_rejects_above_one() {
-        let err = serde_json::from_str::<ZeroOrMore>("1.5").expect_err("1.5 > 1.0");
+    fn check_serde_yaml_rejects_below_min<const MIN_AS_BITS: u32>(v: f32) {
+        let yaml = serde_yaml::to_string(&v).expect("serialize raw f32");
+        let err = serde_yaml::from_str::<Probability<MIN_AS_BITS>>(&yaml)
+            .expect_err("v < MIN");
         assert!(
-            err.to_string().contains("exceeds 1.0"),
+            err.to_string().contains("below lower bound"),
             "unexpected error: {err}"
         );
     }
 
-    #[test]
-    fn serde_yaml_round_trip() {
-        let p = ZeroOrMore::try_new(0.25).expect("0.25 in [0.0, 1.0]");
-        let yaml = serde_yaml::to_string(&p).expect("serialize");
-        let back: ZeroOrMore = serde_yaml::from_str(&yaml).expect("deserialize");
-        assert_eq!(back.get().to_bits(), 0.25_f32.to_bits());
+    // ===== Property tests: input validation =====
+
+    proptest! {
+        #[test]
+        fn accepts_any_value_in_range_zero_or_more(
+            v in valid_value_strategy(ZeroOrMore::MIN),
+        ) {
+            check_accepts_in_range::<{ f32::to_bits(0.0) }>(v);
+        }
+
+        #[test]
+        fn accepts_any_value_in_range_at_least_half(
+            v in valid_value_strategy(AtLeastHalf::MIN),
+        ) {
+            check_accepts_in_range::<{ f32::to_bits(0.5) }>(v);
+        }
+
+        #[test]
+        fn accepts_any_value_in_range_at_least_one(
+            v in valid_value_strategy(AtLeastOne::MIN),
+        ) {
+            check_accepts_in_range::<{ f32::to_bits(1.0) }>(v);
+        }
+
+        #[test]
+        fn rejects_any_value_below_min_zero_or_more(
+            v in below_min_strategy(ZeroOrMore::MIN),
+        ) {
+            check_rejects_below_min::<{ f32::to_bits(0.0) }>(v);
+        }
+
+        #[test]
+        fn rejects_any_value_below_min_at_least_half(
+            v in below_min_strategy(AtLeastHalf::MIN),
+        ) {
+            check_rejects_below_min::<{ f32::to_bits(0.5) }>(v);
+        }
+
+        #[test]
+        fn rejects_any_value_below_min_at_least_one(
+            v in below_min_strategy(AtLeastOne::MIN),
+        ) {
+            check_rejects_below_min::<{ f32::to_bits(1.0) }>(v);
+        }
+
+        #[test]
+        fn rejects_any_value_above_one(v in above_one_strategy()) {
+            let err = ZeroOrMore::try_new(v).expect_err("v > 1.0");
+            prop_assert!(matches!(err, ProbabilityError::AboveOne(_)));
+        }
+
+        #[test]
+        fn rejects_any_non_finite(v in non_finite_strategy()) {
+            let err = ZeroOrMore::try_new(v).expect_err("v is not finite");
+            prop_assert!(matches!(err, ProbabilityError::NotFinite(_)));
+        }
     }
 
-    #[test]
-    fn display_matches_inner_f32() {
-        let p = AtLeastHalf::try_new(0.75).expect("0.75 in [0.5, 1.0]");
-        assert_eq!(format!("{p}"), format!("{}", 0.75_f32));
+    // ===== Property tests: Display =====
+
+    proptest! {
+        #[test]
+        fn display_matches_inner_f32_for_valid_values_zero_or_more(
+            v in valid_value_strategy(ZeroOrMore::MIN),
+        ) {
+            check_display_matches::<{ f32::to_bits(0.0) }>(v);
+        }
+
+        #[test]
+        fn display_matches_inner_f32_for_valid_values_at_least_half(
+            v in valid_value_strategy(AtLeastHalf::MIN),
+        ) {
+            check_display_matches::<{ f32::to_bits(0.5) }>(v);
+        }
+
+        #[test]
+        fn display_matches_inner_f32_for_valid_values_at_least_one(
+            v in valid_value_strategy(AtLeastOne::MIN),
+        ) {
+            check_display_matches::<{ f32::to_bits(1.0) }>(v);
+        }
+
+        #[test]
+        fn display_propagates_precision_zero_or_more(
+            v in valid_value_strategy(ZeroOrMore::MIN),
+            n in 0_usize..=10,
+        ) {
+            check_display_precision::<{ f32::to_bits(0.0) }>(v, n);
+        }
+
+        #[test]
+        fn display_propagates_precision_at_least_half(
+            v in valid_value_strategy(AtLeastHalf::MIN),
+            n in 0_usize..=10,
+        ) {
+            check_display_precision::<{ f32::to_bits(0.5) }>(v, n);
+        }
+
+        #[test]
+        fn display_propagates_precision_at_least_one(
+            v in valid_value_strategy(AtLeastOne::MIN),
+            n in 0_usize..=10,
+        ) {
+            check_display_precision::<{ f32::to_bits(1.0) }>(v, n);
+        }
     }
 
-    #[test]
-    fn display_propagates_format_specifiers() {
-        let p = AtLeastHalf::try_new(0.5).expect("0.5 is the lower bound");
-        assert_eq!(format!("{p:.3}"), format!("{:.3}", 0.5_f32));
+    // ===== Property tests: serde round-trips =====
+
+    proptest! {
+        #[test]
+        fn serde_json_round_trips_for_valid_values_zero_or_more(
+            v in valid_value_strategy(ZeroOrMore::MIN),
+        ) {
+            check_serde_json_round_trip::<{ f32::to_bits(0.0) }>(v);
+        }
+
+        #[test]
+        fn serde_json_round_trips_for_valid_values_at_least_half(
+            v in valid_value_strategy(AtLeastHalf::MIN),
+        ) {
+            check_serde_json_round_trip::<{ f32::to_bits(0.5) }>(v);
+        }
+
+        #[test]
+        fn serde_json_round_trips_for_valid_values_at_least_one(
+            v in valid_value_strategy(AtLeastOne::MIN),
+        ) {
+            check_serde_json_round_trip::<{ f32::to_bits(1.0) }>(v);
+        }
+
+        #[test]
+        fn serde_yaml_round_trips_for_valid_values_zero_or_more(
+            v in valid_value_strategy(ZeroOrMore::MIN),
+        ) {
+            check_serde_yaml_round_trip::<{ f32::to_bits(0.0) }>(v);
+        }
+
+        #[test]
+        fn serde_yaml_round_trips_for_valid_values_at_least_half(
+            v in valid_value_strategy(AtLeastHalf::MIN),
+        ) {
+            check_serde_yaml_round_trip::<{ f32::to_bits(0.5) }>(v);
+        }
+
+        #[test]
+        fn serde_yaml_round_trips_for_valid_values_at_least_one(
+            v in valid_value_strategy(AtLeastOne::MIN),
+        ) {
+            check_serde_yaml_round_trip::<{ f32::to_bits(1.0) }>(v);
+        }
+    }
+
+    // ===== Property tests: serde rejections =====
+
+    proptest! {
+        #[test]
+        fn serde_json_deserialize_rejects_below_min_zero_or_more(
+            v in below_min_strategy(ZeroOrMore::MIN),
+        ) {
+            check_serde_json_rejects_below_min::<{ f32::to_bits(0.0) }>(v);
+        }
+
+        #[test]
+        fn serde_json_deserialize_rejects_below_min_at_least_half(
+            v in below_min_strategy(AtLeastHalf::MIN),
+        ) {
+            check_serde_json_rejects_below_min::<{ f32::to_bits(0.5) }>(v);
+        }
+
+        #[test]
+        fn serde_json_deserialize_rejects_below_min_at_least_one(
+            v in below_min_strategy(AtLeastOne::MIN),
+        ) {
+            check_serde_json_rejects_below_min::<{ f32::to_bits(1.0) }>(v);
+        }
+
+        #[test]
+        fn serde_yaml_deserialize_rejects_below_min_zero_or_more(
+            v in below_min_strategy(ZeroOrMore::MIN),
+        ) {
+            check_serde_yaml_rejects_below_min::<{ f32::to_bits(0.0) }>(v);
+        }
+
+        #[test]
+        fn serde_yaml_deserialize_rejects_below_min_at_least_half(
+            v in below_min_strategy(AtLeastHalf::MIN),
+        ) {
+            check_serde_yaml_rejects_below_min::<{ f32::to_bits(0.5) }>(v);
+        }
+
+        #[test]
+        fn serde_yaml_deserialize_rejects_below_min_at_least_one(
+            v in below_min_strategy(AtLeastOne::MIN),
+        ) {
+            check_serde_yaml_rejects_below_min::<{ f32::to_bits(1.0) }>(v);
+        }
+
+        #[test]
+        fn serde_json_deserialize_rejects_above_one(v in above_one_strategy()) {
+            let json = serde_json::to_string(&v).expect("serialize");
+            let err = serde_json::from_str::<ZeroOrMore>(&json).expect_err("v > 1.0");
+            prop_assert!(
+                err.to_string().contains("exceeds 1.0"),
+                "unexpected error: {}", err
+            );
+        }
+
+        #[test]
+        fn serde_yaml_deserialize_rejects_above_one(v in above_one_strategy()) {
+            let yaml = serde_yaml::to_string(&v).expect("serialize");
+            let err = serde_yaml::from_str::<ZeroOrMore>(&yaml).expect_err("v > 1.0");
+            prop_assert!(
+                err.to_string().contains("exceeds 1.0"),
+                "unexpected error: {}", err
+            );
+        }
     }
 }

--- a/lading_payload/src/common/config.rs
+++ b/lading_payload/src/common/config.rs
@@ -150,6 +150,12 @@ impl<const MIN_BITS: u32> From<Probability<MIN_BITS>> for f32 {
     }
 }
 
+impl<const MIN_BITS: u32> fmt::Display for Probability<MIN_BITS> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Display::fmt(&self.value, f)
+    }
+}
+
 impl<const MIN_BITS: u32> Probability<MIN_BITS> {
     /// The lower bound decoded from `MIN_BITS`.
     ///
@@ -342,5 +348,17 @@ mod probability_tests {
         let yaml = serde_yaml::to_string(&p).expect("serialize");
         let back: ZeroOrMore = serde_yaml::from_str(&yaml).expect("deserialize");
         assert_eq!(back.get().to_bits(), 0.25_f32.to_bits());
+    }
+
+    #[test]
+    fn display_matches_inner_f32() {
+        let p = AtLeastHalf::try_new(0.75).expect("0.75 in [0.5, 1.0]");
+        assert_eq!(format!("{p}"), format!("{}", 0.75_f32));
+    }
+
+    #[test]
+    fn display_propagates_format_specifiers() {
+        let p = AtLeastHalf::try_new(0.5).expect("0.5 is the lower bound");
+        assert_eq!(format!("{p:.3}"), format!("{:.3}", 0.5_f32));
     }
 }

--- a/lading_payload/src/common/config.rs
+++ b/lading_payload/src/common/config.rs
@@ -130,9 +130,24 @@ pub enum ProbabilityError {
 /// let p = AtLeastHalf::try_new(0.75).expect("0.75 is in [0.5, 1.0]");
 /// assert!((p.get() - 0.75).abs() < f32::EPSILON);
 /// ```
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, serde::Serialize, serde::Deserialize)]
+#[serde(into = "f32", try_from = "f32")]
 pub struct Probability<const MIN_BITS: u32> {
     value: f32,
+}
+
+impl<const MIN_BITS: u32> TryFrom<f32> for Probability<MIN_BITS> {
+    type Error = ProbabilityError;
+
+    fn try_from(value: f32) -> Result<Self, Self::Error> {
+        Self::try_new(value)
+    }
+}
+
+impl<const MIN_BITS: u32> From<Probability<MIN_BITS>> for f32 {
+    fn from(p: Probability<MIN_BITS>) -> Self {
+        p.value
+    }
 }
 
 impl<const MIN_BITS: u32> Probability<MIN_BITS> {
@@ -285,5 +300,47 @@ mod probability_tests {
         // -0.1 is finite and not -0.0, so it fails the lower-bound check.
         let err = ZeroOrMore::try_new(-0.1).expect_err("-0.1 < 0.0");
         assert!(matches!(err, ProbabilityError::BelowMin { .. }));
+    }
+
+    #[test]
+    fn serde_round_trip_json() {
+        let p = AtLeastHalf::try_new(0.75).expect("0.75 in [0.5, 1.0]");
+        let json = serde_json::to_string(&p).expect("serialize");
+        assert_eq!(json, "0.75");
+        let back: AtLeastHalf = serde_json::from_str(&json).expect("deserialize");
+        assert_eq!(back.get().to_bits(), 0.75_f32.to_bits());
+    }
+
+    #[test]
+    fn serde_deserialize_accepts_valid() {
+        let p: AtLeastHalf = serde_json::from_str("0.5").expect("0.5 is the lower bound");
+        assert_eq!(p.get().to_bits(), 0.5_f32.to_bits());
+    }
+
+    #[test]
+    fn serde_deserialize_rejects_below_min() {
+        let err = serde_json::from_str::<AtLeastHalf>("0.1").expect_err("0.1 < 0.5");
+        // The serde error wraps our ProbabilityError's Display output.
+        assert!(
+            err.to_string().contains("below lower bound"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn serde_deserialize_rejects_above_one() {
+        let err = serde_json::from_str::<ZeroOrMore>("1.5").expect_err("1.5 > 1.0");
+        assert!(
+            err.to_string().contains("exceeds 1.0"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn serde_yaml_round_trip() {
+        let p = ZeroOrMore::try_new(0.25).expect("0.25 in [0.0, 1.0]");
+        let yaml = serde_yaml::to_string(&p).expect("serialize");
+        let back: ZeroOrMore = serde_yaml::from_str(&yaml).expect("deserialize");
+        assert_eq!(back.get().to_bits(), 0.25_f32.to_bits());
     }
 }


### PR DESCRIPTION
### What does this PR do?

Adds a new `Probability<const u32: MIN_AS_BITS>` type as a proof-of-concept for configuration fields that accept `f32` values interpreted as probabilities. The type isn't used yet. The `MIN_AS_BITS` field is intended for use as a lower bound in cases where the minimum probability for a configuration field should be positive, e.g., unique tag probability of at least 0.1.

### Motivation

Reduce some boilerplate validation code related to probability-valued configuration fields for payloads.

### Related issues

n/a

### Additional Notes

Tests and ergonomics are still a work in progress. The plan files will be removed prior to merging the PR. These files are present in case reviewers find them helpful, but I don't intend them to clutter the repo.