### PR TITLE
refactor(lading): annotate intentional-panic observer/target sites

### DIFF
--- a/lading/src/bin/captool/analyze/jsonl.rs
+++ b/lading/src/bin/captool/analyze/jsonl.rs
@@ -38,6 +38,10 @@ pub(crate) fn list_metrics(lines: &[Line]) -> Vec<MetricInfo> {
 /// Returns statistics grouped by label set (context).
 #[must_use]
 #[expect(clippy::cast_precision_loss)]
+#[expect(
+    clippy::expect_used,
+    reason = "context_map and fetch_indices are populated together by the same loop; a missing fetch_indices entry indicates a programming error in the caller"
+)]
 pub(crate) fn analyze_metric(
     lines: &[Line],
     metric_name: &str,

--- a/lading/src/inspector.rs
+++ b/lading/src/inspector.rs
@@ -123,6 +123,10 @@ impl Server {
     /// # Panics
     ///
     /// None are known.
+    #[expect(
+        clippy::expect_used,
+        reason = "child.id() returning Some always fits in i32 on supported platforms; a failure here indicates a platform invariant violation"
+    )]
     pub async fn run(self, mut pid_snd: TargetPidReceiver) -> Result<ExitStatus, Error> {
         let target_pid = pid_snd.recv().await?;
         drop(pid_snd);

--- a/lading/src/neper/thread.rs
+++ b/lading/src/neper/thread.rs
@@ -45,6 +45,10 @@ pub(crate) fn join_all<T>(handles: Vec<JoinHandle<T>>) -> Result<Vec<T>, ()> {
 }
 
 /// Spawn a named OS thread running `f`.
+#[expect(
+    clippy::expect_used,
+    reason = "thread::Builder::spawn fails only when the OS cannot allocate a thread; this is an unrecoverable resource exhaustion"
+)]
 pub(crate) fn spawn_named<F, T>(name: &str, f: F) -> JoinHandle<T>
 where
     F: FnOnce() -> T + Send + 'static,

--- a/lading/src/observer.rs
+++ b/lading/src/observer.rs
@@ -103,6 +103,10 @@ impl Server {
         clippy::cast_possible_truncation,
         clippy::cast_sign_loss
     )]
+    #[expect(
+        clippy::expect_used,
+        reason = "the observer requires the target PID to begin sampling; a missing PID at this point indicates an unrecoverable orchestration failure"
+    )]
     #[cfg(target_os = "linux")]
     pub async fn run(
         self,

--- a/lading/src/observer/linux/cgroup/v2/cpu.rs
+++ b/lading/src/observer/linux/cgroup/v2/cpu.rs
@@ -41,6 +41,10 @@ impl Sampler {
     }
 
     // Read cgroup CPU data and calculate a percentage of usage.
+    #[expect(
+        clippy::expect_used,
+        reason = "cpu.stat lines from the kernel are guaranteed by the cgroup v2 interface to have key/value pairs; deviation indicates a kernel ABI break"
+    )]
     pub(crate) async fn poll(
         &mut self,
         group_prefix: &Path,

--- a/lading/src/observer/linux/procfs.rs
+++ b/lading/src/observer/linux/procfs.rs
@@ -186,6 +186,10 @@ impl Sampler {
         clippy::cast_possible_truncation,
         clippy::cast_possible_wrap
     )]
