### PR TITLE
fix(lading): surface tooling/FUSE-mount panics as errors

### DIFF
--- a/lading/src/bin/captool/main.rs
+++ b/lading/src/bin/captool/main.rs
@@ -74,7 +74,7 @@ pub enum Error {
 #[expect(clippy::too_many_lines)]
 #[expect(
     clippy::expect_used,
-    reason = "FIXME: line read and JSON deserialization should surface as Error variants rather than panicking; tracked for follow-up. Task join panics are intentional propagation of inner panics."
+    reason = "Remaining .expect() sites are on tokio::task::JoinHandle; a JoinError fires only when the blocking task itself panicked, and we intentionally propagate that inner panic."
 )]
 async fn main() -> Result<(), Error> {
     tracing_subscriber::fmt()
@@ -137,12 +137,14 @@ async fn main() -> Result<(), Error> {
                 };
 
                 let lines_vec: Vec<Line> = lines
-                    .map(|l| {
-                        let line_str = l.expect("failed to read line");
-                        serde_json::from_str(&line_str).expect("failed to deserialize line")
+                    .map(|l| -> Result<Line, Error> {
+                        let line_str = l?;
+                        Ok(serde_json::from_str(&line_str)?)
                     })
-                    .collect()
-                    .await;
+                    .collect::<Vec<Result<Line, Error>>>()
+                    .await
+                    .into_iter()
+                    .collect::<Result<Vec<_>, _>>()?;
 
                 analyze::jsonl::list_metrics(&lines_vec)
             }
@@ -190,12 +192,14 @@ async fn main() -> Result<(), Error> {
                 };
 
                 let lines_vec: Vec<Line> = lines
-                    .map(|l| {
-                        let line_str = l.expect("failed to read line");
-                        serde_json::from_str(&line_str).expect("failed to deserialize line")
+                    .map(|l| -> Result<Line, Error> {
+                        let line_str = l?;
+                        Ok(serde_json::from_str(&line_str)?)
                     })
-                    .collect()
-                    .await;
+                    .collect::<Vec<Result<Line, Error>>>()
+                    .await
+                    .into_iter()
+                    .collect::<Result<Vec<_>, _>>()?;
 
                 analyze::jsonl::analyze_metric(&lines_vec, metric_name)
             }
@@ -233,7 +237,7 @@ async fn main() -> Result<(), Error> {
 
 #[expect(
     clippy::expect_used,
-    reason = "FIXME: line read and JSON deserialization should surface as Error variants rather than panicking; tracked for follow-up. Task join panics are intentional propagation of inner panics."
+    reason = "Remaining .expect() site is on tokio::task::JoinHandle; a JoinError fires only when the blocking task itself panicked, and we intentionally propagate that inner panic."
 )]
 async fn validate_capture(capture_path_str: &str, min_seconds: Option<u64>) -> Result<(), Error> {
     let capture_path = path::Path::new(capture_path_str);
@@ -272,16 +276,14 @@ async fn validate_capture(capture_path_str: &str, min_seconds: Option<u64>) -> R
                 either::Either::Left(LinesStream::new(reader.lines()))
             };
 
-            let mut lines_vec = Vec::new();
-            let mut lines_stream = lines.map(|l| {
-                let line_str = l.expect("failed to read line");
-                let line: Line =
-                    serde_json::from_str(&line_str).expect("failed to deserialize line");
-                line
+            let mut lines_vec: Vec<Line> = Vec::new();
+            let mut lines_stream = lines.map(|l| -> Result<Line, Error> {
+                let line_str = l?;
+                Ok(serde_json::from_str(&line_str)?)
             });
 
             while let Some(line) = lines_stream.next().await {
-                lines_vec.push(line);
+                lines_vec.push(line?);
             }
 
             jsonl::validate_lines(&lines_vec, min_seconds)

--- a/lading/src/generator/file_gen/logrotate_fs.rs
+++ b/lading/src/generator/file_gen/logrotate_fs.rs
@@ -167,13 +167,6 @@ impl Server {
     ///
     /// Function will error if block cache cannot be built.
     ///
-    /// # Panics
-    ///
-    /// Function will panic if the filesystem cannot be started.
-    #[expect(
-        clippy::expect_used,
-        reason = "FIXME: fuse_mount2 spawn failure should propagate as an Error variant rather than panic; tracked for follow-up"
-    )]
     pub fn new(
         _: generator::General,
         config: Config,
@@ -242,8 +235,7 @@ impl Server {
         ];
 
         // Mount the filesystem in the background
-        let background_session = spawn_mount2(fs, config.mount_point, &options)
-            .expect("Failed to mount FUSE filesystem");
+        let background_session = spawn_mount2(fs, config.mount_point, &options)?;
 
         Ok(Self {
             shutdown,


### PR DESCRIPTION
## Summary

Third and final PR in the FIXME-conversion stack. Addresses the three
remaining sites: two in the offline `captool` analyzer, one in the
FUSE-mount setup of the logrotate-fs generator.

### `bin/captool/main.rs` — `main` and `validate_capture`

Both functions consume a `LinesStream` via `.map(|l| { ... })` and
panic via `.expect()` on either a failed line read or a malformed
JSON record. Convert the closures to return `Result<Line, Error>`
and fail-fast on the first error. `captool` is an offline analyzer —
silently skipping corrupt lines would mask the corruption being
investigated.

The fn-level `#[expect(clippy::expect_used)]` stays on both
functions: a few `.expect()` calls remain on `tokio::task::JoinHandle`
results, where a `JoinError` is the intentional propagation of an
inner blocking-task panic. The `reason` text is rewritten so the
attribute no longer reads as tracked debt — it now describes
deliberate panic propagation.

### `generator/file_gen/logrotate_fs.rs::Server::new`

`fuser::spawn_mount2` returns an `io::Result` and the existing
`Error::Io` variant is already `#[from] std::io::Error`. The fix is
trivial: replace `.expect("Failed to mount FUSE filesystem")` with
`?`. No new variant needed. The fn-level FIXME `#[expect]` is
removed.

## End state

After this PR, `grep -rn 'FIXME' lading/src/` returns no results. All
remaining `#[expect(clippy::expect_used)]` attributes in the `lading`
crate are correctly-documented intentional panics (channel-iterator
construction, `OnceCell` set-once, `JoinHandle` task-panic
propagation, `tokio::select!` branch invariants, etc.) rather than
tracked debt.

## Test plan

- [x] `./ci/validate` passes
- [x] `grep -rn 'FIXME' lading/src/` is empty
- [x] `cargo build --workspace --all-targets --all-features`

🤖 Generated with [Claude Code](https://claude.com/claude-code)