### PR TITLE
Namespace datadog blackhole target metrics & default off

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -1,7 +1,8 @@
 [advisories]
 ignore = [
     "RUSTSEC-2020-0159",
-    "RUSTSEC-2026-0001",  # rkyv 0.7.46 UB in Arc/Rc - transitive via rust_decimal <- byte-unit
+    "RUSTSEC-2026-0001",  # rkyv 0.7.46 UB in Arc/Rc - optional dep of rust_decimal <- byte-unit, never compiled
+    "RUSTSEC-2026-0235",  # rkyv 0.7.46 OOB read - optional dep of rust_decimal <- byte-unit, never compiled
     "RUSTSEC-2024-0436",  # paste unmaintained - transitive via parquet
 ]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+
+## Changed
+- **Breaking Change**: Datadog blackhole now records received series under the
+  `target/` prefix, matching the prometheus and expvar target metrics
+  collectors. The `record` policy still matches on the unprefixed series name.
+- **Breaking Change**: Datadog blackhole does not record any target metrics by
+  default.
+
+## Added
 - Datadog blackhole now accepts a `record` policy (`all` / `disabled` /
   `series_to_keep: [...]`) controlling which received series are recorded as
   capture metrics.
@@ -24,7 +33,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   metric, or omits the field entirely if the pool is empty.
 - `dogstatsd` generator now supports DogStatsD protocol v1.3 `|T` timestamps
   for count and gauge metrics via `timestamp.range` and `timestamp.probability`.
-- Fixed: `dogstatsd` tag generation would silently fail with a misleading
+
+## Fixed
+- `dogstatsd` tag generation would silently fail with a misleading
   `StringGenerate` error for any `tag_length` whose range collapses after
   reserving one byte for the `:` separator -- every constant or single-value
   range (e.g. `Constant(3)`, `Constant(4)`, `Inclusive { min: 100, max: 100 }`)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -524,9 +524,9 @@ checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
 
 [[package]]
 name = "byte-unit"
-version = "5.2.0"
+version = "5.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c6d47a4e2961fb8721bcfc54feae6455f2f64e7054f9bc67e875f0e77f4c58d"
+checksum = "4a813de7f2bbedb7dce265b64f1cf5908ebe4d56281ece8d847e98113788b9b0"
 dependencies = [
  "rust_decimal",
  "schemars 1.2.1",
@@ -2269,7 +2269,7 @@ dependencies = [
  "ordered-float 5.3.0",
  "quanta",
  "radix_trie",
- "rand 0.9.2",
+ "rand 0.9.3",
  "rand_xoshiro",
  "sketches-ddsketch",
 ]
@@ -2547,7 +2547,7 @@ dependencies = [
  "futures-util",
  "opentelemetry",
  "percent-encoding",
- "rand 0.9.2",
+ "rand 0.9.3",
  "thiserror 2.0.18",
 ]
 
@@ -2882,7 +2882,7 @@ dependencies = [
  "bit-vec",
  "bitflags",
  "num-traits",
- "rand 0.9.2",
+ "rand 0.9.3",
  "rand_chacha 0.9.0",
  "rand_xorshift",
  "regex-syntax",
@@ -3107,9 +3107,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
  "libc",
  "rand_chacha 0.3.1",
@@ -3118,9 +3118,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "7ec095654a25171c2124e9e3393a930bddbffdc939556c914957a4c3e0a87166"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.5",
@@ -3395,15 +3395,15 @@ dependencies = [
 
 [[package]]
 name = "rust_decimal"
-version = "1.41.0"
+version = "1.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ce901f9a19d251159075a4c37af514c3b8ef99c22e02dd8c19161cf397ee94a"
+checksum = "be2a24f50780bc85f09cc6ac299bdf1424302742d77221106859c9d8b102126a"
 dependencies = [
  "arrayvec",
  "borsh",
  "bytes",
  "num-traits",
- "rand 0.8.5",
+ "rand 0.8.6",
  "rkyv",
  "serde",
  "serde_json",

--- a/lading/src/blackhole/datadog.rs
+++ b/lading/src/blackhole/datadog.rs
@@ -49,6 +49,9 @@ use tracing::{debug, error, info, trace, warn};
 use super::General;
 use crate::proto::datadog::intake::metrics::MetricPayload;
 
+/// Namespace for incoming metrics; matches other target-originated metrics.
+const TARGET_PREFIX: &str = "target/";
+
 #[derive(thiserror::Error, Debug)]
 /// Errors produced by [`Datadog`].
 pub enum Error {
@@ -112,7 +115,7 @@ pub enum RecordPolicy {
 
 impl Default for RecordPolicy {
     fn default() -> Self {
-        Self::All
+        Self::Disabled
     }
 }
 
@@ -367,9 +370,16 @@ async fn handle_v2_protobuf(
             );
 
             if !matches!(record, RecordPolicy::Disabled) {
+                let mut scratch = String::new();
+
                 for series in payload.series.iter().filter(|series| {
                     !series.points.is_empty() && record.records_series(&series.metric)
                 }) {
+                    scratch.clear();
+                    scratch.reserve(TARGET_PREFIX.len() + series.metric.len());
+                    scratch.push_str(TARGET_PREFIX);
+                    scratch.push_str(&series.metric);
+
                     // Parse Datadog tags (format: "key:value" or "key") into label pairs.
                     // Key-only tags are represented with an empty value.
                     let tag_pairs: Vec<(&str, &str)> = series
@@ -395,7 +405,7 @@ async fn handle_v2_protobuf(
                                 // COUNT
                                 #[expect(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
                                 let value = point.value.round() as u64;
-                                counter_incr(&series.metric, &tag_pairs, value, timestamp).await
+                                counter_incr(&scratch, &tag_pairs, value, timestamp).await
                             }
                             2 => {
                                 // RATE
@@ -409,11 +419,11 @@ async fn handle_v2_protobuf(
                                 }
                                 #[expect(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
                                 let val = (point.value * interval as f64).round() as u64;
-                                counter_incr(&series.metric, &tag_pairs, val, timestamp).await
+                                counter_incr(&scratch, &tag_pairs, val, timestamp).await
                             }
                             3 => {
                                 // GAUGE
-                                gauge_set(&series.metric, &tag_pairs, point.value, timestamp).await
+                                gauge_set(&scratch, &tag_pairs, point.value, timestamp).await
                             }
                             i => {
                                 warn!("Unknown metric type, skipping: {i}");


### PR DESCRIPTION
Two breaking changes:

- Apply a prefix to target metrics received by the datadog blackhole for consistency with other target metrics collectors.
- Disable metrics recording by default.