### PR TITLE
chore(clippy): drop expect_used quarantine for lading_throttle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+- Removed the transitional `#![allow(clippy::expect_used)]` quarantine from
+  `lading_throttle`. All `.expect()` sites in that crate are under
+  `#[cfg(test)]` or `#[cfg(kani)]`, so the workspace-level
+  `clippy::expect_used = "deny"` now applies without local overrides.
 - Added `clippy::expect_used = "deny"` to the workspace-level lint set,
   mirroring the existing `clippy::unwrap_used` policy, and set
   `allow-expect-in-tests = true` in `clippy.toml`. Production `.expect()`

--- a/lading_throttle/src/lib.rs
+++ b/lading_throttle/src/lib.rs
@@ -6,9 +6,6 @@
 #![deny(clippy::cargo)]
 #![allow(clippy::cast_precision_loss)]
 #![allow(clippy::multiple_crate_versions)]
-// Quarantine: workspace denies `clippy::expect_used`, but this crate still has
-// production `.expect()` sites awaiting cleanup. Remove once cleaned up.
-#![allow(clippy::expect_used)]
 
 use async_trait::async_trait;
 use serde::{Deserialize, Serialize};


### PR DESCRIPTION
### What does this PR do?

Removes the transitional `#![allow(clippy::expect_used)]` quarantine from `lading_throttle/src/lib.rs`. The crate is now fully governed by the workspace-level `clippy::expect_used = "deny"` introduced in the parent PR.

No code other than the lint-config line is touched.

### Motivation

All 28 `.expect()` sites in `lading_throttle` are already in code paths that the lint does not (and should not) reach:

| Location | Count | Why the lint doesn't apply |
| --- | --- | --- |
| `lading_throttle/src/lib.rs` — inside `#[cfg(test)] mod tests` | 20 | Exempted by `allow-expect-in-tests = true` in `clippy.toml`. |
| `lading_throttle/src/linear.rs` — inside `#[cfg(kani)] mod verification` | 4 | `cargo clippy` does not compile `cfg(kani)` blocks; the kani harness runs under `cargo kani`, which does not run clippy. |
| `lading_throttle/src/stable.rs` — inside `#[cfg(kani)] mod verification` | 4 | Same as above. |

That is, the quarantine was already redundant the moment the parent PR's `allow-expect-in-tests` exemption was in place. Removing it returns this crate to "fully enforced" with no behavior change — and proves the workspace gate is wired correctly.

This is the first per-crate cleanup in the stack started by [#1882](https://github.com/DataDog/lading/pull/1882) (parent). The remaining crates have real production `.expect()` sites that require code changes; this one was cost-free.

### Related issues

Stacked on top of #1882.

### Additional Notes

- `ci/validate` passes locally end-to-end, including kani proofs for `lading_throttle`.
- The gate's active enforcement was already verified in the parent PR. This PR is a no-op for code but flips one more crate from "quarantined" to "enforced" — exactly what the stacked-PR plan called for.