### PR TITLE
refactor(lading): annotate intentional-panic network generators

### DIFF
--- a/lading/src/generator/grpc.rs
+++ b/lading/src/generator/grpc.rs
@@ -192,6 +192,10 @@ impl Grpc {
     /// Function will panic if user has passed zero values for any byte
     /// values. Sharp corners.
     #[expect(clippy::cast_possible_truncation)]
+    #[expect(
+        clippy::expect_used,
+        reason = "FIXME: config.target_uri is user-supplied; parsing and the required path_and_query check should surface as Error variants instead of panicking. Tracked for follow-up."
+    )]
     pub fn new(
         general: General,
         config: Config,
@@ -241,6 +245,10 @@ impl Grpc {
     }
 
     /// Establish a connection with the configured RPC server
+    #[expect(
+        clippy::expect_used,
+        reason = "Uri::from_parts is reconstructing self.target_uri's parts after replacing path_and_query with an empty static; the parts already came from a valid Uri"
+    )]
     async fn connect(&self) -> Result<client::Grpc<transport::Channel>, Error> {
         let mut parts = self.target_uri.clone().into_parts();
         parts.path_and_query = Some(PathAndQuery::from_static(""));

--- a/lading/src/generator/http.rs
+++ b/lading/src/generator/http.rs
@@ -141,6 +141,10 @@ impl Http {
     /// Function will panic if user has passed non-zero values for any byte
     /// values. Sharp corners.
     #[expect(clippy::cast_possible_truncation)]
+    #[expect(
+        clippy::expect_used,
+        reason = "OnceCell::set is called exactly once at HTTP generator startup"
+    )]
     pub fn new(
         general: General,
         config: Config,
@@ -212,6 +216,10 @@ impl Http {
     ///
     /// Function will panic if it is unable to create HTTP requests for the
     /// target.
+    #[expect(
+        clippy::expect_used,
+        reason = "OnceCell::get on a value set during `new`, and Semaphore::acquire panics only after `Semaphore::close`; we never close the throttle semaphore"
+    )]
     pub async fn spin(mut self) -> Result<(), Error> {
         let client = Client::builder(TokioExecutor::new())
             .pool_max_idle_per_host(self.concurrency.connection_count() as usize)

--- a/lading/src/generator/kubernetes/resource.rs
+++ b/lading/src/generator/kubernetes/resource.rs
@@ -76,6 +76,10 @@ impl Resource {
         }
     }
 
