### PR TITLE
feat(payload): adopt Probability for ValueConf::float_probability

### DIFF
--- a/lading_payload/src/dogstatsd.rs
+++ b/lading_payload/src/dogstatsd.rs
@@ -113,15 +113,15 @@ impl Default for MetricWeights {
 #[serde(deny_unknown_fields)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct ValueConf {
-    /// Odds out of 256 that the value will be a float and not an integer.
-    float_probability: f32,
+    /// Probability that the value will be a float and not an integer.
+    float_probability: Probability,
     range: ConfRange<i64>,
 }
 
 impl ValueConf {
     /// Create a new instance of `ValueConf` according to the args
     #[must_use]
-    pub fn new(float_probability: f32, range: ConfRange<i64>) -> Self {
+    pub fn new(float_probability: Probability, range: ConfRange<i64>) -> Self {
         Self {
             float_probability,
             range,
@@ -136,7 +136,7 @@ impl ValueConf {
 impl Default for ValueConf {
     fn default() -> Self {
         Self {
-            float_probability: 0.5, // 50%
+            float_probability: Probability::try_new(0.5).expect("0.5 is in [0.0, 1.0]"),
             range: ConfRange::Inclusive {
                 min: i64::MIN,
                 max: i64::MAX,

--- a/lading_payload/src/dogstatsd/common.rs
+++ b/lading_payload/src/dogstatsd/common.rs
@@ -6,7 +6,7 @@ use rand::{
     prelude::Distribution,
 };
 
-use crate::{Error, Generator};
+use crate::{Error, Generator, common::config::Probability};
 
 use super::{ConfRange, ValueConf};
 
@@ -21,12 +21,12 @@ pub enum NumValue {
 #[derive(Clone, Debug)]
 pub(crate) enum NumValueGenerator {
     Constant {
-        float_probability: f32,
+        float_probability: Probability,
         int: i64,
         float: f64,
     },
     Uniform {
-        float_probability: f32,
+        float_probability: Probability,
         int_distr: Uniform<i64>,
         float_distr: Uniform<f64>,
     },
@@ -67,7 +67,7 @@ impl<'a> Generator<'a> for NumValueGenerator {
                 int,
                 float,
             } => {
-                if prob < *float_probability {
+                if prob < float_probability.get() {
                     Ok(NumValue::Float(*float))
                 } else {
                     Ok(NumValue::Int(*int))
@@ -78,7 +78,7 @@ impl<'a> Generator<'a> for NumValueGenerator {
                 int_distr,
                 float_distr,
             } => {
-                if prob < *float_probability {
+                if prob < float_probability.get() {
                     Ok(NumValue::Float(float_distr.sample(rng)))
                 } else {
                     Ok(NumValue::Int(int_distr.sample(rng)))


### PR DESCRIPTION
### What does this PR do?

Switches `ValueConf::float_probability` from bare `f32` to `Probability`
(`BoundedProbability<{ f32::to_bits(0.0) }>` from #1876). The `try_from`
impl enforces finite + `[0.0, 1.0]` at deserialize time, and the public
constructor `ValueConf::new` now takes the validated type directly.
(`ValueConf::valid()` already had no finite/range check on this field, so
nothing is removed there.) The new type threads through
`NumValueGenerator`'s `Constant` and `Uniform` variants; at the two
comparison sites in `<NumValueGenerator as Generator>::generate`, `.get()`
extracts the inner `f32` so RNG draws and bit-exact output are preserved.

### Motivation

Phase 1, PR 2 of the stacked rollout planned in #1876 — wire
`BoundedProbability` aliases into `lading_payload` configs one field at a
time, smallest blast radius first. After `TimestampConfig::probability`
(#1877), `ValueConf::float_probability` is the next smallest: it touches
only `dogstatsd.rs` and `dogstatsd/common.rs`, and `ValueConf` is
constructed via `Default` or `ValueConf::new` (no test fixtures build it
with a struct literal), so the change stays localized.

Moving the validation into the type means an invalid `float_probability`
is rejected at parse time with a structured error instead of silently
accepted (the existing `valid()` never checked it); the in-code field can
no longer hold a value outside `[0.0, 1.0]`.

### Related issues

Stacked on #1877 (PR 1: `TimestampConfig::probability`), which itself sits
atop #1876 (Phase 0). Remaining fields in this rollout: `Config::sampling_probability`,
`Config::multivalue_pack_probability`, `Config::unique_tag_ratio` (via
`AtLeastOneHundredth`).

### Additional Notes

- **Wire format unchanged.** `Probability` serializes as a bare `f32` via
  `serde(into = "f32", try_from = "f32")`, so YAML/JSON configs written
  for the previous field type continue to parse.
- **Public API breakage at `ValueConf::new`.** The constructor signature
  changes from `new(float_probability: f32, ...)` to
  `new(float_probability: Probability, ...)`. The field is private, so
  external callers that build `ValueConf` go through `new`, `Default`, or
  deserialization. There are no in-tree callers of `ValueConf::new`.
- **No sampler swap.** The hot-path comparison stays
  `OpenClosed01.sample(rng) < float_probability.get()`; `.get()` is a
  `const fn` returning a copied scalar and inlines away.
- **Default value preserved.** `Default for ValueConf` now constructs
  `Probability::try_new(0.5).expect("0.5 is in [0.0, 1.0]")` in place of
  the bare `0.5`.
- **Bench delta.** `cargo bench -p lading-payload --bench dogstatsd
  --baseline pr1` (baseline saved from #1877's tip):
  - `dogstatsd_setup`: −0.29% (within 95% CI of zero)
  - `dogstatsd_throughput/1 MiB`: −5.6%
  - `dogstatsd_throughput/10 MiB`: −2.5%
  - `dogstatsd_throughput/100 MiB`: −4.8%
  - `dogstatsd_throughput/1 GiB`: −5.0%

  All deltas are favorable or neutral. The `--bench block` run against the
  same `pr1` baseline shows ±1-5% swings on `cache_*` benches that don't
  touch any code in this PR, which sets the noise floor — the
  `dogstatsd_throughput` "improvements" fall in the same band and are
  consistent with run-to-run variance rather than a real speedup.