### PR TITLE
refactor(lading): annotate intentional-panic file_gen sites

### DIFF
--- a/lading/src/generator/file_gen/logrotate.rs
+++ b/lading/src/generator/file_gen/logrotate.rs
@@ -343,6 +343,10 @@ impl Child {
         }
     }
 
+    #[expect(
+        clippy::expect_used,
+        reason = "self.names is constructed non-empty at LogrotateGenerator startup"
+    )]
     async fn spin(mut self) -> Result<(), Error> {
         let mut handle = self.block_cache.handle();
         let buffer_capacity = self

--- a/lading/src/generator/file_gen/logrotate_fs.rs
+++ b/lading/src/generator/file_gen/logrotate_fs.rs
@@ -170,6 +170,10 @@ impl Server {
     /// # Panics
     ///
     /// Function will panic if the filesystem cannot be started.
+    #[expect(
+        clippy::expect_used,
+        reason = "FIXME: fuse_mount2 spawn failure should propagate as an Error variant rather than panic; tracked for follow-up"
+    )]
     pub fn new(
         _: generator::General,
         config: Config,
@@ -340,6 +344,10 @@ impl Filesystem for LogrotateFS {
     }
 
     #[tracing::instrument(skip(self, reply))]
+    #[expect(
+        clippy::expect_used,
+        reason = "the inner state mutex is held only briefly within fuse callbacks; poisoning indicates a panic during a prior callback and is unrecoverable"
+    )]
     fn lookup(&mut self, _: &Request, parent: u64, name: &OsStr, reply: ReplyEntry) {
         let tick = self.get_current_tick();
         let mut state = self.state.lock().expect("lock poisoned");
@@ -362,6 +370,10 @@ impl Filesystem for LogrotateFS {
     }
 
     #[tracing::instrument(skip(self, reply))]
+    #[expect(
+        clippy::expect_used,
+        reason = "the inner state mutex is held only briefly within fuse callbacks; poisoning indicates a panic during a prior callback and is unrecoverable"
+    )]
     fn getattr(&mut self, _: &Request, ino: u64, _: Option<u64>, reply: ReplyAttr) {
         let tick = self.get_current_tick();
         let mut state = self.state.lock().expect("lock poisoned");
@@ -377,6 +389,10 @@ impl Filesystem for LogrotateFS {
     }
 
     #[tracing::instrument(skip(self, reply))]
+    #[expect(
+        clippy::expect_used,
+        reason = "the inner state mutex is held only briefly within fuse callbacks; poisoning indicates a panic during a prior callback and is unrecoverable"
+    )]
     fn read(
         &mut self,
         _: &Request,
@@ -416,6 +432,10 @@ impl Filesystem for LogrotateFS {
     }
 
     #[tracing::instrument(skip(self, reply))]
+    #[expect(
+        clippy::expect_used,
+        reason = "the inner state mutex is held only briefly within fuse callbacks; poisoning indicates a panic during a prior callback and is unrecoverable"
+    )]
     fn release(
         &mut self,
         _: &Request,
@@ -448,6 +468,10 @@ impl Filesystem for LogrotateFS {
     }
 
     #[tracing::instrument(skip(self, reply))]
+    #[expect(
+        clippy::expect_used,
+        reason = "the inner state mutex is held only briefly within fuse callbacks; mutex poisoning, parent-inode lookup, file-type lookup, and name lookup are all internal invariants maintained by the fs model"
+    )]
     fn readdir(&mut self, _: &Request, ino: u64, _: u64, offset: i64, mut reply: ReplyDirectory) {
         let tick = self.get_current_tick();
         let mut state = self.state.lock().expect("lock poisoned");
@@ -510,6 +534,10 @@ impl Filesystem for LogrotateFS {
     }
 
     #[tracing::instrument(skip(self, _req, reply))]
+    #[expect(
+        clippy::expect_used,
+        reason = "the inner state mutex is held only briefly within fuse callbacks; poisoning indicates a panic during a prior callback and is unrecoverable"
+    )]
     fn open(&mut self, _req: &Request, ino: u64, flags: i32, reply: fuser::ReplyOpen) {
         let tick = self.get_current_tick();
         let mut state = self.state.lock().expect("lock poisoned");

--- a/lading/src/generator/file_gen/logrotate_fs/model.rs
+++ b/lading/src/generator/file_gen/logrotate_fs/model.rs
@@ -653,6 +653,10 @@ impl State {
 
     #[inline]
     #[expect(clippy::too_many_lines)]
+    #[expect(
+        clippy::expect_used,
+        reason = "node/inode lookups operate on entries the model itself just inserted; invariants enforced inside `State`"
+    )]
     fn advance_time_inner(&mut self, now: Tick) {
         assert!(now >= self.now);
 
@@ -972,6 +976,10 @@ impl State {
     /// be advanced -- and a slice up to `size` bytes will be returned or `None`
     /// if no bytes are available to be read.
     #[tracing::instrument(skip(self))]
+    #[expect(
+        clippy::expect_used,
+        reason = "the bytes-written value is bounded by usize and cannot exceed a machine word here"
+    )]
     pub(crate) fn read(
         &mut self,
         file_handle: FileHandle,


### PR DESCRIPTION
## Summary

Annotate intentional-panic `.expect()` sites in `generator/file_gen/*` with fn-level `#[expect(clippy::expect_used, reason = "...")]`. These are FUSE/logrotate-fs entry points where panicking on an internal invariant violation is the appropriate failure mode for a load-generation harness.

Sites annotated:
- \`generator/file_gen/logrotate.rs\` — file rotation primitives
- \`generator/file_gen/logrotate_fs.rs::{lookup,getattr,read,release,readdir,open}\` — FUSE callback methods
- \`generator/file_gen/logrotate_fs/model.rs::advance_time_inner\`
- \`generator/file_gen/logrotate_fs/model.rs::read\`

Stacked on #1897. Part of the broader push toward enforcing `clippy::expect_used = "deny"` workspace-wide.

## Test plan
- [x] \`./ci/validate\` passes
- [ ] CI green on this PR