### PR TITLE
Prepare 0.33.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## [0.33.0]
 ## Changed
 - **Breaking Change**: Datadog blackhole now records received series under the
   `target/` prefix, matching the prometheus and expvar target metrics

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 
 ## [0.33.0]
+### Changed
+- **Breaking Change**: Datadog blackhole now records received series under the
+  `target/` prefix, matching the prometheus and expvar target metrics
+  collectors. The `record` policy still matches on the unprefixed series name.
+- **Breaking Change**: Datadog blackhole does not record any target metrics by
+  default.
+
 ### Added
 - Datadog blackhole now accepts a `record` policy (`all` / `disabled` /
   `series_to_keep: [...]`) controlling which received series are recorded as
   capture metrics.
+- OpenTelemetry metric payloads now prefix generated metric names with their
+  metric kind to simplify intake debugging.
+- OpenTelemetry cumulative metric generation now updates cumulative sums using
+  aggregation temporality, preserves cumulative histogram min/max bounds, and
+  supports configurable histogram count limits. Cumulative explicit histograms
+  now retain their state across payload generations.
 - HTTP blackhole now supports an `openmetrics` body variant for generated
   Prometheus/OpenMetrics scrape responses.
+- Updated to rand 0.10.x
 - `dogstatsd` generator now supports configurable pools for the `|c:` (container
   ID), `|e:` (external data), and `|card:` (cardinality) origin detection
   extension fields via the new `container_ids`, `external_data`, and
@@ -20,20 +34,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   metric, or omits the field entirely if the pool is empty.
 - `dogstatsd` generator now supports DogStatsD protocol v1.3 `|T` timestamps
   for count and gauge metrics via `timestamp.range` and `timestamp.probability`.
-
-### Changed
-- **Breaking Change**: Datadog blackhole now records received series under the
-  `target/` prefix, matching the prometheus and expvar target metrics
-  collectors. The `record` policy still matches on the unprefixed series name.
-- **Breaking Change**: Datadog blackhole does not record any target metrics by
-  default.
-- OpenTelemetry metric payloads now prefix generated metric names with their
-  metric kind to simplify intake debugging.
-- OpenTelemetry cumulative metric generation now updates cumulative sums using
-  aggregation temporality, preserves cumulative histogram min/max bounds, and
-  supports configurable histogram count limits. Cumulative explicit histograms
-  now retain their state across payload generations.
-- Updated to rand 0.10.x
 
 ### Fixed
 - `dogstatsd` tag generation would silently fail with a misleading

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,26 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 
 ## [0.33.0]
-## Changed
-- **Breaking Change**: Datadog blackhole now records received series under the
-  `target/` prefix, matching the prometheus and expvar target metrics
-  collectors. The `record` policy still matches on the unprefixed series name.
-- **Breaking Change**: Datadog blackhole does not record any target metrics by
-  default.
-
-## Added
+### Added
 - Datadog blackhole now accepts a `record` policy (`all` / `disabled` /
   `series_to_keep: [...]`) controlling which received series are recorded as
   capture metrics.
-- OpenTelemetry metric payloads now prefix generated metric names with their
-  metric kind to simplify intake debugging.
-- OpenTelemetry cumulative metric generation now updates cumulative sums using
-  aggregation temporality, preserves cumulative histogram min/max bounds, and
-  supports configurable histogram count limits. Cumulative explicit histograms
-  now retain their state across payload generations.
 - HTTP blackhole now supports an `openmetrics` body variant for generated
   Prometheus/OpenMetrics scrape responses.
-- Updated to rand 0.10.x
 - `dogstatsd` generator now supports configurable pools for the `|c:` (container
   ID), `|e:` (external data), and `|card:` (cardinality) origin detection
   extension fields via the new `container_ids`, `external_data`, and
@@ -35,7 +21,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `dogstatsd` generator now supports DogStatsD protocol v1.3 `|T` timestamps
   for count and gauge metrics via `timestamp.range` and `timestamp.probability`.
 
-## Fixed
+### Changed
+- **Breaking Change**: Datadog blackhole now records received series under the
+  `target/` prefix, matching the prometheus and expvar target metrics
+  collectors. The `record` policy still matches on the unprefixed series name.
+- **Breaking Change**: Datadog blackhole does not record any target metrics by
+  default.
+- OpenTelemetry metric payloads now prefix generated metric names with their
+  metric kind to simplify intake debugging.
+- OpenTelemetry cumulative metric generation now updates cumulative sums using
+  aggregation temporality, preserves cumulative histogram min/max bounds, and
+  supports configurable histogram count limits. Cumulative explicit histograms
+  now retain their state across payload generations.
+- Updated to rand 0.10.x
+
+### Fixed
 - `dogstatsd` tag generation would silently fail with a misleading
   `StringGenerate` error for any `tag_length` whose range collapses after
   reserving one byte for the `:` separator -- every constant or single-value
@@ -45,7 +45,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   returns a `Validation` error naming the offending range instead of the opaque
   `StringGenerate`.
 
-## Removed
+### Removed
 - Removed no longer used `smaps.private_hugetlb.by_pathname` procfs observer
   metric.
 - Removed no longer used `smaps.swap_pss.by_pathname` procfs observer metric.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1908,7 +1908,7 @@ dependencies = [
 
 [[package]]
 name = "lading"
-version = "0.32.0"
+version = "0.33.0"
 dependencies = [
  "anyhow",
  "arrow-array",

--- a/lading/Cargo.toml
+++ b/lading/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lading"
-version = "0.32.0"
+version = "0.33.0"
 authors = [
   "Brian L. Troutwine <brian.troutwine@datadoghq.com>",
   "George Hahn <george.hahn@datadoghq.com>",


### PR DESCRIPTION
See the [changelog on this branch](https://github.com/DataDog/lading/blob/7f7ec8f9cf42a663fa67af4779485ca418928f11/CHANGELOG.md) for details.

Updates the rand crate for a security warning and silences an issue in an unused crate.