### PR TITLE
feat(lading): add record policy to allowlist recorded series in datadog blackhole

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 - Datadog blackhole now accepts a `record` policy (`all` / `disabled` /
   `tags_to_drop: [...]`) controlling which received series are recorded as
-  capture metrics. Defaults to `all` (unchanged behaviour); `disabled` records
-  nothing and `tags_to_drop: [...]` drops the named tag keys, letting a case
-  strip a high-cardinality tag that would otherwise inflate the capture file.
+  capture metrics.
 - HTTP blackhole now supports an `openmetrics` body variant for generated
   Prometheus/OpenMetrics scrape responses.
 - Updated to rand 0.10.x

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 - Datadog blackhole now accepts a `record` policy (`all` / `disabled` /
-  `tags: { drop: [...] }`) controlling which received series are recorded as
+  `tags_to_drop: [...]`) controlling which received series are recorded as
   capture metrics. Defaults to `all` (unchanged behaviour); `disabled` records
-  nothing and `tags: { drop: [...] }` drops the named tag keys, letting a case
+  nothing and `tags_to_drop: [...]` drops the named tag keys, letting a case
   strip a high-cardinality tag that would otherwise inflate the capture file.
 - HTTP blackhole now supports an `openmetrics` body variant for generated
   Prometheus/OpenMetrics scrape responses.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 - Datadog blackhole now accepts a `record` policy (`all` / `disabled` /
-  `tags_to_drop: [...]`) controlling which received series are recorded as
+  `series_to_keep: [...]`) controlling which received series are recorded as
   capture metrics.
 - HTTP blackhole now supports an `openmetrics` body variant for generated
   Prometheus/OpenMetrics scrape responses.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+- Datadog blackhole now accepts a `record` policy (`all` / `disabled` /
+  `tags: { keep: [...] }`) controlling which received series are recorded as
+  capture metrics. Defaults to `all` (unchanged behaviour); `disabled` or a tag
+  allowlist bound capture-series cardinality for targets that emit unbounded
+  tags.
 - HTTP blackhole now supports an `openmetrics` body variant for generated
   Prometheus/OpenMetrics scrape responses.
 - Updated to rand 0.10.x

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 - Datadog blackhole now accepts a `record` policy (`all` / `disabled` /
-  `tags: { keep: [...] }`) controlling which received series are recorded as
-  capture metrics. Defaults to `all` (unchanged behaviour); `disabled` or a tag
-  allowlist bound capture-series cardinality for targets that emit unbounded
-  tags.
+  `tags: { drop: [...] }`) controlling which received series are recorded as
+  capture metrics. Defaults to `all` (unchanged behaviour); `disabled` records
+  nothing and `tags: { drop: [...] }` drops the named tag keys, letting a case
+  strip a high-cardinality tag that would otherwise inflate the capture file.
 - HTTP blackhole now supports an `openmetrics` body variant for generated
   Prometheus/OpenMetrics scrape responses.
 - Updated to rand 0.10.x