+    #[expect(
+        clippy::expect_used,
+        reason = "callers must set the name via `set_name` before calling `get_name`; this is a documented internal API contract"
+    )]
     pub(super) fn get_name(&self) -> &str {
         self.meta()
             .name

--- a/lading/src/generator/procfs.rs
+++ b/lading/src/generator/procfs.rs
@@ -33,8 +33,10 @@ pub enum Error {
 
 fn default_copy_from_host() -> Vec<PathBuf> {
     vec![
-        PathBuf::from_str("/proc/uptime").expect("failed to convert /proc/uptime to PathBuf"),
-        PathBuf::from_str("/proc/stat").expect("failed to convert /proc/stat to PathBuf"),
+        PathBuf::from_str("/proc/uptime")
+            .unwrap_or_else(|_| unreachable!("\"/proc/uptime\" is a valid PathBuf")),
+        PathBuf::from_str("/proc/stat")
+            .unwrap_or_else(|_| unreachable!("\"/proc/stat\" is a valid PathBuf")),
     ]
 }
 
@@ -141,7 +143,8 @@ impl ProcFs {
         }
 
         // SAFETY: By construction this pathbuf cannot fail to be created.
-        let prefix = PathBuf::from_str("/proc").expect("failed to convert /proc to PathBuf");
+        let prefix = PathBuf::from_str("/proc")
+            .unwrap_or_else(|_| unreachable!("\"/proc\" is a valid PathBuf"));
 
         for path in &config.copy_from_host {
             let base = path.strip_prefix(&prefix)?;

--- a/lading/src/generator/splunk_hec.rs
+++ b/lading/src/generator/splunk_hec.rs
@@ -192,6 +192,10 @@ impl SplunkHec {
     /// Function will panic if user has passed non-zero values for any byte
     /// values. Sharp corners.
     #[expect(clippy::cast_possible_truncation)]
+    #[expect(
+        clippy::expect_used,
+        reason = "OnceCell::set is called exactly once at Splunk HEC generator startup"
+    )]
     pub fn new(
         general: General,
         config: Config,
@@ -267,6 +271,10 @@ impl SplunkHec {
     ///
     /// Function will panic if it is unable to create HTTP requests for the
     /// target.
+    #[expect(
+        clippy::expect_used,
+        reason = "channel iterator is constructed from a non-empty Vec; OnceCell::get and Semaphore::acquire follow the same contract as the HTTP generator"
+    )]
     pub async fn spin(mut self) -> Result<(), Error> {
         let client = Client::builder(TokioExecutor::new())
             .pool_max_idle_per_host(self.parallel_connections as usize)
@@ -339,6 +347,10 @@ impl SplunkHec {
 }
 
 #[expect(clippy::too_many_arguments)]
+#[expect(
+    clippy::expect_used,
+    reason = "FIXME: server response parsing on Splunk HEC ack-id should surface as an Error variant rather than panic on malformed remote responses. Tracked for follow-up."
+)]
 async fn send_hec_request<B>(
     permit: SemaphorePermit<'_>,
     block_length: usize,

--- a/lading/src/generator/splunk_hec/acknowledgements.rs
+++ b/lading/src/generator/splunk_hec/acknowledgements.rs
@@ -52,6 +52,10 @@ impl Channel {
         }
     }
 
+    #[expect(
+        clippy::expect_used,
+        reason = "callers route Some(ack_id) producers into Channel::Ack; the None branch is unreachable per the worker/ack-service contract"
+    )]
     pub(crate) async fn send<Fut>(&self, msg: Fut) -> Result<(), Error>
     where
         Fut: Future<Output = Option<AckId>>,

--- a/lading/src/generator/tcp.rs
+++ b/lading/src/generator/tcp.rs
@@ -131,6 +131,10 @@ impl Tcp {
     /// Function will panic if user has passed zero values for any byte
     /// values. Sharp corners.
     #[expect(clippy::cast_possible_truncation)]
+    #[expect(
+        clippy::expect_used,
+        reason = "FIXME: config.addr is user-supplied; socket address parsing failures should surface as Error variants instead of panicking. Tracked for follow-up."
+    )]
     pub fn new(
         general: General,
         config: &Config,
@@ -168,9 +172,9 @@ impl Tcp {
         for i in 0..worker_count {
             let throttle =
                 create_throttle(config.throttle.as_ref(), config.bytes_per_second.as_ref())?
-                    .divide(
-                        NonZeroU32::new(worker_count.into()).expect("worker_count is always >= 1"),
-                    )?;
+                    .divide(NonZeroU32::new(worker_count.into()).unwrap_or_else(|| {
+                        unreachable!("worker_count is NonZeroU16, always >= 1")
+                    }))?;
 
             let mut worker_labels = labels.clone();
             if worker_count > 1 {


### PR DESCRIPTION
## Summary

Annotate intentional-panic `.expect()` sites in the network protocol generators with fn-level `#[expect(clippy::expect_used, reason = "...")]`. Reasons distinguish documented-contract panics from user-input parsing failures (the latter carry `FIXME` markers tracking eventual conversion to `Error` variants).

Sites annotated:
- \`generator/tcp.rs::new\` (FIXME — user-supplied addr parsing)
- \`generator/grpc.rs\` — gRPC client construction
- \`generator/http.rs\` — HTTP client + header parsing
- \`generator/kubernetes/resource.rs\` — k8s api construction
- \`generator/procfs.rs\` — sysfs path setup
- \`generator/splunk_hec.rs\` — Splunk endpoint setup
- \`generator/splunk_hec/acknowledgements.rs::send\` — channel routing invariant

Stacked on #1898. Part of the broader push toward enforcing `clippy::expect_used = "deny"` workspace-wide.

## Test plan
- [x] \`./ci/validate\` passes
- [ ] CI green on this PR