### PR TITLE
Remove smaps swap_pss pathname metric

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Removed
 - Removed no longer used `smaps.private_hugetlb.by_pathname` procfs observer
   metric.
+- Removed no longer used `smaps.swap_pss.by_pathname` procfs observer metric.
 
 ## [0.32.0]
 ## Changed

--- a/lading/src/observer/linux/procfs.rs
+++ b/lading/src/observer/linux/procfs.rs
@@ -297,9 +297,6 @@ impl Sampler {
                         if let Some(m) = measures.locked {
                             gauge!("smaps.locked.by_pathname", &labels).set(m as f64);
                         }
-                        if let Some(m) = measures.swap_pss {
-                            gauge!("smaps.swap_pss.by_pathname", &labels).set(m as f64);
-                        }
                     }
                 }
                 Err(err) => {


### PR DESCRIPTION
<!-- dd-meta {"pullId":"54bab356-54b8-4ffd-9b78-f65eb2ff0d05","source":"chat","resourceId":"493aa486-52d1-4325-8ff2-f55efdf2e576","workflowId":"77fec958-7da4-45bb-8891-6ac0753d78da","codeChangeId":"77fec958-7da4-45bb-8891-6ac0753d78da","sourceType":"action_platform_high_code"} -->
### What does this PR do?

Removes emission of the `smaps.swap_pss.by_pathname` procfs observer metric.

### Motivation

This metric needs to be removed so it is no longer reported under the `single_machine_performance.regression_detector.capture` namespace.

### Related issues

None.

### Additional Notes

### Changes

- Removed the `smaps.swap_pss.by_pathname` gauge emission in `lading/src/observer/linux/procfs.rs`.
- Verified there are no remaining repository references to:
  - `single_machine_performance.regression_detector.capture.smaps.swap_pss.by_pathname`
  - `smaps.swap_pss.by_pathname`

### Testing/Validation

- Searched the repository for remaining references using ripgrep-based search tooling (no matches).
- Attempted `ci/validate` (blocked because `shellcheck` is not installed in this environment).
- Attempted `ci/check` (blocked by sandbox network restrictions while rustup tried to download toolchain metadata).

---

PR by Bits - [View session in Datadog](https://app.datadoghq.com/code/493aa486-52d1-4325-8ff2-f55efdf2e576)

Comment @datadog to request changes