--- a/lading/src/blackhole/datadog.rs
+++ b/lading/src/blackhole/datadog.rs
@@ -33,7 +33,7 @@ use hyper_util::{
 use lading_capture::{counter_incr, gauge_set};
 use metrics::counter;
 use prost::Message;
-use serde::{Deserialize, Deserializer, Serialize, de};
+use serde::{Deserialize, Serialize};
 use serde_yaml::with::singleton_map_recursive;
 use std::{
     borrow::Cow,
@@ -117,10 +117,7 @@ impl Default for RecordPolicy {
 }
 
 impl RecordPolicy {
-    /// Whether a tag key is retained on recorded capture series. Only consulted
-    /// while recording; [`RecordPolicy::Disabled`] skips the recording loop
-    /// before this is reached.
-    #[inline]
+    /// Whether a tag key is retained on recorded capture series.
     fn retains_tag(&self, tag_key: &str) -> bool {
         match self {
             Self::All => true,
@@ -128,22 +125,6 @@ impl RecordPolicy {
             Self::TagsToDrop(tags) => !tags.contains(tag_key),
         }
     }
-}
-
-/// Deserialize [`RecordPolicy`] accepting both the plain-scalar form for unit
-/// variants (`record: disabled`) and the natural nested-map form for the
-/// non-unit variant (`record: { tags_to_drop: [...] }`). `serde_yaml`
-/// otherwise insists on YAML tags (`!tags_to_drop`) for such variants; this
-/// mirrors the fallback the `http` blackhole uses for its body variant.
-fn deserialize_record<'de, D>(deserializer: D) -> Result<RecordPolicy, D::Error>
-where
-    D: Deserializer<'de>,
-{
-    let value = serde_yaml::Value::deserialize(deserializer)?;
-    RecordPolicy::deserialize(value.clone()).or_else(|original| {
-        singleton_map_recursive::deserialize(value)
-            .map_err(|_| de::Error::custom(original.to_string()))
-    })
 }
 
 #[derive(Debug, Deserialize, Serialize, Clone, PartialEq, Eq)]
@@ -154,8 +135,8 @@ pub struct Config {
     #[serde(flatten)]
     pub variant: Variant,
     /// Which received series to record as lading capture metrics. Defaults to
-    /// [`RecordPolicy::All`], preserving historical behaviour.
-    #[serde(default, deserialize_with = "deserialize_record")]
+    /// [`RecordPolicy::All`].
+    #[serde(default, with = "singleton_map_recursive")]
     pub record: RecordPolicy,
 }
 
@@ -384,76 +365,72 @@ async fn handle_v2_protobuf(
                 payload.series.len()
             );
 
-            // When recording is disabled the payload is decoded above purely
-            // for byte/parse accounting; skip the recording loop entirely so no
-            // capture series are produced and no per-point work is done.
-            for series in &payload.series {
-                if matches!(record, RecordPolicy::Disabled) {
-                    break;
-                }
-                if series.points.is_empty() {
-                    continue;
-                }
+            if !matches!(record, RecordPolicy::Disabled) {
+                for series in &payload.series {
+                    if series.points.is_empty() {
+                        continue;
+                    }
 
-                // Parse Datadog tags (format: "key:value" or "key") into label pairs.
-                // Key-only tags are represented with an empty value. The configured
-                // record policy filters the tag set here, before the capture key is
-                // interned, which is what bounds capture-series cardinality.
-                let tag_pairs: Vec<(&str, &str)> = series
-                    .tags
-                    .iter()
-                    .map(|tag| tag.split_once(':').unwrap_or((tag.as_str(), "")))
-                    .filter(|&(key, _)| record.retains_tag(key))
-                    .collect();
+                    // Parse Datadog tags (format: "key:value" or "key") into label pairs.
+                    // Key-only tags are represented with an empty value. The configured
+                    // record policy filters the tag set here, before the capture key is
+                    // interned, which is what bounds capture-series cardinality.
+                    let tag_pairs: Vec<(&str, &str)> = series
+                        .tags
+                        .iter()
+                        .map(|tag| tag.split_once(':').unwrap_or((tag.as_str(), "")))
+                        .filter(|&(key, _)| record.retains_tag(key))
+                        .collect();
 
-                // Metric types from the agent_payload.proto:
-                //
-                // - COUNT (1): Delta count over the interval
-                // - RATE (2): Per-second rate, converted into a counter by
-                //   multiplication with the interval.
-                // - GAUGE (3): Point-in-time value
-                //
-                // For COUNT/RATE we use counter_incr, for GAUGE we use
-                // gauge_set. Timestamps are Unix epoch.
-                for point in &series.points {
-                    let timestamp = unix_to_instant(point.timestamp);
+                    // Metric types from the agent_payload.proto:
+                    //
+                    // - COUNT (1): Delta count over the interval
+                    // - RATE (2): Per-second rate, converted into a counter by
+                    //   multiplication with the interval.
+                    // - GAUGE (3): Point-in-time value
+                    //
+                    // For COUNT/RATE we use counter_incr, for GAUGE we use
+                    // gauge_set. Timestamps are Unix epoch.
+                    for point in &series.points {
+                        let timestamp = unix_to_instant(point.timestamp);
 
-                    let metrics_res = match series.r#type {
-                        1 => {
-                            // COUNT
-                            #[expect(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
-                            let value = point.value.round() as u64;
-                            counter_incr(&series.metric, &tag_pairs, value, timestamp).await
-                        }
-                        2 => {
-                            // RATE
-                            let interval = series.interval;
-                            if interval <= 0 {
-                                warn!(
-                                    "RATE with non-positive interval for {metric}, ignoring",
-                                    metric = series.metric
-                                );
-                                continue;
+                        let metrics_res = match series.r#type {
+                            1 => {
+                                // COUNT
+                                #[expect(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+                                let value = point.value.round() as u64;
+                                counter_incr(&series.metric, &tag_pairs, value, timestamp).await
                             }
-                            #[expect(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
-                            let val = (point.value * interval as f64).round() as u64;
-                            counter_incr(&series.metric, &tag_pairs, val, timestamp).await
+                            2 => {
+                                // RATE
+                                let interval = series.interval;
+                                if interval <= 0 {
+                                    warn!(
+                                        "RATE with non-positive interval for {metric}, ignoring",
+                                        metric = series.metric
+                                    );
+                                    continue;
+                                }
+                                #[expect(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+                                let val = (point.value * interval as f64).round() as u64;
+                                counter_incr(&series.metric, &tag_pairs, val, timestamp).await
+                            }
+                            3 => {
+                                // GAUGE
+                                gauge_set(&series.metric, &tag_pairs, point.value, timestamp).await
+                            }
+                            i => {
+                                warn!("Unknown metric type, skipping: {i}");
+                                Ok(())
+                            }
+                        };
+                        if let Err(e) = metrics_res {
+                            warn!(
+                                "Failed to record metric {metric} at timestamp {ts}: {e}",
+                                metric = series.metric,
+                                ts = point.timestamp
+                            );
                         }
-                        3 => {
-                            // GAUGE
-                            gauge_set(&series.metric, &tag_pairs, point.value, timestamp).await
-                        }
-                        i => {
-                            warn!("Unknown metric type, skipping: {i}");
-                            Ok(())
-                        }
-                    };
-                    if let Err(e) = metrics_res {
-                        warn!(
-                            "Failed to record metric {metric} at timestamp {ts}: {e}",
-                            metric = series.metric,
-                            ts = point.timestamp
-                        );
                     }
                 }
             }

--- a/lading/src/blackhole/datadog.rs
+++ b/lading/src/blackhole/datadog.rs
@@ -33,9 +33,11 @@ use hyper_util::{
 use lading_capture::{counter_incr, gauge_set};
 use metrics::counter;
 use prost::Message;
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Deserializer, Serialize, de};
+use serde_yaml::with::singleton_map_recursive;
 use std::{
     borrow::Cow,
+    collections::BTreeSet,
     io,
     net::SocketAddr,
     sync::Arc,
@@ -91,13 +93,86 @@ pub enum Variant {
     },
 }
 
-#[derive(Debug, Deserialize, Serialize, Clone, Copy, PartialEq, Eq)]
+/// Controls which received series this blackhole records as lading capture
+/// metrics.
+///
+/// The Datadog intake blackhole re-emits every received series into lading's
+/// capture system, preserving the payload's tags (see [`handle_v2_protobuf`]).
+/// Each unique `(metric, tag-set)` becomes its own capture series, so a payload
+/// carrying an unbounded tag — for example a per-event `host` — produces
+/// unbounded capture series, inflating the capture file without limit and
+/// OOM-ing downstream analysis. This policy bounds that cardinality at the
+/// recording boundary, before the capture key is interned.
+#[derive(Debug, Deserialize, Serialize, Clone, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+#[serde(deny_unknown_fields)]
+pub enum RecordPolicy {
+    /// Record every received series with all of its tags. Default; preserves
+    /// historical behaviour. Cardinality is unbounded if the target emits
+    /// unbounded tags.
+    All,
+    /// Record no series at all. Aggregate `bytes_received` / `requests_received`
+    /// counters are still emitted and payloads are still decoded for
+    /// accounting. Lowest overhead, and the right choice when the experiment's
+    /// signal (e.g. target RSS) does not come from the recorded series.
+    Disabled,
+    /// Record series, but retain only the listed tag keys when forming the
+    /// capture series; every other tag is dropped. Capture-series cardinality
+    /// is then bounded by the value-space of the retained tags.
+    Tags {
+        /// Tag keys to retain. An empty set collapses every series to its bare
+        /// metric name (one capture series per distinct metric).
+        keep: BTreeSet<String>,
+    },
+}
+
+impl Default for RecordPolicy {
+    fn default() -> Self {
+        Self::All
+    }
+}
+
+impl RecordPolicy {
+    /// Whether a tag key is retained on recorded capture series. Only consulted
+    /// while recording; [`RecordPolicy::Disabled`] skips the recording loop
+    /// before this is reached.
+    #[inline]
+    fn retains_tag(&self, tag_key: &str) -> bool {
+        match self {
+            Self::All => true,
+            Self::Disabled => false,
+            Self::Tags { keep } => keep.contains(tag_key),
+        }
+    }
+}
+
+/// Deserialize [`RecordPolicy`] accepting both the plain-scalar form for unit
+/// variants (`record: disabled`) and the natural nested-map form for the struct
+/// variant (`record: { tags: { keep: [...] } }`). `serde_yaml` otherwise
+/// insists on YAML tags (`!tags`) for struct variants; this mirrors the
+/// fallback the `http` blackhole uses for its body variant.
+fn deserialize_record<'de, D>(deserializer: D) -> Result<RecordPolicy, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let value = serde_yaml::Value::deserialize(deserializer)?;
+    RecordPolicy::deserialize(value.clone()).or_else(|original| {
+        singleton_map_recursive::deserialize(value)
+            .map_err(|_| de::Error::custom(original.to_string()))
+    })
+}
+
+#[derive(Debug, Deserialize, Serialize, Clone, PartialEq, Eq)]
 #[serde(deny_unknown_fields)]
 /// Configuration for [`Datadog`].
 pub struct Config {
     /// The Datadog API variant to use
     #[serde(flatten)]
     pub variant: Variant,
+    /// Which received series to record as lading capture metrics. Defaults to
+    /// [`RecordPolicy::All`], preserving historical behaviour.
+    #[serde(default, deserialize_with = "deserialize_record")]
+    pub record: RecordPolicy,
 }
 
 #[derive(Debug)]
@@ -106,11 +181,13 @@ pub struct Datadog {
     binding_addr: SocketAddr,
     shutdown: lading_signal::Watcher,
     metric_labels: Vec<(String, String)>,
+    record: RecordPolicy,
 }
 
 #[derive(Clone)]
 struct AppState {
     metric_labels: Arc<[(String, String)]>,
+    record: RecordPolicy,
 }
 
 impl Datadog {
@@ -133,6 +210,7 @@ impl Datadog {
             binding_addr,
             shutdown,
             metric_labels,
+            record: config.record,
         }
     }
 
@@ -146,7 +224,10 @@ impl Datadog {
     /// Function will return an error if the server fails to start.
     pub async fn run(self) -> Result<(), Error> {
         let metric_labels: Arc<[(String, String)]> = Arc::from(self.metric_labels);
-        let state = Arc::new(AppState { metric_labels });
+        let state = Arc::new(AppState {
+            metric_labels,
+            record: self.record,
+        });
 
         let listener = TcpListener::bind(self.binding_addr).await?;
         info!(
@@ -241,7 +322,7 @@ async fn handle_request(
 
     let status = match (path.as_str(), content_type) {
         ("/api/v2/series", "application/x-protobuf") => {
-            handle_v2_protobuf(&whole_body, content_encoding, &path, labels).await
+            handle_v2_protobuf(&whole_body, content_encoding, &path, labels, &state.record).await
         }
         _ => StatusCode::ACCEPTED,
     };
@@ -299,6 +380,7 @@ async fn handle_v2_protobuf(
     content_encoding: &str,
     path: &str,
     labels: &[(String, String)],
+    record: &RecordPolicy,
 ) -> StatusCode {
     let decompressed = match decompress_if_needed(body, content_encoding) {
         Ok(data) => data,
@@ -318,17 +400,26 @@ async fn handle_v2_protobuf(
                 payload.series.len()
             );
 
+            // When recording is disabled the payload is decoded above purely
+            // for byte/parse accounting; skip the recording loop entirely so no
+            // capture series are produced and no per-point work is done.
             for series in &payload.series {
+                if matches!(record, RecordPolicy::Disabled) {
+                    break;
+                }
                 if series.points.is_empty() {
                     continue;
                 }
 
                 // Parse Datadog tags (format: "key:value" or "key") into label pairs.
-                // Key-only tags are represented with an empty value.
+                // Key-only tags are represented with an empty value. The configured
+                // record policy filters the tag set here, before the capture key is
+                // interned, which is what bounds capture-series cardinality.
                 let tag_pairs: Vec<(&str, &str)> = series
                     .tags
                     .iter()
                     .map(|tag| tag.split_once(':').unwrap_or((tag.as_str(), "")))
+                    .filter(|&(key, _)| record.retains_tag(key))
                     .collect();
 
                 // Metric types from the agent_payload.proto:
@@ -407,5 +498,56 @@ v2:
   binding_addr: "127.0.0.1:9091"
 "#;
         let _config: Config = serde_yaml::from_str(yaml).unwrap();
+    }
+
+    #[test]
+    fn record_defaults_to_all_and_parses_disabled() {
+        // Absent `record` defaults to `All`, preserving historical behaviour.
+        let default_yaml = r#"
+v2:
+  binding_addr: "127.0.0.1:9091"
+"#;
+        let config: Config = serde_yaml::from_str(default_yaml).unwrap();
+        assert_eq!(config.record, RecordPolicy::All);
+
+        // The unit variant parses from a plain scalar.
+        let disabled_yaml = r#"
+v2:
+  binding_addr: "127.0.0.1:9091"
+record: disabled
+"#;
+        let config: Config = serde_yaml::from_str(disabled_yaml).unwrap();
+        assert_eq!(config.record, RecordPolicy::Disabled);
+    }
+
+    #[test]
+    fn record_tags_allowlist_deserializes() {
+        // Exercises the `deserialize_record` fallback: the struct variant is
+        // written as a nested map, not a `!tags` YAML tag.
+        let yaml = r#"
+v2:
+  binding_addr: "127.0.0.1:9091"
+record:
+  tags:
+    keep: [service, env]
+"#;
+        let config: Config = serde_yaml::from_str(yaml).unwrap();
+        let keep: BTreeSet<String> = ["service", "env"]
+            .iter()
+            .map(|s| (*s).to_string())
+            .collect();
+        assert_eq!(config.record, RecordPolicy::Tags { keep });
+    }
+
+    #[test]
+    fn record_policy_retention() {
+        // `All` keeps every tag.
+        assert!(RecordPolicy::All.retains_tag("host"));
+
+        // `Tags` keeps allowlisted keys and drops the rest.
+        let keep: BTreeSet<String> = ["service".to_string()].into_iter().collect();
+        let policy = RecordPolicy::Tags { keep };
+        assert!(policy.retains_tag("service"));
+        assert!(!policy.retains_tag("host"));
     }
 }

--- a/lading/src/blackhole/datadog.rs
+++ b/lading/src/blackhole/datadog.rs
@@ -101,28 +101,26 @@ pub enum Variant {
 /// Each unique `(metric, tag-set)` becomes its own capture series, so a payload
 /// carrying an unbounded tag — for example a per-event `host` — produces
 /// unbounded capture series, inflating the capture file without limit and
-/// OOM-ing downstream analysis. This policy bounds that cardinality at the
-/// recording boundary, before the capture key is interned.
+/// OOM-ing downstream analysis. This policy controls what reaches the capture
+/// system at the recording boundary, before the capture key is interned: drop
+/// a known high-cardinality tag, or disable recording entirely.
 #[derive(Debug, Deserialize, Serialize, Clone, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 #[serde(deny_unknown_fields)]
 pub enum RecordPolicy {
-    /// Record every received series with all of its tags. Default; preserves
-    /// historical behaviour. Cardinality is unbounded if the target emits
-    /// unbounded tags.
+    /// Default behaviour, record every received series with all of its tags.
     All,
     /// Record no series at all. Aggregate `bytes_received` / `requests_received`
     /// counters are still emitted and payloads are still decoded for
-    /// accounting. Lowest overhead, and the right choice when the experiment's
-    /// signal (e.g. target RSS) does not come from the recorded series.
+    /// accounting.
     Disabled,
-    /// Record series, but retain only the listed tag keys when forming the
-    /// capture series; every other tag is dropped. Capture-series cardinality
-    /// is then bounded by the value-space of the retained tags.
+    /// Record series, but drop the listed tag keys when forming the capture
+    /// series; every other tag is retained. Use this to remove a known
+    /// high-cardinality tag while keeping the rest of the series intact.
     Tags {
-        /// Tag keys to retain. An empty set collapses every series to its bare
-        /// metric name (one capture series per distinct metric).
-        keep: BTreeSet<String>,
+        /// Tag keys to drop. An empty set retains every tag (a no-op,
+        /// equivalent to [`RecordPolicy::All`]).
+        drop: BTreeSet<String>,
     },
 }
 
@@ -141,14 +139,14 @@ impl RecordPolicy {
         match self {
             Self::All => true,
             Self::Disabled => false,
-            Self::Tags { keep } => keep.contains(tag_key),
+            Self::Tags { drop } => !drop.contains(tag_key),
         }
     }
 }
 
 /// Deserialize [`RecordPolicy`] accepting both the plain-scalar form for unit
 /// variants (`record: disabled`) and the natural nested-map form for the struct
-/// variant (`record: { tags: { keep: [...] } }`). `serde_yaml` otherwise
+/// variant (`record: { tags: { drop: [...] } }`). `serde_yaml` otherwise
 /// insists on YAML tags (`!tags`) for struct variants; this mirrors the
 /// fallback the `http` blackhole uses for its body variant.
 fn deserialize_record<'de, D>(deserializer: D) -> Result<RecordPolicy, D::Error>
@@ -521,7 +519,7 @@ record: disabled
     }
 
     #[test]
-    fn record_tags_allowlist_deserializes() {
+    fn record_tags_denylist_deserializes() {
         // Exercises the `deserialize_record` fallback: the struct variant is
         // written as a nested map, not a `!tags` YAML tag.
         let yaml = r#"
@@ -529,14 +527,11 @@ v2:
   binding_addr: "127.0.0.1:9091"
 record:
   tags:
-    keep: [service, env]
+    drop: [host]
 "#;
         let config: Config = serde_yaml::from_str(yaml).unwrap();
-        let keep: BTreeSet<String> = ["service", "env"]
-            .iter()
-            .map(|s| (*s).to_string())
-            .collect();
-        assert_eq!(config.record, RecordPolicy::Tags { keep });
+        let drop: BTreeSet<String> = ["host".to_string()].into_iter().collect();
+        assert_eq!(config.record, RecordPolicy::Tags { drop });
     }
 
     #[test]
@@ -544,9 +539,9 @@ record:
         // `All` keeps every tag.
         assert!(RecordPolicy::All.retains_tag("host"));
 
-        // `Tags` keeps allowlisted keys and drops the rest.
-        let keep: BTreeSet<String> = ["service".to_string()].into_iter().collect();
-        let policy = RecordPolicy::Tags { keep };
+        // `Tags` drops the listed keys and keeps the rest.
+        let drop: BTreeSet<String> = ["host".to_string()].into_iter().collect();
+        let policy = RecordPolicy::Tags { drop };
         assert!(policy.retains_tag("service"));
         assert!(!policy.retains_tag("host"));
     }

--- a/lading/src/blackhole/datadog.rs
+++ b/lading/src/blackhole/datadog.rs
@@ -371,10 +371,9 @@ async fn handle_v2_protobuf(
                         continue;
                     }
 
-                    // Parse Datadog tags (format: "key:value" or "key") into label pairs.
-                    // Key-only tags are represented with an empty value. The configured
-                    // record policy filters the tag set here, before the capture key is
-                    // interned, which is what bounds capture-series cardinality.
+                    // Parse Datadog tags (format: "key:value" or "key") into label pairs,
+                    // and the configured record policy filters the tag set here.
+                    // Key-only tags are represented with an empty value.
                     let tag_pairs: Vec<(&str, &str)> = series
                         .tags
                         .iter()
@@ -459,52 +458,5 @@ v2:
   binding_addr: "127.0.0.1:9091"
 "#;
         let _config: Config = serde_yaml::from_str(yaml).unwrap();
-    }
-
-    #[test]
-    fn record_defaults_to_all_and_parses_disabled() {
-        // Absent `record` defaults to `All`, preserving historical behaviour.
-        let default_yaml = r#"
-v2:
-  binding_addr: "127.0.0.1:9091"
-"#;
-        let config: Config = serde_yaml::from_str(default_yaml).unwrap();
-        assert_eq!(config.record, RecordPolicy::All);
-
-        // The unit variant parses from a plain scalar.
-        let disabled_yaml = r#"
-v2:
-  binding_addr: "127.0.0.1:9091"
-record: disabled
-"#;
-        let config: Config = serde_yaml::from_str(disabled_yaml).unwrap();
-        assert_eq!(config.record, RecordPolicy::Disabled);
-    }
-
-    #[test]
-    fn record_tags_to_drop_deserializes() {
-        // Exercises the `deserialize_record` fallback: the variant is written
-        // as a nested map, not a `!tags_to_drop` YAML tag.
-        let yaml = r#"
-v2:
-  binding_addr: "127.0.0.1:9091"
-record:
-  tags_to_drop: [host]
-"#;
-        let config: Config = serde_yaml::from_str(yaml).unwrap();
-        let tags: BTreeSet<String> = ["host".to_string()].into_iter().collect();
-        assert_eq!(config.record, RecordPolicy::TagsToDrop(tags));
-    }
-
-    #[test]
-    fn record_policy_retention() {
-        // `All` keeps every tag.
-        assert!(RecordPolicy::All.retains_tag("host"));
-
-        // `TagsToDrop` drops the listed keys and keeps the rest.
-        let tags: BTreeSet<String> = ["host".to_string()].into_iter().collect();
-        let policy = RecordPolicy::TagsToDrop(tags);
-        assert!(policy.retains_tag("service"));
-        assert!(!policy.retains_tag("host"));
     }
 }

--- a/lading/src/blackhole/datadog.rs
+++ b/lading/src/blackhole/datadog.rs
@@ -95,15 +95,6 @@ pub enum Variant {
 
 /// Controls which received series this blackhole records as lading capture
 /// metrics.
-///
-/// The Datadog intake blackhole re-emits every received series into lading's
-/// capture system, preserving the payload's tags (see [`handle_v2_protobuf`]).
-/// Each unique `(metric, tag-set)` becomes its own capture series, so a payload
-/// carrying an unbounded tag — for example a per-event `host` — produces
-/// unbounded capture series, inflating the capture file without limit and
-/// OOM-ing downstream analysis. This policy controls what reaches the capture
-/// system at the recording boundary, before the capture key is interned: drop
-/// a known high-cardinality tag, or disable recording entirely.
 #[derive(Debug, Deserialize, Serialize, Clone, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 #[serde(deny_unknown_fields)]
@@ -114,14 +105,9 @@ pub enum RecordPolicy {
     /// counters are still emitted and payloads are still decoded for
     /// accounting.
     Disabled,
-    /// Record series, but drop the listed tag keys when forming the capture
-    /// series; every other tag is retained. Use this to remove a known
-    /// high-cardinality tag while keeping the rest of the series intact.
-    Tags {
-        /// Tag keys to drop. An empty set retains every tag (a no-op,
-        /// equivalent to [`RecordPolicy::All`]).
-        drop: BTreeSet<String>,
-    },
+    /// Record series but drop the listed tag keys when forming the capture
+    /// series. An empty list behaves like `All`, only slower.
+    TagsToDrop(BTreeSet<String>),
 }
 
 impl Default for RecordPolicy {
@@ -139,16 +125,16 @@ impl RecordPolicy {
         match self {
             Self::All => true,
             Self::Disabled => false,
-            Self::Tags { drop } => !drop.contains(tag_key),
+            Self::TagsToDrop(tags) => !tags.contains(tag_key),
         }
     }
 }
 
 /// Deserialize [`RecordPolicy`] accepting both the plain-scalar form for unit
-/// variants (`record: disabled`) and the natural nested-map form for the struct
-/// variant (`record: { tags: { drop: [...] } }`). `serde_yaml` otherwise
-/// insists on YAML tags (`!tags`) for struct variants; this mirrors the
-/// fallback the `http` blackhole uses for its body variant.
+/// variants (`record: disabled`) and the natural nested-map form for the
+/// non-unit variant (`record: { tags_to_drop: [...] }`). `serde_yaml`
+/// otherwise insists on YAML tags (`!tags_to_drop`) for such variants; this
+/// mirrors the fallback the `http` blackhole uses for its body variant.
 fn deserialize_record<'de, D>(deserializer: D) -> Result<RecordPolicy, D::Error>
 where
     D: Deserializer<'de>,
@@ -519,19 +505,18 @@ record: disabled
     }
 
     #[test]
-    fn record_tags_denylist_deserializes() {
-        // Exercises the `deserialize_record` fallback: the struct variant is
-        // written as a nested map, not a `!tags` YAML tag.
+    fn record_tags_to_drop_deserializes() {
+        // Exercises the `deserialize_record` fallback: the variant is written
+        // as a nested map, not a `!tags_to_drop` YAML tag.
         let yaml = r#"
 v2:
   binding_addr: "127.0.0.1:9091"
 record:
-  tags:
-    drop: [host]
+  tags_to_drop: [host]
 "#;
         let config: Config = serde_yaml::from_str(yaml).unwrap();
-        let drop: BTreeSet<String> = ["host".to_string()].into_iter().collect();
-        assert_eq!(config.record, RecordPolicy::Tags { drop });
+        let tags: BTreeSet<String> = ["host".to_string()].into_iter().collect();
+        assert_eq!(config.record, RecordPolicy::TagsToDrop(tags));
     }
 
     #[test]
@@ -539,9 +524,9 @@ record:
         // `All` keeps every tag.
         assert!(RecordPolicy::All.retains_tag("host"));
 
-        // `Tags` drops the listed keys and keeps the rest.
-        let drop: BTreeSet<String> = ["host".to_string()].into_iter().collect();
-        let policy = RecordPolicy::Tags { drop };
+        // `TagsToDrop` drops the listed keys and keeps the rest.
+        let tags: BTreeSet<String> = ["host".to_string()].into_iter().collect();
+        let policy = RecordPolicy::TagsToDrop(tags);
         assert!(policy.retains_tag("service"));
         assert!(!policy.retains_tag("host"));
     }

--- a/lading/src/blackhole/datadog.rs
+++ b/lading/src/blackhole/datadog.rs
@@ -105,9 +105,9 @@ pub enum RecordPolicy {
     /// counters are still emitted and payloads are still decoded for
     /// accounting.
     Disabled,
-    /// Record series but drop the listed tag keys when forming the capture
-    /// series. An empty list behaves like `All`, only slower.
-    TagsToDrop(BTreeSet<String>),
+    /// Record only series whose metric name is listed. An empty list behaves
+    /// like `Disabled`.
+    SeriesToKeep(BTreeSet<String>),
 }
 
 impl Default for RecordPolicy {
@@ -117,12 +117,13 @@ impl Default for RecordPolicy {
 }
 
 impl RecordPolicy {
-    /// Whether a tag key is retained on recorded capture series.
-    fn retains_tag(&self, tag_key: &str) -> bool {
+    /// Whether a series with the given metric name is recorded as a capture
+    /// metric.
+    fn records_series(&self, metric: &str) -> bool {
         match self {
             Self::All => true,
             Self::Disabled => false,
-            Self::TagsToDrop(tags) => !tags.contains(tag_key),
+            Self::SeriesToKeep(names) => names.contains(metric),
         }
     }
 }
@@ -366,19 +367,15 @@ async fn handle_v2_protobuf(
             );
 
             if !matches!(record, RecordPolicy::Disabled) {
-                for series in &payload.series {
-                    if series.points.is_empty() {
-                        continue;
-                    }
-
-                    // Parse Datadog tags (format: "key:value" or "key") into label pairs,
-                    // and the configured record policy filters the tag set here.
+                for series in payload.series.iter().filter(|series| {
+                    !series.points.is_empty() && record.records_series(&series.metric)
+                }) {
+                    // Parse Datadog tags (format: "key:value" or "key") into label pairs.
                     // Key-only tags are represented with an empty value.
                     let tag_pairs: Vec<(&str, &str)> = series
                         .tags
                         .iter()
                         .map(|tag| tag.split_once(':').unwrap_or((tag.as_str(), "")))
-                        .filter(|&(key, _)| record.retains_tag(key))
                         .collect();
 
                     // Metric types from the agent_payload.proto:


### PR DESCRIPTION
Adds an optional `record` policy to the `datadog` blackhole config, controlling which received series are recorded as lading capture metrics:

- `all` (default): record every series with every tag. Unchanged behaviour.
- `disabled`: record no series; payloads are still decoded and bytes still counted.
- `series_to_keep: [...]`: record only series whose metric name is listed (with all their tags); drop the rest.

```yaml
blackhole:
  - datadog:
      v2:
        binding_addr: "0.0.0.0:9091"
      record:
        series_to_keep: [my.metric.one, my.metric.two]
```

An allowlist by series name keeps the recorded outputs explicit in the lading config and avoids accidentally recording (and forwarding to org2) generator/fuzz-produced series.