### PR TITLE
Remove smaps swap-by-pathname metric

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Removed no longer used `smaps.private_hugetlb.by_pathname` procfs observer
   metric.
 - Removed no longer used `smaps.swap_pss.by_pathname` procfs observer metric.
+- Removed no longer used `smaps.swap.by_pathname` procfs observer metric.
 
 ## [0.32.0]
 ## Changed

--- a/lading/src/observer/linux/procfs.rs
+++ b/lading/src/observer/linux/procfs.rs
@@ -258,7 +258,6 @@ impl Sampler {
                         ];
                         gauge!("smaps.rss.by_pathname", &labels).set(measures.rss as f64);
                         gauge!("smaps.pss.by_pathname", &labels).set(measures.pss as f64);
-                        gauge!("smaps.swap.by_pathname", &labels).set(measures.swap as f64);
                         gauge!("smaps.size.by_pathname", &labels).set(measures.size as f64);
 
                         if let Some(m) = measures.private_clean {


### PR DESCRIPTION
<!-- dd-meta {"pullId":"3737969d-b34a-4a4e-8f93-56aa8a0e4939","source":"chat","resourceId":"e6fe4ad3-3e2f-435d-ae08-a7075a54b0d0","workflowId":"e480fed4-f07a-4770-9030-09a4c3eb36ce","codeChangeId":"e480fed4-f07a-4770-9030-09a4c3eb36ce","sourceType":"action_platform_high_code"} -->
### What does this PR do?

Removes emission of the `smaps.swap.by_pathname` procfs observer metric so it is no longer reported.

### Motivation

The metric `single_machine_performance.regression_detector.capture.smaps.swap.by_pathname` needs to be fully removed from the codebase.

### Testing

- Searched the repository for `smaps.swap.by_pathname` and `single_machine_performance.regression_detector.capture.smaps.swap.by_pathname`; both now return no matches.
- Attempted to run `ci/validate`, but it fails in this environment because `shellcheck` is not installed.

### Related issues

None.

### Additional Notes

Change is intentionally minimal and limited to removing the single metric emission call in `lading/src/observer/linux/procfs.rs`.

---

PR by Bits - [View session in Datadog](https://app.datadoghq.com/code/e6fe4ad3-3e2f-435d-ae08-a7075a54b0d0)

Comment @datadog to request changes