### PR TITLE
fix(payload): reject zero-byte arbitrary input for Block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+- Fixed a latent panic in `lading_payload::block::Block::arbitrary`
+  (`#[cfg(feature = "arbitrary")]`). `u32::arbitrary` can legitimately
+  produce 0, but `Block::total_bytes` is `NonZeroU32`; the previous code
+  called `NonZeroU32::new(total_bytes).expect("total_bytes must be
+  non-zero")` and panicked on the zero case. The fix returns
+  `arbitrary::Error::IncorrectFormat` so the fuzzer rejects the input
+  and moves on. A regression test (`arbitrary_rejects_zero_total_bytes`)
+  pins the new behavior.
 - Annotated 11 `lading_payload` functions that intentionally panic on
   invariant violations with `#[expect(clippy::expect_used, reason = "...")]`.
   Covered: `block::Cache::read_at` (documented `usize`/`u64` overflow

--- a/lading_payload/src/block.rs
+++ b/lading_payload/src/block.rs
@@ -117,10 +117,16 @@ pub enum ConstructBlockCacheError {
 #[cfg(feature = "arbitrary")]
 impl<'a> arbitrary::Arbitrary<'a> for Block {
     fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
-        let total_bytes = u32::arbitrary(u)?;
-        let bytes = u.bytes(total_bytes as usize).map(Bytes::copy_from_slice)?;
+        // `u32::arbitrary` can legitimately produce 0, but `Block::total_bytes`
+        // is `NonZeroU32`. Reject zero-byte inputs via `IncorrectFormat` so the
+        // fuzzer skips them and tries another input.
+        let total_bytes =
+            NonZeroU32::new(u32::arbitrary(u)?).ok_or(arbitrary::Error::IncorrectFormat)?;
+        let bytes = u
+            .bytes(total_bytes.get() as usize)
+            .map(Bytes::copy_from_slice)?;
         Ok(Self {
-            total_bytes: NonZeroU32::new(total_bytes).expect("total_bytes must be non-zero"),
+            total_bytes,
             bytes,
             metadata: BlockMetadata::default(),
         })
@@ -764,5 +770,25 @@ where
             bytes,
             metadata,
         })
+    }
+}
+
+#[cfg(all(test, feature = "arbitrary"))]
+mod arbitrary_tests {
+    use super::Block;
+    use arbitrary::{Arbitrary, Unstructured};
+
+    /// Regression: prior to the fix, `Block::arbitrary` could panic via
+    /// `NonZeroU32::new(0).expect(...)` whenever `u32::arbitrary` produced 0.
+    /// The fixed version must reject zero-byte inputs via
+    /// `arbitrary::Error::IncorrectFormat` so the fuzzer skips them.
+    #[test]
+    fn arbitrary_rejects_zero_total_bytes() {
+        let data = [0u8; 16];
+        let mut u = Unstructured::new(&data);
+        match Block::arbitrary(&mut u) {
+            Err(arbitrary::Error::IncorrectFormat) => {}
+            other => panic!("expected IncorrectFormat, got {other:?}"),
+        }
     }
 }


### PR DESCRIPTION
### What does this PR do?

Fixes a latent panic in `lading_payload::block::Block::arbitrary` (`#[cfg(feature = "arbitrary")]`). The previous implementation panicked when the fuzzer produced a zero for `u32::arbitrary`; the fix rejects that case via `arbitrary::Error::IncorrectFormat` so the fuzzer skips the input and tries another.

A regression test pins the new behavior.

### The bug

```rust
#[cfg(feature = "arbitrary")]
impl<'a> arbitrary::Arbitrary<'a> for Block {
    fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
        let total_bytes = u32::arbitrary(u)?;
        let bytes = u.bytes(total_bytes as usize).map(Bytes::copy_from_slice)?;
        Ok(Self {
            total_bytes: NonZeroU32::new(total_bytes).expect("total_bytes must be non-zero"),
            bytes,
            metadata: BlockMetadata::default(),
        })
    }
}
```

`u32::arbitrary` is permitted by contract to return any `u32`, including 0. When that happens, `NonZeroU32::new(0)` is `None`, and `.expect(...)` panics. Reachable from `lading_fuzz`, which enables the `arbitrary` feature.

### The fix

```rust
let total_bytes =
    NonZeroU32::new(u32::arbitrary(u)?).ok_or(arbitrary::Error::IncorrectFormat)?;
let bytes = u
    .bytes(total_bytes.get() as usize)
    .map(Bytes::copy_from_slice)?;
Ok(Self { total_bytes, bytes, metadata: BlockMetadata::default() })
```

Three changes:
1. `NonZeroU32::new(...).expect(...)` → `.ok_or(arbitrary::Error::IncorrectFormat)?`. This is the documented way to tell the `arbitrary` crate "skip this input, it's malformed."
2. The `bytes` allocation moves *below* the rejection check, so a rejected input no longer allocates first.
3. `total_bytes.get()` is used for the `u.bytes(...)` call, since `total_bytes` is now `NonZeroU32`.

### Regression test

`arbitrary_rejects_zero_total_bytes` lives in a new `#[cfg(all(test, feature = "arbitrary"))]` submodule of `block.rs`. It constructs `Unstructured::new(&[0u8; 16])` — guaranteeing `u32::arbitrary` reads four zero bytes — and asserts the result is `Err(arbitrary::Error::IncorrectFormat)`. The test was written against the old code first; there, it panicked exactly at the `.expect()`, confirming the bug.

### Motivation

Last targeted PR in the panic-cleanup phase of the stack started by #1882. After this lands, the only remaining work in `lading_payload` is the **Cat-2** sites (~33 `.expect()` sites that need function-signature changes to thread `Result` through) and the final quarantine drop. Those will be the next sub-stack.

### Related issues

Stacked on #1891.

### Additional Notes

- `cargo build --all-targets --all-features` ✓
- `cargo clippy --all-targets --all-features` ✓
- `cargo test -p lading-payload --features arbitrary --lib` ✓ (245 passed including the new regression test)
- Diff: 2 files, +37 −3.