### PR TITLE
refactor(payload): mark in-function invariants as unreachable!()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+- Replaced 6 in-function-invariant `.expect()` sites in `lading_payload`
+  with `.unwrap_or_else(|_| unreachable!("..."))` /
+  `.unwrap_or_else(|| unreachable!("..."))`. Covered: `usize → u32`
+  conversions in `block::construct_block`,
+  `random_string_pool::of_size_with_handle` (×2), and
+  `string_list_pool::range_value_at` (×2, plus one
+  `char::from_u32(...)` on values produced by char range expansion).
+  All sites are guarded by invariants established earlier in the same
+  function or at pool construction (`with_size` asserts pool length
+  fits in u32). No runtime behavior change.
 - Replaced 5 additional infallible-by-construction `.expect()` sites in
   `lading_payload` with `.unwrap_or_else(|_| unreachable!("..."))` /
   `.unwrap_or_else(|| unreachable!("..."))`. Covered: 4 sites in

--- a/lading_payload/src/block.rs
+++ b/lading_payload/src/block.rs
@@ -745,12 +745,9 @@ where
         // serializer.
         Err(SpinError::EmptyBlock)
     } else {
-        let total_bytes = NonZeroU32::new(
-            bytes
-                .len()
-                .try_into()
-                .expect("failed to get length of bytes"),
-        )
+        let total_bytes = NonZeroU32::new(bytes.len().try_into().unwrap_or_else(|_| {
+            unreachable!("bytes.len() fits in u32: blocks are sized by chunk_size: u32")
+        }))
         .ok_or(SpinError::Zero)?;
 
         let mut metadata = BlockMetadata::default();

--- a/lading_payload/src/common/strings/random_string_pool.rs
+++ b/lading_payload/src/common/strings/random_string_pool.rs
@@ -122,8 +122,10 @@ impl Pool for RandomStringPool {
             Handle::PosAndLength(
                 lower_idx
                     .try_into()
-                    .expect("must fit into u32 by construction"),
-                bytes.try_into().expect("must fit in u32 by construction"),
+                    .unwrap_or_else(|_| unreachable!("lower_idx < self.inner.len(), and self.inner.len() fits in u32 by the assert in with_size")),
+                bytes
+                    .try_into()
+                    .unwrap_or_else(|_| unreachable!("bytes < self.inner.len(), and self.inner.len() fits in u32 by the assert in with_size")),
             ),
         ))
     }

--- a/lading_payload/src/common/strings/string_list_pool.rs
+++ b/lading_payload/src/common/strings/string_list_pool.rs
@@ -250,13 +250,21 @@ fn range_len(range: &PatternRange) -> Result<usize, Error> {
 fn range_value_at(range: &PatternRange, idx: usize) -> String {
     match range {
         PatternRange::Char(start, _end) => char::from_u32(
-            *start as u32 + u32::try_from(idx).expect("pattern shouldn't be that big"),
+            *start as u32
+                + u32::try_from(idx).unwrap_or_else(|_| {
+                    unreachable!("idx is bounded by range length, which fits in u32")
+                }),
         )
-        .expect("idx is within range bounds")
+        .unwrap_or_else(|| {
+            unreachable!("char range expansion produces valid Unicode scalars by construction")
+        })
         .to_string(),
         PatternRange::Number(start, end) => {
             let numdigits = std::cmp::max(start.to_string().len(), end.to_string().len());
-            let n = start + u32::try_from(idx).expect("pattern shouldn't be that big");
+            let n = start
+                + u32::try_from(idx).unwrap_or_else(|_| {
+                    unreachable!("idx is bounded by range length, which fits in u32")
+                });
             format!("{n:0numdigits$}")
         }
     }


### PR DESCRIPTION
### What does this PR do?

Converts **6 `.expect()` sites** in `lading_payload` to `.unwrap_or_else(... unreachable!("..."))`. Each site is guarded by an invariant established earlier in the same function or at type/pool construction.

### Sites

| File:line | Site | Local invariant |
| --- | --- | --- |
| `block.rs:752` | `bytes.len().try_into()` → u32 in `construct_block` | `bytes` is sized by `chunk_size: u32`; `bytes.len() <= chunk_size` |
| `common/strings/random_string_pool.rs:125` | `lower_idx.try_into()` → u32 | `lower_idx < self.inner.len()`; pool length asserted ≤ u32::MAX at `with_size` line 35 |
| `common/strings/random_string_pool.rs:127` | `bytes.try_into()` → u32 | `bytes < self.inner.len()`; same assert |
| `common/strings/string_list_pool.rs:253` | `u32::try_from(idx)` in `range_value_at` | `idx` bounded by range length, which fits in u32 by parser construction |
| `common/strings/string_list_pool.rs:256` | `char::from_u32(*start as u32 + offset)` | `*start..=*end` is a parser-validated Unicode scalar range |
| `common/strings/string_list_pool.rs:260` | `u32::try_from(idx)` (`Number` variant) | same as line 253 |

### Why this PR is separate from #1885

Both PRs convert `.expect()` to `unwrap_or_else(... unreachable!())`. The split is by *where the invariant lives*: #1885 (Group A) handles five sites inside `Result`-returning functions where the agent initially recommended `?`-propagation; this PR (Group B) handles six sites where the surrounding function does not return `Result`, so the only options were `.expect()` or `unreachable!()`. The treatment ends up identical, but reviewing them in one batch made the inventory harder to follow.

### Motivation

Fourth per-crate cleanup PR in the stack started by #1882. Remaining sub-stack:
- **Group C** (next): ~16 `.expect()` sites where the message *is* the contract (handle-table lookups, documented API panics) — annotated with `#[expect(clippy::expect_used, reason = "...")]`.
- **Group D**: real bug fix at `block.rs:123` (the `arbitrary::Arbitrary` impl for `Block` can panic when `u32::arbitrary` returns 0).
- **Final**: drop the `lading_payload` quarantine.

### Related issues

Stacked on #1885.

### Additional Notes

- `cargo build --all-targets --all-features` ✓
- `cargo clippy --all-targets --all-features` ✓
- `cargo test -p lading-payload --lib` ✓ (244 passed)
- No public-API change. Diff: 4 files (3 src + CHANGELOG), +26 −6.