### PR TITLE
Remove private_hugetlb metric emission

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `dogstatsd` generator now supports DogStatsD protocol v1.3 `|T` timestamps
   for count and gauge metrics via `timestamp.range` and `timestamp.probability`.
 
+## Removed
+- Removed no longer used `smaps.private_hugetlb.by_pathname` procfs observer
+  metric.
+
 ## [0.32.0]
 ## Changed
 - Updated dependencies

--- a/lading/src/observer/linux/procfs.rs
+++ b/lading/src/observer/linux/procfs.rs
@@ -291,9 +291,6 @@ impl Sampler {
                         if let Some(m) = measures.shared_hugetlb {
                             gauge!("smaps.shared_hugetlb.by_pathname", &labels).set(m as f64);
                         }
-                        if let Some(m) = measures.private_hugetlb {
-                            gauge!("smaps.private_hugetlb.by_pathname", &labels).set(m as f64);
-                        }
                         if let Some(m) = measures.file_pmd_mapped {
                             gauge!("smaps.file_pmd_mapped.by_pathname", &labels).set(m as f64);
                         }


### PR DESCRIPTION
<!-- dd-meta {"pullId":"923bb43a-dec6-4a90-a859-2287337a368d","source":"chat","resourceId":"139d1d84-6db3-43de-b2a2-0622bbd8ab2e","workflowId":"d51433b9-7449-415a-be67-a67361f029cd","codeChangeId":"d51433b9-7449-415a-be67-a67361f029cd","sourceType":"action_platform_high_code"} -->
### What does this PR do?

Removes emission of the `smaps.private_hugetlb.by_pathname` metric from the Linux procfs observer so it is no longer reported.

### Motivation

The metric `single_machine_performance.regression_detector.capture.smaps.private_hugetlb.by_pathname` needs to be fully removed from the code path that emits procfs smaps metrics.

### Changes

- Removed the `gauge!("smaps.private_hugetlb.by_pathname", ...)` emission block in `lading/src/observer/linux/procfs.rs`.
- Kept parser and aggregation fields intact to avoid unrelated behavioral changes.
- Confirmed there are no remaining references to:
  - `smaps.private_hugetlb.by_pathname`
  - `single_machine_performance.regression_detector.capture.smaps.private_hugetlb.by_pathname`

### Testing/Validation

- Searched repository-wide for both target metric strings; no matches remain.
- Attempted `ci/validate`, but it failed in this environment because `shellcheck` is not installed.
- Attempted `ci/check`, but it failed due toolchain download/network restrictions in the sandbox.

### Related issues

None.

### Additional Notes

Validation command failures are environment/tooling related and not caused by this code change.

---

PR by Bits - [View session in Datadog](https://app.datadoghq.com/code/139d1d84-6db3-43de-b2a2-0622bbd8ab2e)

Comment @datadog to request changes