### PR TITLE
Remove shared_hugetlb smaps metric

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   metric.
 - Removed no longer used `smaps.swap_pss.by_pathname` procfs observer metric.
 - Removed no longer used `smaps.swap.by_pathname` procfs observer metric.
+- Removed no longer used `smaps.shared_hugetlb.by_pathname` procfs observer
+  metric.
 
 ## [0.32.0]
 ## Changed

--- a/lading/src/observer/linux/procfs.rs
+++ b/lading/src/observer/linux/procfs.rs
@@ -287,9 +287,6 @@ impl Sampler {
                         if let Some(m) = measures.shmem_pmd_mapped {
                             gauge!("smaps.shmem_pmd_mapped.by_pathname", &labels).set(m as f64);
                         }
-                        if let Some(m) = measures.shared_hugetlb {
-                            gauge!("smaps.shared_hugetlb.by_pathname", &labels).set(m as f64);
-                        }
                         if let Some(m) = measures.file_pmd_mapped {
                             gauge!("smaps.file_pmd_mapped.by_pathname", &labels).set(m as f64);
                         }


### PR DESCRIPTION
<!-- dd-meta {"pullId":"d29a0ace-fda0-4ab0-ae47-47cbc0bdee96","source":"chat","resourceId":"4138a5e0-6c7f-49da-b3fc-d8d8030724fb","workflowId":"d8fb1d48-f03f-4e20-93af-ec3d0827ce5f","codeChangeId":"d8fb1d48-f03f-4e20-93af-ec3d0827ce5f","sourceType":"action_platform_high_code"} -->
### What does this PR do?

Removes emission of the `smaps.shared_hugetlb.by_pathname` procfs observer metric so it is no longer reported.

### Motivation

This metric is being retired and should no longer be emitted or referenced by the procfs observer.

### Testing

- Searched the repository for `single_machine_performance.regression_detector.capture.smaps.shared_hugetlb.by_pathname` and confirmed no matches remain.
- Searched the repository for `smaps.shared_hugetlb.by_pathname` and confirmed no matches remain.
- Attempted `ci/validate` (failed in this environment because `shellcheck` is not installed).
- Attempted `ci/check` (failed in this environment due rustup toolchain download/network restriction).

### Related issues

None.

### Additional Notes

Change is intentionally minimal and only removes the metric emission block from the Linux procfs observer.

---

PR by Bits - [View session in Datadog](https://app.datadoghq.com/code/4138a5e0-6c7f-49da-b3fc-d8d8030724fb)

Comment @datadog to request changes