### PR TITLE
feat(payload): adopt Probability for Config::multivalue_pack_probability

### DIFF
--- a/lading_payload/src/dogstatsd.rs
+++ b/lading_payload/src/dogstatsd.rs
@@ -162,9 +162,8 @@ pub struct Config {
     /// Number of tags per individual dogstatsd msg a tag is a key-value pair
     /// separated by a :
     pub tags_per_msg: ConfRange<u8>,
-    /// Probability between 0 and 1 that a given dogstatsd msg
-    /// contains multiple values
-    pub multivalue_pack_probability: f32,
+    /// Probability that a given dogstatsd msg contains multiple values
+    pub multivalue_pack_probability: Probability,
     /// The count of values that will be generated if multi-value is chosen to
     /// be generated
     pub multivalue_count: ConfRange<u16>,
@@ -271,7 +270,7 @@ impl Default for Config {
             tag_length: ConfRange::Inclusive { min: 3, max: 100 },
             tags_per_msg: ConfRange::Inclusive { min: 2, max: 50 },
             multivalue_count: ConfRange::Inclusive { min: 2, max: 32 },
-            multivalue_pack_probability: 0.08,
+            multivalue_pack_probability: Probability::try_new(0.08).expect("0.08 is in [0.0, 1.0]"),
             sampling_range: ConfRange::Inclusive { min: 0.1, max: 1.0 },
             sampling_probability: Probability::try_new(0.5).expect("0.5 is in [0.0, 1.0]"),
             kind_weights: KindWeights::default(),
@@ -420,7 +419,7 @@ impl MemberGenerator {
         tag_length: ConfRange<u16>,
         tags_per_msg: ConfRange<u8>,
         multivalue_count: ConfRange<u16>,
-        multivalue_pack_probability: f32,
+        multivalue_pack_probability: Probability,
         sampling: ConfRange<f32>,
         sampling_probability: Probability,
         kind_weights: KindWeights,

--- a/lading_payload/src/dogstatsd/metric.rs
+++ b/lading_payload/src/dogstatsd/metric.rs
@@ -33,7 +33,7 @@ pub(crate) struct MetricGenerator {
     pub(crate) timestamp_probability: Probability,
     pub(crate) templates: Vec<template::Template>,
     pub(crate) multivalue_count: ConfRange<u16>,
-    pub(crate) multivalue_pack_probability: f32,
+    pub(crate) multivalue_pack_probability: Probability,
     pub(crate) sampling: ConfRange<f32>,
     pub(crate) sampling_probability: Probability,
     pub(crate) num_value_generator: NumValueGenerator,
@@ -50,7 +50,7 @@ impl MetricGenerator {
         num_contexts: usize,
         name_length: ConfRange<u16>,
         multivalue_count: ConfRange<u16>,
-        multivalue_pack_probability: f32,
+        multivalue_pack_probability: Probability,
         sampling: ConfRange<f32>,
         sampling_probability: Probability,
         metric_weights: &WeightedIndex<u16>,
@@ -162,7 +162,7 @@ impl<'a> Generator<'a> for MetricGenerator {
         values.push(value);
 
         let prob: f32 = OpenClosed01.sample(&mut rng);
-        if prob < self.multivalue_pack_probability {
+        if prob < self.multivalue_pack_probability.get() {
             let num_desired_values = self.multivalue_count.sample(&mut rng) as usize;
             for _ in 1..num_desired_values {
                 values.push(self.num_value_generator.generate(&mut rng)?);


### PR DESCRIPTION
### What does this PR do?

Switches `Config::multivalue_pack_probability` (in
`lading_payload::dogstatsd`) from bare `f32` to `Probability`
(`BoundedProbability<{ f32::to_bits(0.0) }>` from #1876). The `try_from`
impl enforces finite + `[0.0, 1.0]` at deserialize time. `Config::valid()`
did not previously validate this field, so no check is removed — the new
type adds parse-time validation that did not exist before. The new type
threads through `MemberGenerator::new` and `MetricGenerator::new`; at the
hot-path comparison site in `<MetricGenerator as Generator>::generate`,
`.get()` extracts the inner `f32` so RNG draws and bit-exact output are
preserved.

### Motivation

Phase 1, PR 4 of the stacked rollout planned in #1876 — wire
`BoundedProbability` aliases into `lading_payload` configs one field at a
time, smallest blast radius first. After `TimestampConfig::probability`
(#1877), `ValueConf::float_probability` (#1878), and
`Config::sampling_probability` (#1879), `Config::multivalue_pack_probability`
is next: it threads through the same `MemberGenerator::new` ->
`MetricGenerator::new` constructor chain in `dogstatsd.rs` /
`dogstatsd/metric.rs`, with one hot-path comparison site.

Moving the validation into the type means an invalid
`multivalue_pack_probability` is rejected at parse time with a structured
error; the in-code field can no longer hold a value outside `[0.0, 1.0]`.
Previously this field had no validation at all in `Config::valid()`, so a
NaN or out-of-range value would have been accepted silently and reached
the `OpenClosed01.sample(rng) < p` comparison.

### Related issues

Stacked on #1879 (PR 3: `Config::sampling_probability`), which sits atop
#1878 (PR 2), #1877 (PR 1), and #1876 (Phase 0). One field remains in this
rollout: `Config::unique_tag_ratio` (PR 5, `AtLeastOneHundredth`).

### Additional Notes

- **Wire format unchanged.** `Probability` serializes as a bare `f32` via
  `serde(into = "f32", try_from = "f32")`, so YAML/JSON configs written
  for the previous field type continue to parse.
- **Public API breakage at the `Config` struct literal.** The
  `multivalue_pack_probability` field is `pub`; external callers that
  construct `Config` literally (rather than via `Default`) must now wrap
  the value in `Probability::try_new(...)`. The in-tree default and all
  test fixtures use `..Default::default()` for this field, so no in-tree
  fixtures need updating.
- **No sampler swap.** The hot-path comparison stays
  `OpenClosed01.sample(rng) < multivalue_pack_probability.get()`; `.get()`
  is a `const fn` returning a copied scalar and inlines away.
- **Default value preserved.** `Default for Config` now constructs
  `Probability::try_new(0.08).expect("0.08 is in [0.0, 1.0]")` in place
  of the bare `0.08`.
- **Verified.** `cargo check --workspace --all-targets`, `cargo clippy -p
  lading-payload --all-targets -- -D warnings`, `cargo fmt --all --
  --check`, and `cargo test -p lading-payload --lib --tests` (250 pass)
  all clean.
- **Bench delta.** Per the rollout plan, `cargo bench -p lading-payload
  --bench dogstatsd` (and `--bench block`) should be run against the
  #1879 tip; deltas are expected to be machine noise since `.get()`
  inlines away. Benches pending in a follow-up commit on this branch.