### PR TITLE
refactor(payload): mark fallible-context infallibles as unreachable!()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+- Replaced 5 additional infallible-by-construction `.expect()` sites in
+  `lading_payload` with `.unwrap_or_else(|_| unreachable!("..."))` /
+  `.unwrap_or_else(|| unreachable!("..."))`. Covered: 4 sites in
+  `string_list_pool::validate_range` (parse-and-chars-iter calls guarded by
+  flags set immediately above) and 1 site in
+  `templated_json::resolver::resolve_def` (take-from-`Option`-Vec inside a
+  three-color visit state machine). No runtime behavior change.
 - Replaced 26 infallible-by-construction `.expect()` sites in `lading_payload`
   with `.unwrap_or_else(|| unreachable!("..."))`, making the impossibility
   structural and explicit. Sites covered: 20 `CONST_ARR.choose(rng)` against

--- a/lading_payload/src/common/strings/string_list_pool.rs
+++ b/lading_payload/src/common/strings/string_list_pool.rs
@@ -174,12 +174,12 @@ impl StringListPool {
 
         // Validate that ranges are not backwards
         if start_is_num && end_is_num {
-            let start_num = start
-                .parse::<u32>()
-                .expect("start_is_num guarantees this parses");
-            let end_num = end
-                .parse::<u32>()
-                .expect("end_is_num guarantees this parses");
+            let start_num = start.parse::<u32>().unwrap_or_else(|_| {
+                unreachable!("start_is_num was set from start.parse::<u32>().is_ok()")
+            });
+            let end_num = end.parse::<u32>().unwrap_or_else(|_| {
+                unreachable!("end_is_num was set from end.parse::<u32>().is_ok()")
+            });
             if start_num > end_num {
                 return Err(Error::MalformedPattern {
                     pattern: format!("{{{{{start}-{end}}}}}"),
@@ -189,11 +189,11 @@ impl StringListPool {
             let start_char = start
                 .chars()
                 .next()
-                .expect("start_is_char guarantees non-empty");
+                .unwrap_or_else(|| unreachable!("start_is_char requires start.len() == 1"));
             let end_char = end
                 .chars()
                 .next()
-                .expect("end_is_char guarantees non-empty");
+                .unwrap_or_else(|| unreachable!("end_is_char requires end.len() == 1"));
             if start_char > end_char {
                 return Err(Error::MalformedPattern {
                     pattern: format!("{{{{{start}-{end}}}}}"),

--- a/lading_payload/src/templated_json/resolver.rs
+++ b/lading_payload/src/templated_json/resolver.rs
@@ -152,7 +152,7 @@ impl Resolver {
         self.grey[idx] = true;
         let vgen = self.raw_defs[idx]
             .take()
-            .expect("raw definition should exist");
+            .unwrap_or_else(|| unreachable!("raw_defs[idx] is Some when grey[idx] is first set"));
         let resolved = vgen.resolve(self)?;
         self.resolved_defs[idx] = Some(resolved);
         self.grey[idx] = false;


### PR DESCRIPTION
### What does this PR do?

Converts **5 `.expect()` sites** in `lading_payload` to `.unwrap_or_else(... unreachable!("..."))`. The sites all live inside `Result`-returning functions but are themselves guarded by local invariants — propagating with `?` would introduce dead error paths.

### Sites

| File:line | Site | Local invariant |
| --- | --- | --- |
| `common/strings/string_list_pool.rs:179` | `start.parse::<u32>().expect(...)` | `start_is_num` was set to `start.parse::<u32>().is_ok()` 27 lines above |
| `common/strings/string_list_pool.rs:182` | `end.parse::<u32>().expect(...)` | same, for `end` |
| `common/strings/string_list_pool.rs:192` | `start.chars().next().expect(...)` | `start_is_char = start.len() == 1 && !start_is_num` |
| `common/strings/string_list_pool.rs:196` | `end.chars().next().expect(...)` | same, for `end` |
| `templated_json/resolver.rs:155` | `self.raw_defs[idx].take().expect(...)` | three-color visit machine: reachable only when `!black[idx] && !grey[idx]`, which corresponds to `raw_defs[idx]` being `Some` |

### Why `unreachable!()` and not `?`

An earlier draft of this PR used `?`-propagation (the agent's initial recommendation, since the containing functions return `Result`). On review the choice changes: these aren't real error paths — the parses cannot fail because `start_is_num` was set from a successful `parse::<u32>().is_ok()`, and `chars().next()` cannot return `None` on a string the local code has just established has `len() == 1`. `unreachable!()` documents that fact; `?` would leave a dead `Err(Error::MalformedPattern{...})` branch behind that's never produced.

These sites fit the same shape as the previous `unwrap_or_else(|| unreachable!())` refactor (#1884), but were initially split out because they live in `Result`-returning functions. They're being landed in their own PR for review clarity, not because they need a different treatment.

### Motivation

Third per-crate cleanup-PR in the stack started by #1882. Future PRs in this sub-stack:
- **Group B** (next): 6 sites in `block.rs`, `random_string_pool.rs`, `string_list_pool.rs` where the invariant is established in the same function (same pattern as this PR; separated by the "originally in a `Result` fn" distinction).
- **Group C**: ~16 sites where the `.expect()` *is* the contract (handle-table lookups, documented API panics) — annotated with `#[expect(clippy::expect_used, reason = "...")]`.
- **Group D**: real bug fix in `block.rs:123` (the `arbitrary::Arbitrary` impl for `Block` can panic on `u32::arbitrary` returning 0).
- **Final**: drop the `lading_payload` quarantine.

### Related issues

Stacked on #1884.

### Additional Notes

- `cargo build --all-targets --all-features` ✓
- `cargo clippy --all-targets --all-features` ✓
- `cargo test -p lading-payload --lib` ✓ (244 passed)
- No public-API change. Diff: 3 files, +12 −5.