+    #[expect(
+        clippy::expect_used,
+        reason = "process_info is populated for every pid before handle_process is called; a missing entry here indicates a programming error in the sampler driver"
+    )]
     async fn handle_process(
         &mut self,
         process: Process,
@@ -375,6 +379,10 @@ async fn proc_comm(pid: i32) -> Result<String, Error> {
 
 /// Collect the 'name' of the process. This is pulled from `/proc/<pid>/exe` and
 /// we take the last part of that, like posix `top` does.
+#[expect(
+    clippy::expect_used,
+    reason = "Linux exe symlink targets are valid UTF-8 paths in all real-world cases; non-UTF-8 indicates a non-standard filesystem encoding"
+)]
 async fn proc_exe(pid: i32) -> Result<String, Error> {
     let exe_path = format!("/proc/{pid}/exe");
     let exe = tokio::fs::read_link(&exe_path).await?;

--- a/lading/src/observer/linux/procfs/memory/smaps.rs
+++ b/lading/src/observer/linux/procfs/memory/smaps.rs
@@ -320,6 +320,10 @@ impl Regions {
         map.into_iter().collect()
     }
 
+    #[expect(
+        clippy::expect_used,
+        reason = "compile-time-constant regex literal; failure to compile is a programming error caught in tests"
+    )]
     fn into_region_strs(contents: &str) -> Vec<&str> {
         let mut str_regions = Vec::new();
         // Split the smaps file into regions

--- a/lading/src/target.rs
+++ b/lading/src/target.rs
@@ -201,6 +201,10 @@ impl Server {
 
     /// Watch a container running elsewhere on the system. lading will report an
     /// error if the container exits before the test completes.
+    #[expect(
+        clippy::expect_used,
+        reason = "container PIDs fit in i32 on supported platforms; a failure indicates a platform invariant violation"
+    )]
     async fn watch_container(
         config: DockerConfig,
         pid_snd: TargetPidSender,
@@ -374,6 +378,10 @@ impl Server {
 
     /// Execute a binary target. lading will attempt to gracefully terminate the
     /// process after the test has completed.
+    #[expect(
+        clippy::expect_used,
+        reason = "child PIDs returned by tokio::process::Command fit in i32 on supported platforms; a failure indicates a platform invariant violation"
+    )]
     async fn execute_binary(
         config: BinaryConfig,
         pid_snd: TargetPidSender,

--- a/lading/src/target_metrics/expvar.rs
+++ b/lading/src/target_metrics/expvar.rs
@@ -72,6 +72,10 @@ impl Expvar {
     /// # Panics
     ///
     /// None are known.
+    #[expect(
+        clippy::expect_used,
+        reason = "reqwest::ClientBuilder::build fails only on TLS backend setup; an unrecoverable bootstrap failure"
+    )]
     pub(crate) async fn run(self) -> Result<(), Error> {
         info!("Expvar target metrics scraper running, but waiting for warmup to complete");
         self.experiment_started.recv().await; // block until experimental lading_signal::Watcher entered

--- a/lading/src/target_metrics/prometheus.rs
+++ b/lading/src/target_metrics/prometheus.rs
@@ -15,6 +15,10 @@ use tracing::{error, info, trace, warn};
 
 // Regex to match Prometheus label pairs: label_name="label_value"
 // The value can be empty (e.g., label="")
+#[expect(
+    clippy::expect_used,
+    reason = "compile-time-constant regex literal; failure to compile is a programming error caught in tests"
+)]
 static LABEL_REGEX: Lazy<Regex> =
     Lazy::new(|| Regex::new(r#"(\w+)="([^"]*)""#).expect("Failed to compile label regex"));
 
@@ -178,6 +182,10 @@ pub(crate) async fn scrape_metrics(
     clippy::too_many_lines,
     clippy::cast_possible_truncation,
     clippy::cast_sign_loss
+)]
+#[expect(
+    clippy::expect_used,
+    reason = "FIXME: this is an ad-hoc Prometheus parser that panics on malformed input; reported parse failures should surface as recoverable errors. Tracked for follow-up."
 )]
 pub(crate) fn parse_prometheus_metrics(
     text: &str,


### PR DESCRIPTION
## Summary

Annotate intentional-panic `.expect()` sites across the observer subsystem, target launcher, target metrics scrapers, inspector, neper threading, and the captool analyzer. Reasons document the invariant (telemetry channel, cgroup ABI, paired-map structure, etc.); FIXME markers track sites that should eventually surface as `Error` variants.

Sites annotated:
- \`observer.rs::run\` — telemetry channel invariant
- \`observer/linux/procfs.rs::{handle_process, proc_exe}\` — process_info map invariant; UTF-8 exe path
- \`observer/linux/cgroup/v2/cpu.rs::poll\` — cgroup v2 kernel ABI
- \`observer/linux/procfs/memory/smaps.rs::into_region_strs\` — const regex
- \`target.rs::{watch_container, execute_binary}\` — PID i32 conversion
- \`target_metrics/expvar.rs::run\` — reqwest TLS bootstrap
- \`target_metrics/prometheus.rs::{LABEL_REGEX, parse_prometheus_metrics}\` — const regex + FIXME for parser panic
- \`inspector.rs::run\` — PID i32 conversion
- \`neper/thread.rs::spawn_named\` — OS thread alloc
- \`bin/captool/analyze/jsonl.rs::analyze_metric\` — paired-map invariant

Stacked on #1899. Part of the broader push toward enforcing `clippy::expect_used = "deny"` workspace-wide.

## Test plan
- [x] \`./ci/validate\` passes
- [ ] CI green on this PR