### PR TITLE
feat(payload): adopt Probability for Config::sampling_probability

### DIFF
--- a/lading_payload/src/dogstatsd.rs
+++ b/lading_payload/src/dogstatsd.rs
@@ -170,9 +170,9 @@ pub struct Config {
     pub multivalue_count: ConfRange<u16>,
     /// Range of possible values for the sampling rate sent in dogstatsd messages
     pub sampling_range: ConfRange<f32>,
-    /// Probability between 0 and 1 that a given dogstatsd msg will specify a sampling rate.
+    /// Probability that a given dogstatsd msg will specify a sampling rate.
     /// The sampling rate is chosen from `sampling_range`
-    pub sampling_probability: f32,
+    pub sampling_probability: Probability,
     /// Defines the relative probability of each kind of `DogStatsD` kinds of
     /// payload.
     pub kind_weights: KindWeights,
@@ -273,7 +273,7 @@ impl Default for Config {
             multivalue_count: ConfRange::Inclusive { min: 2, max: 32 },
             multivalue_pack_probability: 0.08,
             sampling_range: ConfRange::Inclusive { min: 0.1, max: 1.0 },
-            sampling_probability: 0.5,
+            sampling_probability: Probability::try_new(0.5).expect("0.5 is in [0.0, 1.0]"),
             kind_weights: KindWeights::default(),
             metric_weights: MetricWeights::default(),
             value: ValueConf::default(),
@@ -371,16 +371,6 @@ impl Config {
             }
         }
 
-        if !self.sampling_probability.is_finite()
-            || self.sampling_probability < 0.0
-            || self.sampling_probability > 1.0
-        {
-            return Result::Err(format!(
-                "Sampling probability {} must be finite and in range [0.0, 1.0]",
-                self.sampling_probability
-            ));
-        }
-
         self.timestamp.valid()?;
 
         if self.kind_weights.metric == 0
@@ -432,7 +422,7 @@ impl MemberGenerator {
         multivalue_count: ConfRange<u16>,
         multivalue_pack_probability: f32,
         sampling: ConfRange<f32>,
-        sampling_probability: f32,
+        sampling_probability: Probability,
         kind_weights: KindWeights,
         metric_weights: MetricWeights,
         value_conf: ValueConf,

--- a/lading_payload/src/dogstatsd/metric.rs
+++ b/lading_payload/src/dogstatsd/metric.rs
@@ -35,7 +35,7 @@ pub(crate) struct MetricGenerator {
     pub(crate) multivalue_count: ConfRange<u16>,
     pub(crate) multivalue_pack_probability: f32,
     pub(crate) sampling: ConfRange<f32>,
-    pub(crate) sampling_probability: f32,
+    pub(crate) sampling_probability: Probability,
     pub(crate) num_value_generator: NumValueGenerator,
     pub(crate) pools: StringPools,
     /// Tags for each template. Each position in this Vec corresponds to the
@@ -52,7 +52,7 @@ impl MetricGenerator {
         multivalue_count: ConfRange<u16>,
         multivalue_pack_probability: f32,
         sampling: ConfRange<f32>,
-        sampling_probability: f32,
+        sampling_probability: Probability,
         metric_weights: &WeightedIndex<u16>,
         container_ids: Vec<String>,
         external_data: Vec<String>,
@@ -148,7 +148,7 @@ impl<'a> Generator<'a> for MetricGenerator {
         let cardinality = choose_or_not_ref(&mut rng, &self.cardinality).map(String::as_str);
         // https://docs.datadoghq.com/metrics/custom_metrics/dogstatsd_metrics_submission/#sample-rates
         let prob: f32 = OpenClosed01.sample(&mut rng);
-        let sample_rate = if prob < self.sampling_probability {
+        let sample_rate = if prob < self.sampling_probability.get() {
             let sample_rate = self.sampling.sample(&mut rng).clamp(0.0, 1.0);
             let sample_rate = common::ZeroToOne::try_from(sample_rate)
                 .expect("failed to convert sample rate to ZeroToOne");


### PR DESCRIPTION
### What does this PR do?

Switches `Config::sampling_probability` (in `lading_payload::dogstatsd`) from
bare `f32` to `Probability` (`BoundedProbability<{ f32::to_bits(0.0) }>` from
#1876). The `try_from` impl enforces finite + `[0.0, 1.0]` at deserialize
time, so the matching range/`is_finite()` check in `Config::valid()` is
removed. The new type threads through `MemberGenerator::new` and
`MetricGenerator::new`; at the comparison site in
`<MetricGenerator as Generator>::generate`, `.get()` extracts the inner
`f32` so RNG draws and bit-exact output are preserved.

### Motivation

Phase 1, PR 3 of the stacked rollout planned in #1876 — wire
`BoundedProbability` aliases into `lading_payload` configs one field at a
time, smallest blast radius first. After `TimestampConfig::probability`
(#1877) and `ValueConf::float_probability` (#1878),
`Config::sampling_probability` is next: it threads through the
`MemberGenerator::new` -> `MetricGenerator::new` constructor chain in
`dogstatsd.rs` / `dogstatsd/metric.rs`, with one hot-path comparison site.

Moving the validation into the type means an invalid
`sampling_probability` is rejected at parse time with a structured error
instead of inside `Config::valid()`; the in-code field can no longer hold
a value outside `[0.0, 1.0]`.

### Related issues

Stacked on #1878 (PR 2: `ValueConf::float_probability`), which sits atop
#1877 (PR 1) and #1876 (Phase 0). Remaining fields in this rollout:
`Config::multivalue_pack_probability` (PR 4, `Probability`) and
`Config::unique_tag_ratio` (PR 5, `AtLeastOneHundredth`).

### Additional Notes

- **Wire format unchanged.** `Probability` serializes as a bare `f32` via
  `serde(into = "f32", try_from = "f32")`, so YAML/JSON configs written
  for the previous field type continue to parse.
- **Public API breakage at the `Config` struct literal.** The
  `sampling_probability` field is `pub`; external callers that construct
  `Config` literally (rather than via `Default`) must now wrap the value
  in `Probability::try_new(...)`. The in-tree default and all test
  fixtures use `..Default::default()` for this field, so no in-tree
  fixtures need updating.
- **No sampler swap.** The hot-path comparison stays
  `OpenClosed01.sample(rng) < sampling_probability.get()`; `.get()` is a
  `const fn` returning a copied scalar and inlines away.
- **Default value preserved.** `Default for Config` now constructs
  `Probability::try_new(0.5).expect("0.5 is in [0.0, 1.0]")` in place of
  the bare `0.5`.
- **Verified.** `cargo build --workspace`, `cargo clippy -p lading-payload
  --all-targets -- -D warnings`, and `cargo test -p lading-payload --lib`
  (250 pass) all clean.
- **Bench delta.** `cargo bench -p lading-payload --bench dogstatsd
  --baseline pr2` (baseline saved from #1878's tip):
  - `dogstatsd_setup`: −0.19% (p = 0.59, no change)
  - `dogstatsd_throughput/1 MiB`: −18% point estimate, but CI is
    [−36%, −3.3%] (p = 0.13, no change — noisy bench at this size)
  - `dogstatsd_throughput/10 MiB`: −1.7% (p < 0.05, criterion classifies
    as "Change within noise threshold")
  - `dogstatsd_throughput/100 MiB`: −0.53% (p = 0.39, no change)
  - `dogstatsd_throughput/1 GiB`: −0.27% (p = 0.66, no change)

  The corresponding `--bench block` run against `pr2` shows scattered
  ±2-3% \"regressions\" on `cache_setup` and `cache_advance` plus a −9.0%
  \"improvement\" on `cache_read_at/1048576`, on code that this PR does
  not touch. That sets a wide machine noise floor and confirms the
  `dogstatsd_throughput` deltas are run-to-run variance, not a real
  effect — consistent with the expectation in the rollout plan (\".get()
  inlines away\").