### PR TITLE
fix(otlp): enforce sketch count be at most i64::MAX 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - OpenTelemetry metric payloads now prefix generated metric names with their
   metric kind to simplify intake debugging.
 - OpenTelemetry cumulative metric generation now updates cumulative sums using
-  aggregation temporality and preserves cumulative histogram min/max bounds.
+  aggregation temporality, preserves cumulative histogram min/max bounds, and
+  keeps generated histogram counts within downstream-compatible limits.
 - HTTP blackhole now supports an `openmetrics` body variant for generated
   Prometheus/OpenMetrics scrape responses.
 - Updated to rand 0.10.x

--- a/lading_payload/src/opentelemetry/metric.rs
+++ b/lading_payload/src/opentelemetry/metric.rs
@@ -1646,6 +1646,46 @@ mod test {
         }
     }
 
+    fn prop_assert_histogram_count_limits(point: &HistogramDataPoint) -> Result<(), TestCaseError> {
+        prop_assert_eq!(
+            point.count,
+            checked_count_sum(point.bucket_counts.iter().copied())
+        );
+        prop_assert!(point.count <= MAX_HISTOGRAM_COUNT);
+        for count in &point.bucket_counts {
+            prop_assert!(*count <= MAX_BUCKET_COUNT);
+        }
+        Ok(())
+    }
+
+    fn prop_assert_exp_histogram_count_limits(
+        point: &ExponentialHistogramDataPoint,
+    ) -> Result<(), TestCaseError> {
+        let positive_count = point.positive.as_ref().map_or(0, |buckets| {
+            checked_count_sum(buckets.bucket_counts.iter().copied())
+        });
+        let negative_count = point.negative.as_ref().map_or(0, |buckets| {
+            checked_count_sum(buckets.bucket_counts.iter().copied())
+        });
+        prop_assert_eq!(
+            point.count,
+            checked_count_sum([point.zero_count, positive_count, negative_count])
+        );
+        prop_assert!(point.count <= MAX_HISTOGRAM_COUNT);
+        prop_assert!(point.zero_count <= MAX_BUCKET_COUNT);
+        if let Some(positive) = &point.positive {
+            for count in &positive.bucket_counts {
+                prop_assert!(*count <= MAX_BUCKET_COUNT);
+            }
+        }
+        if let Some(negative) = &point.negative {
+            for count in &negative.bucket_counts {
+                prop_assert!(*count <= MAX_BUCKET_COUNT);
+            }
+        }
+        Ok(())
+    }
+
     #[test]
     fn cumulative_histograms_preserve_state_across_generations() -> Result<(), crate::Error> {
         let configs = [
@@ -1722,6 +1762,77 @@ mod test {
         }
 
         Ok(())
+    }
+
+    // Property: cumulative histogram count limits hold across repeated
+    // generation.
+    proptest! {
+        #[test]
+        fn cumulative_histogram_counts_stay_within_limits(
+            seed: u64,
+            steps in 1..128_u8,
+        ) {
+            let configs = [
+                super::MetricWeights {
+                    gauge: 0,
+                    sum_delta: 0,
+                    sum_cumulative: 0,
+                    histogram_delta: 0,
+                    histogram_cumulative: 1,
+                    exp_histogram_delta: 0,
+                    exp_histogram_cumulative: 0,
+                    summary: 0,
+                },
+                super::MetricWeights {
+                    gauge: 0,
+                    sum_delta: 0,
+                    sum_cumulative: 0,
+                    histogram_delta: 0,
+                    histogram_cumulative: 0,
+                    exp_histogram_delta: 0,
+                    exp_histogram_cumulative: 1,
+                    summary: 0,
+                },
+            ];
+
+            for metric_weights in configs {
+                let config = Config {
+                    contexts: Contexts {
+                        total_contexts: ConfRange::Constant(1),
+                        attributes_per_resource: ConfRange::Constant(1),
+                        scopes_per_resource: ConfRange::Constant(1),
+                        attributes_per_scope: ConfRange::Constant(0),
+                        metrics_per_scope: ConfRange::Constant(1),
+                        attributes_per_metric: ConfRange::Constant(0),
+                    },
+                    metric_weights,
+                };
+                let mut rng = SmallRng::seed_from_u64(seed);
+                let mut otel_metrics = OpentelemetryMetrics::new(config, 1_000_000, &mut rng)?;
+
+                for _ in 0..steps {
+                    let mut budget = 1_000_000;
+                    let resource_metric = otel_metrics.generate(&mut rng, &mut budget)?;
+                    for scope_metric in &resource_metric.scope_metrics {
+                        for metric in &scope_metric.metrics {
+                            match &metric.data {
+                                Some(Data::Histogram(histogram)) => {
+                                    for point in &histogram.data_points {
+                                        prop_assert_histogram_count_limits(point)?;
+                                    }
+                                }
+                                Some(Data::ExponentialHistogram(histogram)) => {
+                                    for point in &histogram.data_points {
+                                        prop_assert_exp_histogram_count_limits(point)?;
+                                    }
+                                }
+                                _ => {}
+                            }
+                        }
+                    }
+                }
+            }
+        }
     }
 
     // Property: tick tally in OpentelemetryMetrics increase with calls to

--- a/lading_payload/src/opentelemetry/metric.rs
+++ b/lading_payload/src/opentelemetry/metric.rs
@@ -72,15 +72,35 @@ pub const SMALLEST_PROTOBUF: usize = 31;
 
 /// Increment timestamps by 100 milliseconds (in nanoseconds) per tick
 const TIME_INCREMENT_NANOS: u64 = 1_000_000;
+const MAX_BUCKET_COUNT: u64 = u32::MAX as u64;
+const MAX_HISTOGRAM_COUNT: u64 = i64::MAX as u64;
+
+fn increment_bounded_count(count: &mut u64, increment: u64) {
+    *count = count.saturating_add(increment).min(MAX_BUCKET_COUNT);
+}
+
+fn checked_count_sum<I>(counts: I) -> u64
+where
+    I: IntoIterator<Item = u64>,
+{
+    let mut total = 0_u64;
+    for count in counts {
+        let Some(next) = total.checked_add(count) else {
+            return MAX_HISTOGRAM_COUNT;
+        };
+        total = next;
+    }
+    total.min(MAX_HISTOGRAM_COUNT)
+}
 
 fn increment_exp_bucket_counts(
     buckets: &mut exponential_histogram_data_point::Buckets,
     increment: u64,
 ) -> u64 {
     for count in &mut buckets.bucket_counts {
-        *count = count.saturating_add(increment);
+        increment_bounded_count(count, increment);
     }
-    buckets.bucket_counts.iter().sum()
+    checked_count_sum(buckets.bucket_counts.iter().copied())
 }
 
 fn randomize_exp_bucket_counts<R>(
@@ -93,7 +113,7 @@ where
     for count in &mut buckets.bucket_counts {
         *count = rng.random_range(0_u64..=10);
     }
-    buckets.bucket_counts.iter().sum()
+    checked_count_sum(buckets.bucket_counts.iter().copied())
 }
 
 fn populated_bucket_range(bucket_counts: &[u64]) -> Option<(usize, usize)> {
@@ -598,9 +618,10 @@ impl<'a> SizedGenerator<'a> for OpentelemetryMetrics {
                                     #[allow(clippy::cast_sign_loss)]
                                     let increment = self.incr_i as u64;
                                     for bc in &mut point.bucket_counts {
-                                        *bc = bc.saturating_add(increment);
+                                        increment_bounded_count(bc, increment);
                                     }
-                                    point.count = point.bucket_counts.iter().sum();
+                                    point.count =
+                                        checked_count_sum(point.bucket_counts.iter().copied());
                                     set_histogram_min_max(point, rng);
                                     if let (Some(previous), Some(current)) =
                                         (previous_min, point.min.as_mut())
@@ -629,7 +650,8 @@ impl<'a> SizedGenerator<'a> for OpentelemetryMetrics {
                                     for bc in &mut point.bucket_counts {
                                         *bc = rng.random_range(1_u64..=10);
                                     }
-                                    point.count = point.bucket_counts.iter().sum();
+                                    point.count =
+                                        checked_count_sum(point.bucket_counts.iter().copied());
                                     set_histogram_min_max(point, rng);
                                     if let Some(sum) = &mut point.sum {
                                         *sum = rng.random_range(1.0_f64..=1000.0);
@@ -651,15 +673,20 @@ impl<'a> SizedGenerator<'a> for OpentelemetryMetrics {
                                     // bucket counts only grow.
                                     #[allow(clippy::cast_sign_loss)]
                                     let increment = self.incr_i as u64;
-                                    point.zero_count = point.zero_count.saturating_add(increment);
-                                    let mut count = point.zero_count;
-                                    if let Some(positive) = &mut point.positive {
-                                        count += increment_exp_bucket_counts(positive, increment);
-                                    }
-                                    if let Some(negative) = &mut point.negative {
-                                        count += increment_exp_bucket_counts(negative, increment);
-                                    }
-                                    point.count = count;
+                                    increment_bounded_count(&mut point.zero_count, increment);
+                                    let positive_count =
+                                        point.positive.as_mut().map_or(0, |positive| {
+                                            increment_exp_bucket_counts(positive, increment)
+                                        });
+                                    let negative_count =
+                                        point.negative.as_mut().map_or(0, |negative| {
+                                            increment_exp_bucket_counts(negative, increment)
+                                        });
+                                    point.count = checked_count_sum([
+                                        point.zero_count,
+                                        positive_count,
+                                        negative_count,
+                                    ]);
                                     set_exp_histogram_min_max(point, rng);
                                     if let Some(negative) = &point.negative
                                         && let Some((_, last)) =
@@ -694,14 +721,19 @@ impl<'a> SizedGenerator<'a> for OpentelemetryMetrics {
                                 } else {
                                     // Delta: fresh observations each window.
                                     point.zero_count = rng.random_range(1_u64..=10);
-                                    let mut count = point.zero_count;
-                                    if let Some(positive) = &mut point.positive {
-                                        count += randomize_exp_bucket_counts(positive, rng);
-                                    }
-                                    if let Some(negative) = &mut point.negative {
-                                        count += randomize_exp_bucket_counts(negative, rng);
-                                    }
-                                    point.count = count;
+                                    let positive_count =
+                                        point.positive.as_mut().map_or(0, |positive| {
+                                            randomize_exp_bucket_counts(positive, rng)
+                                        });
+                                    let negative_count =
+                                        point.negative.as_mut().map_or(0, |negative| {
+                                            randomize_exp_bucket_counts(negative, rng)
+                                        });
+                                    point.count = checked_count_sum([
+                                        point.zero_count,
+                                        positive_count,
+                                        negative_count,
+                                    ]);
                                     set_exp_histogram_min_max(point, rng);
                                     if let Some(sum) = &mut point.sum {
                                         *sum = rng.random_range(1.0_f64..=1000.0);
@@ -833,7 +865,10 @@ impl crate::Serialize for OpentelemetryMetrics {
 
 #[cfg(test)]
 mod test {
-    use super::{Config, Contexts, OpentelemetryMetrics, ResourceMetrics, SMALLEST_PROTOBUF};
+    use super::{
+        Config, Contexts, MAX_BUCKET_COUNT, MAX_HISTOGRAM_COUNT, OpentelemetryMetrics,
+        ResourceMetrics, SMALLEST_PROTOBUF, checked_count_sum,
+    };
     use crate::{Serialize, SizedGenerator, common::config::ConfRange};
     use opentelemetry_proto::tonic::common::v1::any_value;
     use opentelemetry_proto::tonic::metrics::v1::{
@@ -1517,6 +1552,10 @@ mod test {
                         Some(Data::Histogram(histogram)) => {
                             for point in &histogram.data_points {
                                 assert_eq!(point.count, point.bucket_counts.iter().sum::<u64>());
+                                assert!(point.count <= MAX_HISTOGRAM_COUNT);
+                                for count in &point.bucket_counts {
+                                    assert!(*count <= MAX_BUCKET_COUNT);
+                                }
                                 assert!(point.min.is_some());
                                 assert!(point.max.is_some());
                                 assert!(point.min <= point.max);
@@ -1537,8 +1576,24 @@ mod test {
                                     .map_or(0, |buckets| buckets.bucket_counts.iter().sum());
                                 assert_eq!(
                                     point.count,
-                                    point.zero_count + positive_count + negative_count
+                                    checked_count_sum([
+                                        point.zero_count,
+                                        positive_count,
+                                        negative_count
+                                    ])
                                 );
+                                assert!(point.count <= MAX_HISTOGRAM_COUNT);
+                                assert!(point.zero_count <= MAX_BUCKET_COUNT);
+                                if let Some(positive) = &point.positive {
+                                    for count in &positive.bucket_counts {
+                                        assert!(*count <= MAX_BUCKET_COUNT);
+                                    }
+                                }
+                                if let Some(negative) = &point.negative {
+                                    for count in &negative.bucket_counts {
+                                        assert!(*count <= MAX_BUCKET_COUNT);
+                                    }
+                                }
                                 assert!(point.min.is_some());
                                 assert!(point.max.is_some());
                                 assert!(point.min <= point.max);


### PR DESCRIPTION
### What does this PR do?

Enforces sketch count to be at **most** i64::MAX. 

### Motivation

A [failing CI job](https://github.com/DataDog/saluki/pull/2159) when updating the lading version in Agent Data Plane exposed a small bug caused by the Core Agent. Although counts are required to be positive, they are stored as `i64`. Previously, lading could produce count sizes up to `u64`, which would cause overflows, and subsequently, negative numbers. To mitigate this, we are now requiring lading OTLP payloads to be at most `i64::MAX` to ensure the invariant that `count >= 0` holds true. 

### Related issues

A list of issues either fixed, containing architectural discussions, otherwise relevant
for this Pull Request.

### Additional Notes

Anything else we should know when reviewing?
